### PR TITLE
Add macOS Dock recent folders setting

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2076,6 +2076,11 @@ impl App {
         self.platform.add_recent_document(path);
     }
 
+    /// Clears the recent paths associated with the application.
+    pub fn clear_recent_documents(&self) {
+        self.platform.clear_recent_documents();
+    }
+
     /// Updates the jump list with the updated list of recent paths for the application, only used on Windows for now.
     /// Note that this also sets the dock menu on Windows.
     pub fn update_jump_list(

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -354,6 +354,16 @@ impl TestAppContext {
         self.test_platform.opened_url.borrow().clone()
     }
 
+    /// Returns the recent documents recorded by the test platform.
+    pub fn recent_documents(&self) -> Vec<PathBuf> {
+        self.test_platform.recent_documents()
+    }
+
+    /// Returns how many times the test platform cleared recent documents.
+    pub fn recent_documents_clear_count(&self) -> usize {
+        self.test_platform.recent_documents_clear_count()
+    }
+
     /// Simulates the user resizing the window to the new size.
     pub fn simulate_window_resize(&self, window_handle: AnyWindowHandle, size: Size<Pixels>) {
         self.test_window(window_handle).simulate_resize(size);

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -183,6 +183,7 @@ pub trait Platform: 'static {
     fn set_dock_menu(&self, menu: Vec<MenuItem>, keymap: &Keymap);
     fn perform_dock_menu_action(&self, _action: usize) {}
     fn add_recent_document(&self, _path: &Path) {}
+    fn clear_recent_documents(&self) {}
     fn update_jump_list(
         &self,
         _menus: Vec<MenuItem>,

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -34,6 +34,8 @@ pub(crate) struct TestPlatform {
     pub opened_url: RefCell<Option<String>>,
     pub text_system: Arc<dyn PlatformTextSystem>,
     pub expect_restart: RefCell<Option<oneshot::Sender<Option<PathBuf>>>>,
+    recent_documents: RefCell<Vec<PathBuf>>,
+    recent_documents_clear_count: RefCell<usize>,
     headless_renderer_factory: Option<Box<dyn Fn() -> Option<Box<dyn PlatformHeadlessRenderer>>>>,
     weak: Weak<Self>,
 }
@@ -129,6 +131,8 @@ impl TestPlatform {
             current_find_pasteboard_item: Mutex::new(None),
             weak: weak.clone(),
             opened_url: Default::default(),
+            recent_documents: Default::default(),
+            recent_documents_clear_count: Default::default(),
             text_system,
             headless_renderer_factory,
         })
@@ -179,6 +183,14 @@ impl TestPlatform {
 
     pub(crate) fn set_screen_capture_sources(&self, sources: Vec<TestScreenCaptureSource>) {
         *self.screen_capture_sources.borrow_mut() = sources;
+    }
+
+    pub(crate) fn recent_documents(&self) -> Vec<PathBuf> {
+        self.recent_documents.borrow().clone()
+    }
+
+    pub(crate) fn recent_documents_clear_count(&self) -> usize {
+        *self.recent_documents_clear_count.borrow()
     }
 
     pub(crate) fn prompt(
@@ -383,7 +395,21 @@ impl Platform for TestPlatform {
     fn set_menus(&self, _menus: Vec<crate::Menu>, _keymap: &Keymap) {}
     fn set_dock_menu(&self, _menu: Vec<crate::MenuItem>, _keymap: &Keymap) {}
 
-    fn add_recent_document(&self, _paths: &Path) {}
+    fn add_recent_document(&self, path: &Path) {
+        let mut recent_documents = self.recent_documents.borrow_mut();
+        if let Some(index) = recent_documents
+            .iter()
+            .position(|existing| existing == path)
+        {
+            recent_documents.remove(index);
+        }
+        recent_documents.push(path.to_path_buf());
+    }
+
+    fn clear_recent_documents(&self) {
+        self.recent_documents.borrow_mut().clear();
+        *self.recent_documents_clear_count.borrow_mut() += 1;
+    }
 
     fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn crate::Action)>) {}
 

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -958,6 +958,14 @@ impl Platform for MacPlatform {
         }
     }
 
+    fn clear_recent_documents(&self) {
+        unsafe {
+            let document_controller: id =
+                msg_send![class!(NSDocumentController), sharedDocumentController];
+            let _: () = msg_send![document_controller, clearRecentDocuments:nil];
+        }
+    }
+
     fn path_for_auxiliary_executable(&self, name: &str) -> Result<PathBuf> {
         unsafe {
             let bundle: id = NSBundle::mainBundle();

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -19,6 +19,7 @@ use rpc::{
     AnyProtoClient, ErrorExt, TypedEnvelope,
     proto::{self, REMOTE_SERVER_PROJECT_ID},
 };
+use settings::{RegisterSetting, Settings};
 use text::ReplicaId;
 use util::{
     ResultExt,
@@ -63,6 +64,22 @@ impl WorktreeIdCounter {
 }
 
 impl Global for WorktreeIdCounter {}
+
+#[derive(Copy, Clone, Debug, RegisterSetting)]
+struct DockRecentFoldersSettings {
+    show_dock_recent_folders: bool,
+}
+
+impl Settings for DockRecentFoldersSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        Self {
+            show_dock_recent_folders: content
+                .workspace
+                .show_dock_recent_folders
+                .unwrap_or(!cfg!(target_os = "macos")),
+        }
+    }
+}
 
 pub struct WorktreeStore {
     next_entry_id: Arc<AtomicUsize>,
@@ -680,7 +697,11 @@ impl WorktreeStore {
 
             this.update(cx, |this, cx| this.add(&worktree, cx))?;
 
-            if visible {
+            let should_add_recent_document = visible
+                && cx.update(|cx| {
+                    DockRecentFoldersSettings::get_global(cx).show_dock_recent_folders
+                });
+            if should_add_recent_document {
                 cx.update(|cx| {
                     cx.add_recent_document(abs_path.as_path());
                 });

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -809,6 +809,95 @@ async fn test_removing_worktree_cleans_up_external_editorconfig(cx: &mut gpui::T
 }
 
 #[gpui::test]
+async fn test_recent_documents_follow_show_dock_recent_folders_setting(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "base": {
+                "main.rs": ""
+            },
+            "visible-enabled": {},
+            "visible-disabled": {},
+            "visible-reenabled": {},
+            "invisible": {}
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/root/base").as_ref()], cx).await;
+    cx.update(|cx| cx.clear_recent_documents());
+
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.workspace.show_dock_recent_folders = Some(true);
+            });
+        });
+    });
+
+    let _ = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/root/visible-enabled"), true, cx)
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        cx.recent_documents(),
+        vec![PathBuf::from(path!("/root/visible-enabled"))]
+    );
+
+    cx.update(|cx| cx.clear_recent_documents());
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.workspace.show_dock_recent_folders = Some(false);
+            });
+        });
+    });
+
+    let _ = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/root/visible-disabled"), true, cx)
+        })
+        .await
+        .unwrap();
+    assert!(cx.recent_documents().is_empty());
+
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |settings, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.workspace.show_dock_recent_folders = Some(true);
+            });
+        });
+    });
+
+    let _ = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/root/visible-reenabled"), true, cx)
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        cx.recent_documents(),
+        vec![PathBuf::from(path!("/root/visible-reenabled"))]
+    );
+
+    cx.update(|cx| cx.clear_recent_documents());
+    let _ = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/root/invisible"), false, cx)
+        })
+        .await
+        .unwrap();
+    assert!(cx.recent_documents().is_empty());
+}
+
+#[gpui::test]
 async fn test_shared_external_editorconfig_cleanup_with_multiple_worktrees(
     cx: &mut gpui::TestAppContext,
 ) {

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2564,5 +2564,7 @@ mod tests {
 
         assert!(user_schema_str.contains("\"auto_update\""));
         assert!(!project_schema_str.contains("\"auto_update\""));
+        assert!(user_schema_str.contains("\"show_dock_recent_folders\""));
+        assert!(!project_schema_str.contains("\"show_dock_recent_folders\""));
     }
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -983,6 +983,7 @@ impl VsCodeSettings {
             resize_all_panels_in_dock: None,
             restore_on_file_reopen: self.read_bool("workbench.editor.restoreViewState"),
             restore_on_startup: None,
+            show_dock_recent_folders: None,
             window_decorations: None,
             show_call_status_icon: None,
             use_system_path_prompts: self.read_bool("files.simpleDialog.enable"),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -119,6 +119,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: false
     pub close_panel_on_toggle: Option<bool>,
+    /// Whether to show folders opened by Superzent in macOS Dock recent items.
+    /// This setting is user-global only and does not apply to project settings.
+    ///
+    /// Default: false on macOS, true otherwise
+    pub show_dock_recent_folders: Option<bool>,
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -32,6 +32,7 @@ pub struct WorkspaceSettings {
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub close_panel_on_toggle: bool,
+    pub show_dock_recent_folders: bool,
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
@@ -110,6 +111,9 @@ impl Settings for WorkspaceSettings {
                 .collect(),
             close_on_file_delete: workspace.close_on_file_delete.unwrap(),
             close_panel_on_toggle: workspace.close_panel_on_toggle.unwrap(),
+            show_dock_recent_folders: workspace
+                .show_dock_recent_folders
+                .unwrap_or(!cfg!(target_os = "macos")),
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -170,6 +170,7 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
+    bind_dock_recent_documents(cx);
     #[cfg(target_os = "macos")]
     cx.on_action(|_: &Hide, cx| cx.hide());
     #[cfg(target_os = "macos")]
@@ -329,6 +330,23 @@ fn bind_on_window_closed(cx: &mut App) -> Option<gpui::Subscription> {
             }
         }))
     }
+}
+
+fn bind_dock_recent_documents(cx: &mut App) {
+    let mut were_recent_folders_enabled =
+        WorkspaceSettings::get_global(cx).show_dock_recent_folders;
+    if !were_recent_folders_enabled {
+        cx.clear_recent_documents();
+    }
+
+    cx.observe_global::<SettingsStore>(move |cx| {
+        let are_recent_folders_enabled = WorkspaceSettings::get_global(cx).show_dock_recent_folders;
+        if were_recent_folders_enabled && !are_recent_folders_enabled {
+            cx.clear_recent_documents();
+        }
+        were_recent_folders_enabled = are_recent_folders_enabled;
+    })
+    .detach();
 }
 
 pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowOptions {
@@ -5594,6 +5612,113 @@ mod tests {
         cx.run_until_parked();
 
         // If this panics, the test has failed
+    }
+
+    #[gpui::test]
+    async fn test_recent_documents_cleared_on_startup_when_disabled(cx: &mut gpui::TestAppContext) {
+        let _app_state = init_test(cx);
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings_store, cx| {
+                settings_store.update_user_settings(cx, |settings| {
+                    settings.workspace.show_dock_recent_folders = Some(false);
+                });
+            });
+            cx.add_recent_document(Path::new(path!("/root/old-worktree")));
+        });
+
+        assert_eq!(
+            cx.recent_documents(),
+            vec![PathBuf::from(path!("/root/old-worktree"))]
+        );
+
+        cx.update(init);
+        cx.run_until_parked();
+
+        assert!(cx.recent_documents().is_empty());
+        assert_eq!(cx.recent_documents_clear_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_recent_documents_not_cleared_on_startup_when_enabled(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let _app_state = init_test(cx);
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings_store, cx| {
+                settings_store.update_user_settings(cx, |settings| {
+                    settings.workspace.show_dock_recent_folders = Some(true);
+                });
+            });
+            cx.add_recent_document(Path::new(path!("/root/old-worktree")));
+        });
+
+        cx.update(init);
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.recent_documents(),
+            vec![PathBuf::from(path!("/root/old-worktree"))]
+        );
+        assert_eq!(cx.recent_documents_clear_count(), 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    async fn test_recent_documents_cleared_on_startup_with_macos_default(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let _app_state = init_test(cx);
+        cx.update(|cx| {
+            cx.add_recent_document(Path::new(path!("/root/old-worktree")));
+        });
+
+        cx.update(init);
+        cx.run_until_parked();
+
+        assert!(cx.recent_documents().is_empty());
+        assert_eq!(cx.recent_documents_clear_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_recent_documents_cleared_on_enabled_to_disabled_transition(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let _app_state = init_test(cx);
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings_store, cx| {
+                settings_store.update_user_settings(cx, |settings| {
+                    settings.workspace.show_dock_recent_folders = Some(true);
+                });
+            });
+            cx.add_recent_document(Path::new(path!("/root/old-worktree")));
+        });
+
+        cx.update(init);
+        cx.run_until_parked();
+        assert_eq!(cx.recent_documents_clear_count(), 0);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings_store, cx| {
+                settings_store.update_user_settings(cx, |settings| {
+                    settings.workspace.show_dock_recent_folders = Some(false);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        assert!(cx.recent_documents().is_empty());
+        assert_eq!(cx.recent_documents_clear_count(), 1);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |settings_store, cx| {
+                settings_store.update_user_settings(cx, |settings| {
+                    settings.workspace.show_dock_recent_folders = Some(false);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        assert_eq!(cx.recent_documents_clear_count(), 1);
     }
 
     #[gpui::test]

--- a/docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md
+++ b/docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md
@@ -6,6 +6,7 @@ topic: macos-dock-recent-folders-setting
 # macOS Dock Recent Folders Setting
 
 ## Problem Frame
+
 When users right-click the app icon in the macOS Dock, macOS shows recently opened local
 folders. For users who work with many temporary or disposable workspaces, this creates
 clutter and can expose folders they do not want surfaced from the Dock. The product should
@@ -15,6 +16,7 @@ Recent Projects experience.
 ## Requirements
 
 **Settings**
+
 - R1. Add a user-facing `settings.json` setting that controls whether the app contributes
   local folders to macOS Dock recent items.
 - R2. The setting must default to disabled on macOS.
@@ -23,6 +25,7 @@ Recent Projects experience.
   Recent Projects surfaces must continue to work unchanged.
 
 **Behavior**
+
 - R5. When the setting is disabled, newly opened visible local workspaces must not be added
   to the macOS Dock recent-folder list.
 - R6. When the app starts on macOS with the setting disabled, any existing Dock recent-folder
@@ -31,11 +34,13 @@ Recent Projects experience.
   recent-folder entries should be cleared immediately.
 
 **Platform Boundaries**
+
 - R8. Non-macOS platforms must not have their current recent-workspace behavior changed by
   this setting.
 - R9. On macOS, enabling the setting should preserve current behavior for future entries.
 
 ## Success Criteria
+
 - Right-clicking the Dock icon on macOS no longer shows previously recorded recent folders
   after startup when the setting is disabled.
 - Opening additional local workspaces while the setting is disabled does not repopulate Dock
@@ -44,6 +49,7 @@ Recent Projects experience.
 - Non-macOS behavior is unchanged.
 
 ## Scope Boundaries
+
 - No Settings UI control in this phase.
 - No change to app-internal Recent Projects lists, launchpad content, or workspace history
   persistence.
@@ -51,6 +57,7 @@ Recent Projects experience.
   contribution.
 
 ## Key Decisions
+
 - JSON-only control for this phase: keep the change targeted and avoid expanding the Settings
   UI surface.
 - macOS default is disabled: optimize for privacy and clutter reduction in Dock behavior.
@@ -59,6 +66,7 @@ Recent Projects experience.
 - Scope is Dock-only: in-app Recent Projects remains the intentional history surface.
 
 ## Dependencies / Assumptions
+
 - The Dock recent-folder entries are currently being populated through the app's macOS
   recent-document integration rather than through a custom Dock menu.
 - Clearing the app's macOS recent-document list can be done without affecting the app's
@@ -67,6 +75,7 @@ Recent Projects experience.
 ## Outstanding Questions
 
 ### Deferred to Planning
+
 - [Affects R1][Technical] What exact `settings.json` key name and schema placement best match
   existing workspace-setting conventions?
 - [Affects R6][Technical] What is the safest lifecycle hook for clearing macOS recent-document
@@ -75,4 +84,5 @@ Recent Projects experience.
   transitions from enabled to disabled?
 
 ## Next Steps
+
 -> /prompts:ce-plan for structured implementation planning

--- a/docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md
+++ b/docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md
@@ -1,0 +1,78 @@
+---
+date: 2026-04-03
+topic: macos-dock-recent-folders-setting
+---
+
+# macOS Dock Recent Folders Setting
+
+## Problem Frame
+When users right-click the app icon in the macOS Dock, macOS shows recently opened local
+folders. For users who work with many temporary or disposable workspaces, this creates
+clutter and can expose folders they do not want surfaced from the Dock. The product should
+let users suppress this Dock-specific recent-folder behavior without removing the app's own
+Recent Projects experience.
+
+## Requirements
+
+**Settings**
+- R1. Add a user-facing `settings.json` setting that controls whether the app contributes
+  local folders to macOS Dock recent items.
+- R2. The setting must default to disabled on macOS.
+- R3. The setting must not be exposed in Settings UI in this phase.
+- R4. The setting's effect must be limited to macOS Dock recent folders; the app's internal
+  Recent Projects surfaces must continue to work unchanged.
+
+**Behavior**
+- R5. When the setting is disabled, newly opened visible local workspaces must not be added
+  to the macOS Dock recent-folder list.
+- R6. When the app starts on macOS with the setting disabled, any existing Dock recent-folder
+  entries previously contributed by the app should be cleared automatically.
+- R7. When a user changes the setting from enabled to disabled on macOS, the existing Dock
+  recent-folder entries should be cleared immediately.
+
+**Platform Boundaries**
+- R8. Non-macOS platforms must not have their current recent-workspace behavior changed by
+  this setting.
+- R9. On macOS, enabling the setting should preserve current behavior for future entries.
+
+## Success Criteria
+- Right-clicking the Dock icon on macOS no longer shows previously recorded recent folders
+  after startup when the setting is disabled.
+- Opening additional local workspaces while the setting is disabled does not repopulate Dock
+  recent folders.
+- In-app Recent Projects and workspace history continue to behave as they do today.
+- Non-macOS behavior is unchanged.
+
+## Scope Boundaries
+- No Settings UI control in this phase.
+- No change to app-internal Recent Projects lists, launchpad content, or workspace history
+  persistence.
+- No attempt to change system-wide recent item behavior outside the app's Dock recent-folder
+  contribution.
+
+## Key Decisions
+- JSON-only control for this phase: keep the change targeted and avoid expanding the Settings
+  UI surface.
+- macOS default is disabled: optimize for privacy and clutter reduction in Dock behavior.
+- Disabling clears existing items automatically: users should not need a second manual cleanup
+  step.
+- Scope is Dock-only: in-app Recent Projects remains the intentional history surface.
+
+## Dependencies / Assumptions
+- The Dock recent-folder entries are currently being populated through the app's macOS
+  recent-document integration rather than through a custom Dock menu.
+- Clearing the app's macOS recent-document list can be done without affecting the app's
+  internal recent-project persistence.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R1][Technical] What exact `settings.json` key name and schema placement best match
+  existing workspace-setting conventions?
+- [Affects R6][Technical] What is the safest lifecycle hook for clearing macOS recent-document
+  entries at startup without causing repeated unnecessary work?
+- [Affects R7][Technical] What is the cleanest way to detect and handle runtime setting
+  transitions from enabled to disabled?
+
+## Next Steps
+-> /prompts:ce-plan for structured implementation planning

--- a/docs/plans/2026-04-03-001-fix-macos-dock-recent-folders-plan.md
+++ b/docs/plans/2026-04-03-001-fix-macos-dock-recent-folders-plan.md
@@ -136,17 +136,17 @@ surfaces.
 
 ## High-Level Technical Design
 
-> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
 
-| Trigger | Effective `show_dock_recent_folders` | Intended outcome |
-|---|---|---|
-| App startup | `false` | Clear app-level recent documents once |
-| Settings reload `true -> false` | `false` | Clear app-level recent documents immediately |
-| Settings reload `false -> false` | `false` | No duplicate work beyond the startup clear |
-| Settings reload `false -> true` | `true` | Do not repopulate history retroactively |
-| Visible local worktree created | `true` | Add the worktree path to recent documents |
-| Visible local worktree created | `false` | Skip platform registration |
-| Recent Projects UI queries | any | Continue reading workspace DB with no behavior change |
+| Trigger                          | Effective `show_dock_recent_folders` | Intended outcome                                      |
+| -------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| App startup                      | `false`                              | Clear app-level recent documents once                 |
+| Settings reload `true -> false`  | `false`                              | Clear app-level recent documents immediately          |
+| Settings reload `false -> false` | `false`                              | No duplicate work beyond the startup clear            |
+| Settings reload `false -> true`  | `true`                               | Do not repopulate history retroactively               |
+| Visible local worktree created   | `true`                               | Add the worktree path to recent documents             |
+| Visible local worktree created   | `false`                              | Skip platform registration                            |
+| Recent Projects UI queries       | any                                  | Continue reading workspace DB with no behavior change |
 
 ## Implementation Units
 
@@ -160,6 +160,7 @@ documents in addition to adding them.
 **Dependencies:** None
 
 **Files:**
+
 - Modify: `crates/settings_content/src/workspace.rs`
 - Modify: `crates/settings/src/settings_store.rs`
 - Modify: `crates/workspace/src/workspace_settings.rs`
@@ -172,6 +173,7 @@ documents in addition to adding them.
 - Test: `crates/project/tests/integration/project_tests.rs`
 
 **Approach:**
+
 - Add `show_dock_recent_folders: Option<bool>` to `WorkspaceSettingsContent` with a doc comment
   that marks it as macOS-only and JSON-only for now.
 - Keep the field out of `ProjectSettingsContent` so it is valid in user settings schema but not
@@ -187,6 +189,7 @@ documents in addition to adding them.
   times the clear operation ran.
 
 **Patterns to follow:**
+
 - `crates/workspace/src/workspace_settings.rs` runtime mapping style for workspace settings
 - `crates/settings/src/settings_store.rs` user-vs-project schema split
 - `crates/gpui/src/app.rs` and `crates/gpui/src/platform.rs` pairing around
@@ -194,6 +197,7 @@ documents in addition to adding them.
 - `crates/gpui/src/app/test_context.rs` helper exposure pattern for platform-observable effects
 
 **Test scenarios:**
+
 - Happy path: with explicit `show_dock_recent_folders = true`, the effective runtime setting
   remains enabled and downstream callers can still record recent documents.
 - Edge case: when the setting is omitted, the effective runtime value resolves to the platform
@@ -206,6 +210,7 @@ documents in addition to adding them.
   the existing add path.
 
 **Verification:**
+
 - The settings schema exposes the new key for `settings.json`.
 - The project settings schema does not expose the new key.
 - Test infrastructure can observe both "recent document added" and "recent documents cleared"
@@ -221,10 +226,12 @@ setting is disabled, while preserving all current worktree creation behavior.
 **Dependencies:** Unit 1
 
 **Files:**
+
 - Modify: `crates/project/src/worktree_store.rs`
 - Test: `crates/project/tests/integration/project_tests.rs`
 
 **Approach:**
+
 - At the existing `visible` call site, read `WorkspaceSettings::get_global(cx)` and gate
   `cx.add_recent_document(...)` on the new effective boolean.
 - Keep the current `visible` requirement intact so invisible worktrees continue to skip recent
@@ -237,11 +244,13 @@ setting is disabled, while preserving all current worktree creation behavior.
 platform recent-document side effect.
 
 **Patterns to follow:**
+
 - The existing `visible` guard around `cx.add_recent_document(...)` in
   `crates/project/src/worktree_store.rs`
 - Settings mutation style in `crates/project/tests/integration/project_tests.rs`
 
 **Test scenarios:**
+
 - Happy path: creating a visible local worktree with `show_dock_recent_folders = true` records
   the worktree path in the test platform's recent-document list.
 - Edge case: creating a visible local worktree with `show_dock_recent_folders = false` does not
@@ -252,6 +261,7 @@ platform recent-document side effect.
   the setting only gates the platform side effect.
 
 **Verification:**
+
 - The only observable behavior change is whether the recent-document recorder changes; worktree
   creation and project state remain intact.
 
@@ -265,10 +275,12 @@ startup and on enabled-to-disabled settings changes.
 **Dependencies:** Unit 1
 
 **Files:**
+
 - Modify: `crates/zed/src/zed.rs`
 - Test: `crates/zed/src/zed.rs`
 
 **Approach:**
+
 - Add a small helper invoked from `zed::init(cx)` that:
   - reads the effective `WorkspaceSettings::get_global(cx).show_dock_recent_folders` value once
     during init and clears recent documents immediately when it is `false`
@@ -282,11 +294,13 @@ startup and on enabled-to-disabled settings changes.
   app-internal Recent Projects remains DB-backed and unchanged.
 
 **Patterns to follow:**
+
 - Prior-value observer logic in `crates/zed/src/zed.rs` (`handle_keymap_file_changes`)
 - Existing settings observer registration style in `crates/zed/src/zed.rs`
 - Existing `init_test(cx); cx.update(init);` test setup pattern in `crates/zed/src/zed.rs`
 
 **Test scenarios:**
+
 - Happy path: when user settings explicitly set `show_dock_recent_folders = false` before
   `zed::init`, startup clears the test platform's recent documents exactly once.
 - Edge case: when the setting is omitted, startup still clears recent documents on macOS because
@@ -304,6 +318,7 @@ startup and on enabled-to-disabled settings changes.
   Unit 2.
 
 **Verification:**
+
 - Startup and runtime-disable flows both converge on the same clear side effect.
 - No code path touches the DB-backed recent-project surfaces.
 
@@ -325,11 +340,11 @@ startup and on enabled-to-disabled settings changes.
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
+| Risk                                                                                           | Mitigation                                                                                                                                                        |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `clear_recent_documents` is app-wide and would clear any future recent-document call sites too | Keep the API addition tightly documented, note the current single caller in code comments or tests, and avoid broadening recent-document usage in the same change |
-| Startup/settings observers could clear repeatedly on every settings reload | Track the previous effective boolean and assert idempotent behavior in tests |
-| The new setting might accidentally leak into Settings UI | Limit changes to `settings_content` and `workspace_settings`; do not add a `settings_ui` page-data entry in this phase |
+| Startup/settings observers could clear repeatedly on every settings reload                     | Track the previous effective boolean and assert idempotent behavior in tests                                                                                      |
+| The new setting might accidentally leak into Settings UI                                       | Limit changes to `settings_content` and `workspace_settings`; do not add a `settings_ui` page-data entry in this phase                                            |
 
 ## Documentation / Operational Notes
 

--- a/docs/plans/2026-04-03-001-fix-macos-dock-recent-folders-plan.md
+++ b/docs/plans/2026-04-03-001-fix-macos-dock-recent-folders-plan.md
@@ -1,0 +1,354 @@
+---
+title: fix: Add macOS Dock recent folders setting
+type: fix
+status: completed
+date: 2026-04-03
+origin: docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md
+---
+
+# fix: Add macOS Dock recent folders setting
+
+## Overview
+
+Add a JSON-only workspace setting that controls whether Superzent contributes opened local
+workspaces to macOS Dock recent folders. When the effective setting is disabled, the app
+must stop adding new entries and clear any existing app-level Dock recent documents on
+startup and on enabled-to-disabled transitions. In-app Recent Projects remains unchanged
+(see origin: docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md).
+
+## Problem Frame
+
+Today the only local call site for Dock recent items is `crates/project/src/worktree_store.rs`,
+which forwards visible worktree paths into `App::add_recent_document()`. On macOS that flows
+into `NSDocumentController`, so right-clicking the Dock icon surfaces prior workspaces even
+when the user does not want that history exposed. The product intent is to make this
+Dock-specific behavior optional without changing the app's database-backed recent-project
+surfaces.
+
+## Requirements Trace
+
+- R1. Add a user-facing `settings.json` setting to control Dock recent-folder contribution.
+- R2. Default that setting to disabled on macOS.
+- R3. Keep the setting out of Settings UI for this phase.
+- R4. Limit behavior changes to macOS Dock recent folders; preserve app-internal Recent Projects.
+- R5. Skip adding new visible local workspaces when disabled.
+- R6. Clear existing Dock recent-folder entries on startup when disabled.
+- R7. Clear existing Dock recent-folder entries when the setting changes from enabled to disabled.
+- R8. Preserve current non-macOS behavior.
+- R9. Preserve current macOS behavior when the setting is enabled.
+
+## Scope Boundaries
+
+- Do not add a Settings UI control in `crates/settings_ui`.
+- Do not support project-local or worktree-local overrides; this setting is user-global only.
+- Do not change `crates/recent_projects`, `crates/workspace/src/history_manager.rs`, or
+  workspace DB persistence semantics.
+- Do not redesign the Dock menu itself; this is about AppKit recent-document integration only.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/project/src/worktree_store.rs` is the only current local caller of
+  `cx.add_recent_document(...)`, guarded by `visible`.
+- `crates/gpui/src/app.rs` and `crates/gpui/src/platform.rs` already expose
+  `add_recent_document`, so the cleanest place for the matching clear operation is the same
+  abstraction layer.
+- `crates/gpui_macos/src/platform.rs` implements the AppKit bridge via
+  `NSDocumentController::noteNewRecentDocumentURL`.
+- `crates/workspace/src/workspace_settings.rs` is the repo pattern for turning
+  `settings_content` values into runtime `WorkspaceSettings`.
+- `crates/settings/src/settings_store.rs` generates distinct user and project settings schemas;
+  project settings are rooted in `ProjectSettingsContent`, so a new workspace setting should stay
+  user-global unless the change explicitly broadens the project schema.
+- `crates/zed/src/zed.rs` already contains global settings observers that track prior values,
+  for example `handle_keymap_file_changes`, and is the natural place for a one-time startup
+  check plus runtime transition handling.
+- `crates/recent_projects/src/recent_projects.rs` and
+  `crates/workspace/src/history_manager.rs` are separate, DB-backed recent-history surfaces and
+  do not currently depend on the AppKit recent-document bridge.
+- `crates/workspace/src/workspace.rs` and `crates/project/tests/integration/project_tests.rs`
+  show the standard settings mutation test pattern through `SettingsStore::update_global`.
+- `crates/gpui/src/platform/test/platform.rs` and `crates/gpui/src/app/test_context.rs`
+  provide the existing hooks for observing platform side effects in tests.
+
+### Institutional Learnings
+
+- No `docs/solutions/` corpus exists in this repo today, so planning is grounded in current
+  code patterns rather than prior solution docs.
+
+### External References
+
+- None. Local patterns are strong and the change is bounded to existing platform abstractions.
+
+## Key Technical Decisions
+
+- `show_dock_recent_folders` is the planned `settings.json` key.
+  Rationale: it is user-facing, matches existing boolean naming such as `show_call_status_icon`,
+  and describes the visible Dock behavior rather than the underlying AppKit API.
+- Keep the schema field as a simple boolean and apply the macOS-only default in
+  `WorkspaceSettings::from_settings`.
+  Rationale: this avoids adding a new tri-state enum or Settings UI complexity for a JSON-only
+  setting, while still allowing explicit user override on every platform.
+- Keep the setting user-global only by defining it in `WorkspaceSettingsContent` and leaving
+  `ProjectSettingsContent` unchanged.
+  Rationale: Dock recent documents are application-level state, so project-local overrides would
+  create cross-window inconsistency and do not map cleanly to AppKit's single recent-document
+  list.
+- Add a matching `clear_recent_documents` platform/app API next to `add_recent_document`.
+  Rationale: the add/clear lifecycle belongs in GPUI's platform boundary, not in a
+  `zed`-specific Objective-C call site.
+- Treat the setting as an app-global decision and read it through
+  `WorkspaceSettings::get_global(cx)` in both startup and worktree code paths.
+  Rationale: macOS Dock recent documents are application-level state rather than per-project
+  state, so a workspace-local override would create inconsistent behavior across windows.
+- Run clear logic from `crates/zed/src/zed.rs` using the effective runtime setting and prior
+  value tracking.
+  Rationale: startup and settings transitions are application-level lifecycle concerns, while
+  worktree creation stays focused on add/skip behavior.
+- Keep non-macOS logic generic but make the platform clear implementation a no-op outside macOS.
+  Rationale: this preserves production behavior on other platforms while keeping the code path
+  testable with the shared test platform.
+
+## Open Questions
+
+### Resolved During Planning
+
+- What `settings.json` key and placement should this use?
+  Resolution: a top-level workspace setting named `show_dock_recent_folders`.
+- Should this support project-local overrides?
+  Resolution: no; it is user-global only and should not appear in project settings schema.
+- Where should startup clearing happen?
+  Resolution: a dedicated helper registered from `zed::init(cx)` that evaluates the effective
+  setting once at startup and then observes `SettingsStore` for transitions.
+- How should runtime enabled-to-disabled transitions be detected?
+  Resolution: store the previous effective boolean in the observer closure and clear only on
+  `true -> false` changes.
+
+### Deferred to Implementation
+
+- What exact Objective-C selector signature is needed for clearing AppKit recent documents?
+  Why deferred: the plan chooses the API boundary and lifecycle; the exact `msg_send!` form is a
+  small implementation detail to confirm while editing `crates/gpui_macos/src/platform.rs`.
+- Whether the checked-in settings reference output needs regeneration in the same change.
+  Why deferred: this depends on the repo's normal docs generation flow once the schema field is
+  added.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+| Trigger | Effective `show_dock_recent_folders` | Intended outcome |
+|---|---|---|
+| App startup | `false` | Clear app-level recent documents once |
+| Settings reload `true -> false` | `false` | Clear app-level recent documents immediately |
+| Settings reload `false -> false` | `false` | No duplicate work beyond the startup clear |
+| Settings reload `false -> true` | `true` | Do not repopulate history retroactively |
+| Visible local worktree created | `true` | Add the worktree path to recent documents |
+| Visible local worktree created | `false` | Skip platform registration |
+| Recent Projects UI queries | any | Continue reading workspace DB with no behavior change |
+
+## Implementation Units
+
+- [ ] **Unit 1: Add the setting contract and platform clear API**
+
+**Goal:** Introduce the new workspace setting and the GPUI API surface needed to clear recent
+documents in addition to adding them.
+
+**Requirements:** R1, R2, R3, R6, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/settings_content/src/workspace.rs`
+- Modify: `crates/settings/src/settings_store.rs`
+- Modify: `crates/workspace/src/workspace_settings.rs`
+- Modify: `crates/gpui/src/platform.rs`
+- Modify: `crates/gpui/src/app.rs`
+- Modify: `crates/gpui_macos/src/platform.rs`
+- Modify: `crates/gpui/src/platform/test/platform.rs`
+- Modify: `crates/gpui/src/app/test_context.rs`
+- Test: `crates/zed/src/zed.rs`
+- Test: `crates/project/tests/integration/project_tests.rs`
+
+**Approach:**
+- Add `show_dock_recent_folders: Option<bool>` to `WorkspaceSettingsContent` with a doc comment
+  that marks it as macOS-only and JSON-only for now.
+- Keep the field out of `ProjectSettingsContent` so it is valid in user settings schema but not
+  in project settings schema.
+- Thread the field into `WorkspaceSettings`, using a platform-aware fallback in
+  `WorkspaceSettings::from_settings` so unspecified settings resolve to `false` on macOS and
+  `true` elsewhere.
+- Extend the GPUI platform trait with a `clear_recent_documents` no-op default and expose it via
+  `App`, mirroring the existing `add_recent_document` shape.
+- Implement the macOS clear behavior through `NSDocumentController`; leave Linux/Windows on the
+  default no-op path.
+- Extend the test platform so tests can inspect the recorded recent-document paths and how many
+  times the clear operation ran.
+
+**Patterns to follow:**
+- `crates/workspace/src/workspace_settings.rs` runtime mapping style for workspace settings
+- `crates/settings/src/settings_store.rs` user-vs-project schema split
+- `crates/gpui/src/app.rs` and `crates/gpui/src/platform.rs` pairing around
+  `add_recent_document`
+- `crates/gpui/src/app/test_context.rs` helper exposure pattern for platform-observable effects
+
+**Test scenarios:**
+- Happy path: with explicit `show_dock_recent_folders = true`, the effective runtime setting
+  remains enabled and downstream callers can still record recent documents.
+- Edge case: when the setting is omitted, the effective runtime value resolves to the platform
+  default (`false` on macOS, `true` elsewhere).
+- Integration: the user settings schema includes `show_dock_recent_folders` while the project
+  settings schema omits it, preserving the user-global-only contract.
+- Integration: calling the new clear API on the test platform empties the recorded recent
+  documents and increments a clear counter that later tests can assert against.
+- Error path: none expected; the platform abstraction remains best-effort and non-throwing, like
+  the existing add path.
+
+**Verification:**
+- The settings schema exposes the new key for `settings.json`.
+- The project settings schema does not expose the new key.
+- Test infrastructure can observe both "recent document added" and "recent documents cleared"
+  side effects.
+
+- [ ] **Unit 2: Gate worktree additions with the new setting**
+
+**Goal:** Prevent visible local workspaces from being registered with recent documents when the
+setting is disabled, while preserving all current worktree creation behavior.
+
+**Requirements:** R4, R5, R8, R9
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/project/src/worktree_store.rs`
+- Test: `crates/project/tests/integration/project_tests.rs`
+
+**Approach:**
+- At the existing `visible` call site, read `WorkspaceSettings::get_global(cx)` and gate
+  `cx.add_recent_document(...)` on the new effective boolean.
+- Keep the current `visible` requirement intact so invisible worktrees continue to skip recent
+  document registration regardless of the setting.
+- Do not touch worktree creation, project loading, or workspace DB persistence paths.
+- Read the effective value from global user settings so gating stays consistent with the
+  startup clear behavior in Unit 3.
+
+**Execution note:** Start with integration coverage that proves the only changed behavior is the
+platform recent-document side effect.
+
+**Patterns to follow:**
+- The existing `visible` guard around `cx.add_recent_document(...)` in
+  `crates/project/src/worktree_store.rs`
+- Settings mutation style in `crates/project/tests/integration/project_tests.rs`
+
+**Test scenarios:**
+- Happy path: creating a visible local worktree with `show_dock_recent_folders = true` records
+  the worktree path in the test platform's recent-document list.
+- Edge case: creating a visible local worktree with `show_dock_recent_folders = false` does not
+  record any new recent-document path.
+- Edge case: creating an invisible worktree does not record a recent-document path even when the
+  setting is enabled.
+- Integration: worktree creation still returns successfully in all three scenarios above, proving
+  the setting only gates the platform side effect.
+
+**Verification:**
+- The only observable behavior change is whether the recent-document recorder changes; worktree
+  creation and project state remain intact.
+
+- [ ] **Unit 3: Clear existing Dock recent documents at startup and on disable transitions**
+
+**Goal:** Enforce the "disabled means hidden now" behavior by clearing AppKit recent documents at
+startup and on enabled-to-disabled settings changes.
+
+**Requirements:** R4, R6, R7, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/zed/src/zed.rs`
+- Test: `crates/zed/src/zed.rs`
+
+**Approach:**
+- Add a small helper invoked from `zed::init(cx)` that:
+  - reads the effective `WorkspaceSettings::get_global(cx).show_dock_recent_folders` value once
+    during init and clears recent documents immediately when it is `false`
+  - registers a `SettingsStore` observer that tracks the previous effective value and clears only
+    on `true -> false` transitions
+- Keep the helper separate from keymap and window lifecycle observers so its purpose remains
+  narrowly scoped and testable.
+- Do not backfill recent documents when the setting becomes enabled again; new worktree openings
+  repopulate the list naturally through Unit 2.
+- Leave `crates/recent_projects` and `crates/workspace/src/history_manager.rs` untouched so
+  app-internal Recent Projects remains DB-backed and unchanged.
+
+**Patterns to follow:**
+- Prior-value observer logic in `crates/zed/src/zed.rs` (`handle_keymap_file_changes`)
+- Existing settings observer registration style in `crates/zed/src/zed.rs`
+- Existing `init_test(cx); cx.update(init);` test setup pattern in `crates/zed/src/zed.rs`
+
+**Test scenarios:**
+- Happy path: when user settings explicitly set `show_dock_recent_folders = false` before
+  `zed::init`, startup clears the test platform's recent documents exactly once.
+- Edge case: when the setting is omitted, startup still clears recent documents on macOS because
+  the effective default resolves to disabled there.
+- Happy path: when user settings explicitly set `show_dock_recent_folders = true` before
+  `zed::init`, startup does not clear recent documents.
+- Edge case: after init with the setting enabled, changing settings to `false` clears recent
+  documents exactly once.
+- Edge case: changing settings from `false -> false` or `true -> true` does not perform an extra
+  clear.
+- Integration: after changing settings from `false -> true`, a newly opened visible worktree is
+  recorded again, proving the plan preserves forward behavior without retroactive backfill.
+- Integration: after a clear, creating a visible worktree while the setting remains disabled does
+  not repopulate recent documents, proving the startup/transition logic composes correctly with
+  Unit 2.
+
+**Verification:**
+- Startup and runtime-disable flows both converge on the same clear side effect.
+- No code path touches the DB-backed recent-project surfaces.
+
+## System-Wide Impact
+
+- **Interaction graph:** `WorkspaceSettings` now influences two paths: the existing
+  `WorktreeStore -> App::add_recent_document` path and a new `zed::init -> App::clear_recent_documents`
+  lifecycle path.
+- **Error propagation:** recent-document add/clear remains best-effort platform behavior with no
+  new user-visible error channel, matching the current `add_recent_document` contract.
+- **State lifecycle risks:** repeated settings reloads can trigger duplicate clears unless the
+  observer tracks prior state; tests should lock this down.
+- **API surface parity:** Windows jump-list behavior via `update_jump_list` must remain unchanged.
+- **Integration coverage:** the important cross-layer scenario is startup clear + later worktree
+  creation under a disabled setting.
+- **Unchanged invariants:** `crates/recent_projects/src/recent_projects.rs` and
+  `crates/workspace/src/history_manager.rs` remain the source of truth for app-internal recent
+  surfaces and should not be modified by this plan.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `clear_recent_documents` is app-wide and would clear any future recent-document call sites too | Keep the API addition tightly documented, note the current single caller in code comments or tests, and avoid broadening recent-document usage in the same change |
+| Startup/settings observers could clear repeatedly on every settings reload | Track the previous effective boolean and assert idempotent behavior in tests |
+| The new setting might accidentally leak into Settings UI | Limit changes to `settings_content` and `workspace_settings`; do not add a `settings_ui` page-data entry in this phase |
+
+## Documentation / Operational Notes
+
+- The new setting should be documented through the settings schema comments in
+  `crates/settings_content/src/workspace.rs`.
+- No rollout flag or migration is needed; the macOS default change takes effect immediately for
+  users who do not override the new setting.
+- If the repo expects checked-in generated settings reference output, regenerate it as part of the
+  implementation change.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-03-macos-dock-recent-folders-setting-requirements.md`
+- Related code: `crates/project/src/worktree_store.rs`
+- Related code: `crates/gpui/src/app.rs`
+- Related code: `crates/gpui/src/platform.rs`
+- Related code: `crates/gpui_macos/src/platform.rs`
+- Related code: `crates/settings/src/settings_store.rs`
+- Related code: `crates/recent_projects/src/recent_projects.rs`
+- Related code: `crates/workspace/src/history_manager.rs`
+- Related code: `crates/workspace/src/workspace_settings.rs`
+- Related code: `crates/zed/src/zed.rs`


### PR DESCRIPTION
Add a user-global show_dock_recent_folders setting with a macOS-default-off behavior, gate recent-document registration on it, and clear existing recent items at startup and when the setting is disabled.

Keep app-internal Recent Projects unchanged and add tests for schema, worktree registration, and startup/transition clearing behavior.

Closes #ISSUE

Before marking this PR ready for review, make sure that you have:
- [ ] Added tests or clear manual verification notes
- [ ] Done a self-review for regressions, security, and release-facing behavior
- [ ] Updated docs or templates if the change affects installation, updates, release flow, or OSS contribution workflow
- [ ] Checked the current guidance in [CONTRIBUTING.md](https://github.com/currybab/superzent/blob/main/CONTRIBUTING.md)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
