### PR TITLE
Restore default-build next edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Current focus:
 - native editor, split panes, and diff views
 - terminal-first use of external coding agents
 - center-pane ACP tabs built from selected pieces of the existing ACP / `agent_ui` stack
+- default-build next-edit with non-Zed-hosted providers
 - public macOS Apple Silicon releases
 
 Deliberately out of scope for the default build:
@@ -46,7 +47,6 @@ Next:
 
 - remote project fix
 - session restore
-- next-edit integration
 - native alarm
 
 Later:
@@ -75,7 +75,7 @@ For day-to-day development, stay on the default lightweight shell:
 cargo check -p superzent
 ```
 
-The default build includes `acp_tabs`, so external ACP agents open in center-pane tabs without enabling the heavier upstream AI surface.
+The default build includes `acp_tabs` and next-edit, so external ACP agents open in center-pane tabs and regular editor buffers can use non-Zed-hosted edit prediction without enabling the heavier upstream AI surface.
 
 Before cutting a release, run the local maintainer preflight:
 
@@ -100,8 +100,9 @@ For a signed macOS bundle:
 - Extensions still use the upstream Zed marketplace.
 - Much of the editor and platform code still comes from upstream Zed and is intentionally kept close for easier maintenance.
 - This repository is regularly synced with upstream Zed, so GitHub contributor counts and graphs may include upstream contributors alongside superzent-specific work.
-- The default app build is `lite + acp_tabs`.
+- The default app build is `lite + acp_tabs + next_edit`.
 - `superzent` reuses selected ACP / `agent_ui` pieces to open external ACP chats in center-pane tabs.
+- The default build also restores an edit prediction footer entry for non-Zed-hosted providers in regular editor buffers.
 - That does not mean bringing back Zed's own docked agent panel, native text-thread surface, or hosted AI product flow in the default build.
 
 ## Project Docs

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -266,6 +266,10 @@ impl EventEmitter<Event> for Copilot {}
 #[derive(Clone)]
 pub struct GlobalCopilotAuth(pub Entity<Copilot>);
 
+fn next_edit_copilot_allowed(cx: &App) -> bool {
+    all_language_settings(None, cx).edit_predictions.provider == EditPredictionProvider::Copilot
+}
+
 impl GlobalCopilotAuth {
     pub fn set_global(
         server_id: LanguageServerId,
@@ -283,24 +287,15 @@ impl GlobalCopilotAuth {
     }
 
     pub fn try_get_or_init(app_state: Arc<AppState>, cx: &mut App) -> Option<GlobalCopilotAuth> {
-        let ai_enabled = !DisableAiSettings::get(None, cx).disable_ai;
-
         if let Some(copilot) = cx.try_global::<Self>().cloned() {
-            if ai_enabled {
-                Some(copilot)
-            } else {
-                cx.remove_global::<Self>();
-                None
-            }
-        } else if ai_enabled {
+            Some(copilot)
+        } else {
             Some(Self::set_global(
                 app_state.languages.next_language_server_id(),
                 app_state.fs.clone(),
                 app_state.node_runtime.clone(),
                 cx,
             ))
-        } else {
-            None
         }
     }
 }
@@ -394,8 +389,9 @@ impl Copilot {
         this.start_copilot(true, false, cx);
         cx.observe_global::<SettingsStore>(move |this, cx| {
             let ai_disabled = DisableAiSettings::get_global(cx).disable_ai;
+            let keep_copilot_for_next_edit = next_edit_copilot_allowed(cx);
 
-            if ai_disabled {
+            if ai_disabled && !keep_copilot_for_next_edit {
                 // Stop the server if AI is disabled
                 if !matches!(this.server, CopilotServer::Disabled) {
                     let shutdown = match mem::replace(&mut this.server, CopilotServer::Disabled) {
@@ -455,9 +451,6 @@ impl Copilot {
         awaiting_sign_in_after_start: bool,
         cx: &mut Context<Self>,
     ) {
-        if DisableAiSettings::get_global(cx).disable_ai {
-            return;
-        }
         if !matches!(self.server, CopilotServer::Disabled) {
             return;
         }
@@ -1307,9 +1300,10 @@ impl Copilot {
         let status = self.status();
 
         let is_ai_disabled = DisableAiSettings::get_global(cx).disable_ai;
+        let keep_copilot_for_next_edit = next_edit_copilot_allowed(cx);
         let filter = CommandPaletteFilter::global_mut(cx);
 
-        if is_ai_disabled {
+        if is_ai_disabled && !keep_copilot_for_next_edit {
             filter.hide_action_types(&signed_in_actions);
             filter.hide_action_types(&auth_actions);
             filter.hide_action_types(&no_auth_actions);

--- a/crates/copilot_ui/src/copilot_ui.rs
+++ b/crates/copilot_ui/src/copilot_ui.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use copilot::GlobalCopilotAuth;
 use gpui::AppContext;
 use language::language_settings::AllLanguageSettings;
-use project::DisableAiSettings;
 use settings::SettingsStore;
 pub use sign_in::{
     ConfigurationMode, ConfigurationView, CopilotCodeVerification, initiate_sign_in,
@@ -15,16 +14,13 @@ use ui::App;
 use workspace::AppState;
 
 pub fn init(app_state: &Arc<AppState>, cx: &mut App) {
-    let disable_ai = cx.read_global(|settings: &SettingsStore, _| {
-        settings.get::<DisableAiSettings>(None).disable_ai
-    });
     let provider = cx.read_global(|settings: &SettingsStore, _| {
         settings
             .get::<AllLanguageSettings>(None)
             .edit_predictions
             .provider
     });
-    if !disable_ai && provider == settings::EditPredictionProvider::Copilot {
+    if provider == settings::EditPredictionProvider::Copilot {
         GlobalCopilotAuth::set_global(
             app_state.languages.next_language_server_id(),
             app_state.fs.clone(),

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -31,13 +31,11 @@ use language::language_settings::all_language_settings;
 use language::{Anchor, Buffer, File, Point, TextBufferSnapshot, ToOffset, ToPoint};
 use language::{BufferSnapshot, OffsetRangeExt};
 use language_model::{LlmApiToken, NeedsLlmTokenRefresh};
-use project::{DisableAiSettings, Project, ProjectPath, WorktreeId};
+use project::{Project, ProjectPath, WorktreeId};
 use release_channel::AppVersion;
 use semver::Version;
 use serde::de::DeserializeOwned;
-use settings::{
-    EditPredictionPromptFormat, EditPredictionProvider, Settings as _, update_settings_file,
-};
+use settings::{EditPredictionPromptFormat, EditPredictionProvider, update_settings_file};
 use std::collections::{VecDeque, hash_map};
 use std::env;
 use text::{AnchorRangeExt, Edit};
@@ -1035,9 +1033,6 @@ impl EditPredictionStore {
         project: &Entity<Project>,
         cx: &mut Context<Self>,
     ) -> Option<Entity<Copilot>> {
-        if DisableAiSettings::get(None, cx).disable_ai {
-            return None;
-        }
         let state = self.get_or_init_project(project, cx);
 
         if state.copilot.is_some() {

--- a/crates/edit_prediction_ui/Cargo.toml
+++ b/crates/edit_prediction_ui/Cargo.toml
@@ -12,6 +12,10 @@ workspace = true
 path = "src/edit_prediction_ui.rs"
 doctest = false
 
+[features]
+default = []
+zed-hosted-provider = []
+
 [dependencies]
 anyhow.workspace = true
 buffer_diff.workspace = true
@@ -57,5 +61,4 @@ indoc.workspace = true
 project = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
-
 

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -20,7 +20,7 @@ use language::{
     EditPredictionsMode, File, Language,
     language_settings::{self, AllLanguageSettings, EditPredictionProvider, all_language_settings},
 };
-use project::{DisableAiSettings, Project};
+use project::Project;
 use regex::Regex;
 use settings::{Settings, SettingsStore, update_settings_file};
 use std::{
@@ -41,7 +41,12 @@ use workspace::{
 use zed_actions::{OpenBrowser, OpenSettingsAt};
 
 use crate::{
-    CaptureExample, RatePredictions, rate_prediction_modal::PredictEditsRatePredictionsFeatureFlag,
+    CaptureExample, RatePredictions,
+    provider_policy::{
+        current_edit_prediction_provider, edit_prediction_provider_supported,
+        normalize_edit_prediction_provider, zed_hosted_provider_supported,
+    },
+    rate_prediction_modal::PredictEditsRatePredictionsFeatureFlag,
 };
 
 actions!(
@@ -74,19 +79,15 @@ pub struct EditPredictionButton {
 
 impl Render for EditPredictionButton {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // Return empty div if AI is disabled
-        if DisableAiSettings::get_global(cx).disable_ai {
-            return div().hidden();
-        }
+        let current_provider = current_edit_prediction_provider(cx);
 
-        let language_settings = all_language_settings(None, cx);
-
-        match language_settings.edit_predictions.provider {
+        match current_provider {
             EditPredictionProvider::Copilot => {
                 let Some(copilot) = EditPredictionStore::try_global(cx)
                     .and_then(|store| store.read(cx).copilot_for_project(&self.project.upgrade()?))
                 else {
-                    return div().hidden();
+                    return div()
+                        .child(self.render_setup_button(self.editor_enabled.unwrap_or(true), cx));
                 };
                 let status = copilot.read(cx).status();
 
@@ -379,7 +380,11 @@ impl Render for EditPredictionButton {
                     }
                 };
 
-                if edit_prediction::should_show_upsell_modal() {
+                if matches!(
+                    provider,
+                    EditPredictionProvider::Zed | EditPredictionProvider::Experimental(_)
+                ) && edit_prediction::should_show_upsell_modal()
+                {
                     let tooltip_meta = if self.user_store.read(cx).current_user().is_some() {
                         "Choose a Plan"
                     } else {
@@ -519,12 +524,49 @@ impl Render for EditPredictionButton {
                 div().child(popover_menu.into_any_element())
             }
 
-            EditPredictionProvider::None => div().hidden(),
+            EditPredictionProvider::None => {
+                div().child(self.render_setup_button(self.editor_enabled.unwrap_or(true), cx))
+            }
         }
     }
 }
 
 impl EditPredictionButton {
+    fn render_setup_button(&self, enabled: bool, cx: &mut Context<Self>) -> AnyElement {
+        IconButton::new("edit-prediction-setup-button", IconName::ZedPredict)
+            .shape(IconButtonShape::Square)
+            .when(!enabled, |this| {
+                this.indicator(Indicator::dot().color(Color::Ignored))
+                    .indicator_border_color(Some(cx.theme().colors().status_bar_background))
+            })
+            .when(enabled, |this| {
+                this.indicator(Indicator::dot().color(Color::Muted))
+                    .indicator_border_color(Some(cx.theme().colors().status_bar_background))
+            })
+            .tooltip(|_window, cx| {
+                Tooltip::with_meta(
+                    "Edit Prediction",
+                    Some(&ToggleMenu),
+                    "No provider configured",
+                    cx,
+                )
+            })
+            .on_click(cx.listener(|_, _, window, cx| {
+                telemetry::event!(
+                    "Edit Prediction Menu Action",
+                    action = "configure_providers",
+                );
+                window.dispatch_action(
+                    OpenSettingsAt {
+                        path: "edit_predictions.providers".to_string(),
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
+            }))
+            .into_any_element()
+    }
+
     pub fn new(
         fs: Arc<dyn Fs>,
         user_store: Entity<UserStore>,
@@ -587,12 +629,7 @@ impl EditPredictionButton {
         current_provider: EditPredictionProvider,
         cx: &mut App,
     ) -> ContextMenu {
-        let available_providers = get_available_providers(cx);
-
-        let providers: Vec<_> = available_providers
-            .into_iter()
-            .filter(|p| *p != EditPredictionProvider::None)
-            .collect();
+        let providers = get_available_providers(cx);
 
         if !providers.is_empty() {
             menu = menu.separator().header("Providers");
@@ -625,38 +662,43 @@ impl EditPredictionButton {
         let fs = self.fs.clone();
         let project = self.project.clone();
         ContextMenu::build(window, cx, |menu, _, _| {
-            menu.entry("Sign In to Copilot", None, move |window, cx| {
-                telemetry::event!(
-                    "Edit Prediction Menu Action",
-                    action = "sign_in",
-                    provider = "copilot",
-                );
-                if let Some(copilot) = EditPredictionStore::try_global(cx).and_then(|store| {
-                    store.update(cx, |this, cx| {
-                        this.start_copilot_for_project(&project.upgrade()?, cx)
-                    })
-                }) {
-                    copilot_ui::initiate_sign_in(copilot, window, cx);
-                }
-            })
-            .entry("Disable Copilot", None, {
-                let fs = fs.clone();
-                move |_window, cx| {
+            let menu = menu
+                .entry("Sign In to Copilot", None, move |window, cx| {
                     telemetry::event!(
                         "Edit Prediction Menu Action",
-                        action = "disable_provider",
+                        action = "sign_in",
                         provider = "copilot",
                     );
-                    hide_copilot(fs.clone(), cx)
-                }
-            })
-            .separator()
-            .entry("Use Zed AI", None, {
-                let fs = fs.clone();
-                move |_window, cx| {
-                    set_completion_provider(fs.clone(), cx, EditPredictionProvider::Zed)
-                }
-            })
+                    if let Some(copilot) = EditPredictionStore::try_global(cx).and_then(|store| {
+                        store.update(cx, |this, cx| {
+                            this.start_copilot_for_project(&project.upgrade()?, cx)
+                        })
+                    }) {
+                        copilot_ui::initiate_sign_in(copilot, window, cx);
+                    }
+                })
+                .entry("Disable Copilot", None, {
+                    let fs = fs.clone();
+                    move |_window, cx| {
+                        telemetry::event!(
+                            "Edit Prediction Menu Action",
+                            action = "disable_provider",
+                            provider = "copilot",
+                        );
+                        hide_copilot(fs.clone(), cx)
+                    }
+                });
+
+            if zed_hosted_provider_supported() {
+                menu.separator().entry("Use Zed AI", None, {
+                    let fs = fs.clone();
+                    move |_window, cx| {
+                        set_completion_provider(fs.clone(), cx, EditPredictionProvider::Zed)
+                    }
+                })
+            } else {
+                menu
+            }
         })
     }
 
@@ -738,7 +780,7 @@ impl EditPredictionButton {
             });
         menu = menu.item(entry);
 
-        let provider = settings.edit_predictions.provider;
+        let provider = normalize_edit_prediction_provider(settings.edit_predictions.provider);
         let current_mode = settings.edit_predictions_mode();
         let subtle_mode = matches!(current_mode, EditPredictionsMode::Subtle);
         let eager_mode = matches!(current_mode, EditPredictionsMode::Eager);
@@ -1049,7 +1091,8 @@ impl EditPredictionButton {
         ContextMenu::build(window, cx, |mut menu, window, cx| {
             let user = self.user_store.read(cx).current_user();
 
-            let needs_sign_in = user.is_none()
+            let needs_sign_in = zed_hosted_provider_supported()
+                && user.is_none()
                 && matches!(
                     provider,
                     EditPredictionProvider::None | EditPredictionProvider::Zed
@@ -1418,6 +1461,7 @@ async fn open_disabled_globs_setting_in_editor(
 }
 
 pub fn set_completion_provider(fs: Arc<dyn Fs>, cx: &mut App, provider: EditPredictionProvider) {
+    let provider = normalize_edit_prediction_provider(provider);
     update_settings_file(fs, cx, move |settings, _| {
         settings
             .project
@@ -1431,7 +1475,9 @@ pub fn set_completion_provider(fs: Arc<dyn Fs>, cx: &mut App, provider: EditPred
 pub fn get_available_providers(cx: &mut App) -> Vec<EditPredictionProvider> {
     let mut providers = Vec::new();
 
-    providers.push(EditPredictionProvider::Zed);
+    if edit_prediction_provider_supported(EditPredictionProvider::Zed) {
+        providers.push(EditPredictionProvider::Zed);
+    }
 
     if let Some(app_state) = workspace::AppState::global(cx).upgrade()
         && copilot::GlobalCopilotAuth::try_get_or_init(app_state, cx)

--- a/crates/edit_prediction_ui/src/edit_prediction_ui.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_ui.rs
@@ -1,5 +1,6 @@
 mod edit_prediction_button;
 mod edit_prediction_context_view;
+mod provider_policy;
 mod rate_prediction_modal;
 
 use command_palette_hooks::CommandPaletteFilter;
@@ -9,7 +10,6 @@ use editor::Editor;
 use feature_flags::FeatureFlagAppExt as _;
 use gpui::actions;
 use language::language_settings::AllLanguageSettings;
-use project::DisableAiSettings;
 use rate_prediction_modal::RatePredictionsModal;
 use settings::{Settings as _, SettingsStore};
 use std::any::{Any as _, TypeId};
@@ -18,6 +18,11 @@ use workspace::{SplitDirection, Workspace};
 
 pub use edit_prediction_button::{
     EditPredictionButton, ToggleMenu, get_available_providers, set_completion_provider,
+};
+pub use provider_policy::{
+    current_edit_prediction_provider, edit_prediction_provider_supported,
+    normalize_edit_prediction_provider, supported_edit_prediction_providers,
+    zed_hosted_provider_supported,
 };
 
 use crate::rate_prediction_modal::PredictEditsRatePredictionsFeatureFlag;
@@ -81,18 +86,6 @@ pub fn init(cx: &mut App) {
 fn feature_gate_predict_edits_actions(cx: &mut App) {
     let rate_completion_action_types = [TypeId::of::<RatePredictions>()];
     let reset_onboarding_action_types = [TypeId::of::<ResetOnboarding>()];
-    let all_action_types = [
-        TypeId::of::<RatePredictions>(),
-        TypeId::of::<CaptureExample>(),
-        TypeId::of::<edit_prediction::ResetOnboarding>(),
-        zed_actions::OpenZedPredictOnboarding.type_id(),
-        TypeId::of::<edit_prediction::ClearHistory>(),
-        TypeId::of::<rate_prediction_modal::ThumbsUpActivePrediction>(),
-        TypeId::of::<rate_prediction_modal::ThumbsDownActivePrediction>(),
-        TypeId::of::<rate_prediction_modal::NextEdit>(),
-        TypeId::of::<rate_prediction_modal::PreviousEdit>(),
-    ];
-
     CommandPaletteFilter::update_global(cx, |filter, _cx| {
         filter.hide_action_types(&rate_completion_action_types);
         filter.hide_action_types(&reset_onboarding_action_types);
@@ -100,13 +93,10 @@ fn feature_gate_predict_edits_actions(cx: &mut App) {
     });
 
     cx.observe_global::<SettingsStore>(move |cx| {
-        let is_ai_disabled = DisableAiSettings::get_global(cx).disable_ai;
         let has_feature_flag = cx.has_flag::<PredictEditsRatePredictionsFeatureFlag>();
 
         CommandPaletteFilter::update_global(cx, |filter, _cx| {
-            if is_ai_disabled {
-                filter.hide_action_types(&all_action_types);
-            } else if has_feature_flag {
+            if has_feature_flag {
                 filter.show_action_types(&rate_completion_action_types);
             } else {
                 filter.hide_action_types(&rate_completion_action_types);
@@ -116,16 +106,14 @@ fn feature_gate_predict_edits_actions(cx: &mut App) {
     .detach();
 
     cx.observe_flag::<PredictEditsRatePredictionsFeatureFlag, _>(move |is_enabled, cx| {
-        if !DisableAiSettings::get_global(cx).disable_ai {
-            if is_enabled {
-                CommandPaletteFilter::update_global(cx, |filter, _cx| {
-                    filter.show_action_types(&rate_completion_action_types);
-                });
-            } else {
-                CommandPaletteFilter::update_global(cx, |filter, _cx| {
-                    filter.hide_action_types(&rate_completion_action_types);
-                });
-            }
+        if is_enabled {
+            CommandPaletteFilter::update_global(cx, |filter, _cx| {
+                filter.show_action_types(&rate_completion_action_types);
+            });
+        } else {
+            CommandPaletteFilter::update_global(cx, |filter, _cx| {
+                filter.hide_action_types(&rate_completion_action_types);
+            });
         }
     })
     .detach();

--- a/crates/edit_prediction_ui/src/provider_policy.rs
+++ b/crates/edit_prediction_ui/src/provider_policy.rs
@@ -1,0 +1,83 @@
+use gpui::App;
+use language::language_settings::{EditPredictionProvider, all_language_settings};
+
+pub fn current_edit_prediction_provider(cx: &App) -> EditPredictionProvider {
+    normalize_edit_prediction_provider(all_language_settings(None, cx).edit_predictions.provider)
+}
+
+pub fn normalize_edit_prediction_provider(
+    provider: EditPredictionProvider,
+) -> EditPredictionProvider {
+    if edit_prediction_provider_supported(provider) {
+        provider
+    } else {
+        EditPredictionProvider::None
+    }
+}
+
+pub fn edit_prediction_provider_supported(provider: EditPredictionProvider) -> bool {
+    match provider {
+        EditPredictionProvider::Zed | EditPredictionProvider::Experimental(_) => {
+            zed_hosted_provider_supported()
+        }
+        EditPredictionProvider::None
+        | EditPredictionProvider::Copilot
+        | EditPredictionProvider::Codestral
+        | EditPredictionProvider::Ollama
+        | EditPredictionProvider::OpenAiCompatibleApi
+        | EditPredictionProvider::Sweep
+        | EditPredictionProvider::Mercury => true,
+    }
+}
+
+pub fn supported_edit_prediction_providers() -> Vec<EditPredictionProvider> {
+    let mut providers = vec![EditPredictionProvider::None];
+
+    if zed_hosted_provider_supported() {
+        providers.push(EditPredictionProvider::Zed);
+    }
+
+    providers.extend([
+        EditPredictionProvider::Copilot,
+        EditPredictionProvider::Codestral,
+        EditPredictionProvider::Ollama,
+        EditPredictionProvider::OpenAiCompatibleApi,
+        EditPredictionProvider::Sweep,
+        EditPredictionProvider::Mercury,
+    ]);
+
+    providers
+}
+
+pub const fn zed_hosted_provider_supported() -> bool {
+    cfg!(feature = "zed-hosted-provider")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_edit_prediction_provider_disables_zed_hosted_providers_by_default() {
+        assert_eq!(
+            normalize_edit_prediction_provider(EditPredictionProvider::Zed),
+            EditPredictionProvider::None
+        );
+        assert_eq!(
+            normalize_edit_prediction_provider(EditPredictionProvider::Experimental("zeta2")),
+            EditPredictionProvider::None
+        );
+        assert_eq!(
+            normalize_edit_prediction_provider(EditPredictionProvider::Copilot),
+            EditPredictionProvider::Copilot
+        );
+        assert_eq!(
+            normalize_edit_prediction_provider(EditPredictionProvider::Codestral),
+            EditPredictionProvider::Codestral
+        );
+        assert_eq!(
+            normalize_edit_prediction_provider(EditPredictionProvider::Mercury),
+            EditPredictionProvider::Mercury
+        );
+    }
+}

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -156,7 +156,7 @@ use parking_lot::Mutex;
 use persistence::DB;
 use project::{
     BreakpointWithPosition, CodeAction, Completion, CompletionDisplayOptions, CompletionIntent,
-    CompletionResponse, CompletionSource, DisableAiSettings, DocumentHighlight, InlayHint, InlayId,
+    CompletionResponse, CompletionSource, DocumentHighlight, InlayHint, InlayId,
     InvalidationStrategy, Location, LocationLink, LspAction, PrepareRenameResponse, Project,
     ProjectItem, ProjectPath, ProjectTransaction,
     debugger::{
@@ -7811,10 +7811,6 @@ impl Editor {
         let (buffer, cursor_buffer_position) =
             self.buffer.read(cx).text_anchor_for_position(cursor, cx)?;
 
-        if DisableAiSettings::is_ai_disabled_for_buffer(Some(&buffer), cx) {
-            return None;
-        }
-
         if !self.edit_predictions_enabled_in_buffer(&buffer, cursor_buffer_position, cx) {
             self.discard_edit_prediction(EditPredictionDiscardReason::Ignored, cx);
             return None;
@@ -7873,11 +7869,6 @@ impl Editor {
         if let Some((buffer, cursor_buffer_position)) =
             self.buffer.read(cx).text_anchor_for_position(cursor, cx)
         {
-            if DisableAiSettings::is_ai_disabled_for_buffer(Some(&buffer), cx) {
-                self.edit_prediction_settings = EditPredictionSettings::Disabled;
-                self.discard_edit_prediction(EditPredictionDiscardReason::Ignored, cx);
-                return;
-            }
             self.edit_prediction_settings =
                 self.edit_prediction_settings_at_position(&buffer, cursor_buffer_position, cx);
         }
@@ -8530,12 +8521,6 @@ impl Editor {
         let cursor = selection.head();
         let multibuffer = self.buffer.read(cx).snapshot(cx);
 
-        // Check project-level disable_ai setting for the current buffer
-        if let Some((buffer, _)) = self.buffer.read(cx).text_anchor_for_position(cursor, cx) {
-            if DisableAiSettings::is_ai_disabled_for_buffer(Some(&buffer), cx) {
-                return None;
-            }
-        }
         let offset_selection = selection.map(|endpoint| endpoint.to_offset(&multibuffer));
         let excerpt_id = cursor.excerpt_id;
 

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -122,6 +122,17 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
     .detach();
 }
 
+pub fn register_copilot_chat_provider(cx: &mut App) {
+    let registry = LanguageModelRegistry::global(cx);
+    registry.update(cx, |registry, cx| {
+        registry.unregister_provider(
+            LanguageModelProviderId::from("copilot_chat".to_string()),
+            cx,
+        );
+        registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+    });
+}
+
 fn register_openai_compatible_providers(
     registry: &mut LanguageModelRegistry,
     old: &HashSet<Arc<str>>,
@@ -220,7 +231,4 @@ fn register_language_model_providers(
         Arc::new(XAiLanguageModelProvider::new(client.http_client(), cx)),
         cx,
     );
-    if copilot_chat::CopilotChat::global(cx).is_some() {
-        registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
-    }
 }

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -220,5 +220,7 @@ fn register_language_model_providers(
         Arc::new(XAiLanguageModelProvider::new(client.http_client(), cx)),
         cx,
     );
-    registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+    if copilot_chat::CopilotChat::global(cx).is_some() {
+        registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+    }
 }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -153,11 +153,12 @@ impl EditPredictionProvider {
     pub fn display_name(&self) -> Option<&'static str> {
         match self {
             EditPredictionProvider::Zed => Some("Zed AI"),
+            EditPredictionProvider::None => Some("Off"),
             EditPredictionProvider::Copilot => Some("GitHub Copilot"),
             EditPredictionProvider::Codestral => Some("Codestral"),
             EditPredictionProvider::Sweep => Some("Sweep"),
             EditPredictionProvider::Mercury => Some("Mercury"),
-            EditPredictionProvider::Experimental(_) | EditPredictionProvider::None => None,
+            EditPredictionProvider::Experimental(_) => None,
             EditPredictionProvider::Ollama => Some("Ollama"),
             EditPredictionProvider::OpenAiCompatibleApi => Some("OpenAI-Compatible API"),
         }

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -13,14 +13,17 @@ path = "src/settings_ui.rs"
 
 [features]
 default = []
-ai = [
-    "dep:agent",
-    "dep:agent_settings",
+edit_prediction = [
     "dep:codestral",
     "dep:copilot",
     "dep:copilot_ui",
     "dep:edit_prediction",
     "dep:edit_prediction_ui",
+]
+ai = [
+    "edit_prediction",
+    "dep:agent",
+    "dep:agent_settings",
 ]
 test-support = []
 

--- a/crates/settings_ui/src/components.rs
+++ b/crates/settings_ui/src/components.rs
@@ -3,7 +3,7 @@ mod font_picker;
 mod icon_theme_picker;
 mod input_field;
 mod number_field;
-#[cfg(feature = "ai")]
+#[cfg(feature = "edit_prediction")]
 mod ollama_model_picker;
 mod section_items;
 mod theme_picker;
@@ -13,7 +13,7 @@ pub use font_picker::font_picker;
 pub use icon_theme_picker::icon_theme_picker;
 pub use input_field::*;
 pub use number_field::*;
-#[cfg(feature = "ai")]
+#[cfg(feature = "edit_prediction")]
 pub use ollama_model_picker::render_ollama_model_picker;
 pub use section_items::*;
 pub use theme_picker::theme_picker;

--- a/crates/settings_ui/src/components/section_items.rs
+++ b/crates/settings_ui/src/components/section_items.rs
@@ -17,13 +17,11 @@ impl SettingsSectionHeader {
         }
     }
 
-    #[cfg(feature = "ai")]
     pub fn icon(mut self, icon: IconName) -> Self {
         self.icon = Some(icon);
         self
     }
 
-    #[cfg(feature = "ai")]
     pub fn no_padding(mut self, no_padding: bool) -> Self {
         self.no_padding = no_padding;
         self

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2867,6 +2867,24 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
         ]
     }
 
+    #[cfg(feature = "edit_prediction")]
+    fn edit_prediction_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Edit Predictions"),
+            SettingsPageItem::SubPageLink(SubPageLink {
+                title: "Configure Providers".into(),
+                r#type: crate::SubPageType::default(),
+                description: Some(
+                    "Choose and configure next-edit providers for regular editor buffers.".into(),
+                ),
+                json_path: Some("edit_predictions.providers"),
+                in_json: false,
+                files: USER,
+                render: crate::pages::render_edit_prediction_setup_page,
+            }),
+        ]
+    }
+
     fn languages_list_section(cx: &App) -> Box<[SettingsPageItem]> {
         // todo(settings_ui): Refresh on extension (un)/installed
         // Note that `crates/json_schema_store` solves the same problem, there is probably a way to unify the two
@@ -2901,15 +2919,19 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
     SettingsPage {
         title: "Languages & Tools",
         items: {
-            concat_sections!(
+            let mut items = concat_sections!(
+                @vec,
                 non_editor_language_settings_data(),
                 file_types_section(),
                 diagnostics_section(),
                 inline_diagnostics_section(),
                 lsp_pull_diagnostics_section(),
                 lsp_highlights_section(),
-                languages_list_section(cx),
-            )
+            );
+            #[cfg(feature = "edit_prediction")]
+            items.extend(edit_prediction_section());
+            items.extend(languages_list_section(cx));
+            items.into_boxed_slice()
         },
     }
 }

--- a/crates/settings_ui/src/pages.rs
+++ b/crates/settings_ui/src/pages.rs
@@ -3,7 +3,7 @@ mod audio_input_output_setup;
 #[cfg(test)]
 mod audio_test_window;
 #[allow(dead_code)]
-#[cfg(feature = "ai")]
+#[cfg(feature = "edit_prediction")]
 mod edit_prediction_provider_setup;
 mod superzent_agent_presets;
 #[allow(dead_code)]
@@ -13,6 +13,8 @@ mod tool_permissions_setup;
 pub(crate) use audio_input_output_setup::{
     render_input_audio_device_dropdown, render_output_audio_device_dropdown,
 };
+#[cfg(feature = "edit_prediction")]
+pub(crate) use edit_prediction_provider_setup::render_edit_prediction_setup_page;
 pub(crate) use superzent_agent_presets::render_superzent_agent_presets_page;
 
 #[cfg(feature = "ai")]

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -5,11 +5,11 @@ use edit_prediction::{
     open_ai_compatible::{open_ai_compatible_api_token, open_ai_compatible_api_url},
     sweep_ai::{SWEEP_CREDENTIALS_URL, sweep_api_token},
 };
-use edit_prediction_ui::{get_available_providers, set_completion_provider};
+use edit_prediction_ui::{
+    current_edit_prediction_provider, set_completion_provider, supported_edit_prediction_providers,
+};
 use gpui::{Entity, ScrollHandle, prelude::*};
-use language::language_settings::AllLanguageSettings;
 
-use settings::Settings as _;
 use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle, prelude::*};
 use workspace::AppState;
 
@@ -138,13 +138,11 @@ pub(crate) fn render_edit_prediction_setup_page(
 }
 
 fn render_provider_dropdown(window: &mut Window, cx: &mut App) -> AnyElement {
-    let current_provider = AllLanguageSettings::get_global(cx)
-        .edit_predictions
-        .provider;
+    let current_provider = current_edit_prediction_provider(cx);
     let current_provider_name = current_provider.display_name().unwrap_or("No provider set");
 
     let menu = ContextMenu::build(window, cx, move |mut menu, _, cx| {
-        let available_providers = get_available_providers(cx);
+        let available_providers = supported_edit_prediction_providers();
         let fs = <dyn fs::Fs>::global(cx);
 
         for provider in available_providers {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -560,7 +560,7 @@ fn init_renderers(cx: &mut App) {
         // please semicolon stay on next line
         ;
 
-    #[cfg(feature = "ai")]
+    #[cfg(feature = "edit_prediction")]
     cx.default_global::<SettingFieldRenderer>()
         .add_basic_renderer::<settings::OllamaModelName>(
             crate::components::render_ollama_model_picker,
@@ -3028,7 +3028,7 @@ impl SettingsWindow {
         self.render_sub_page_items_in(page_content, items, false, window, cx)
     }
 
-    #[cfg(feature = "ai")]
+    #[cfg(feature = "edit_prediction")]
     fn render_sub_page_items_section<'a, Items>(
         &self,
         items: Items,
@@ -4721,6 +4721,37 @@ pub mod test {
         > Appearance & Behavior
         "
     );
+
+    #[cfg(feature = "edit_prediction")]
+    #[gpui::test]
+    async fn test_edit_prediction_provider_subpage_is_registered(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            register_settings(cx);
+            let app_state = AppState::test(cx);
+            AppState::set_global(Arc::downgrade(&app_state), cx);
+        });
+
+        let (settings_window, cx) =
+            cx.add_window_view(|window, cx| SettingsWindow::new(None, window, cx));
+
+        settings_window.read_with(cx, |settings_window, _| {
+            assert!(
+                settings_window
+                    .pages
+                    .iter()
+                    .any(|page| page.items.iter().any(|item| {
+                        matches!(
+                            item,
+                            SettingsPageItem::SubPageLink(SubPageLink {
+                                json_path: Some("edit_predictions.providers"),
+                                ..
+                            })
+                        )
+                    })),
+                "settings UI should register the edit prediction providers sub-page"
+            );
+        });
+    }
 
     #[gpui::test]
     async fn test_settings_window_shows_worktrees_from_multiple_workspaces(

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [features]
 # Default local builds stay on the lightweight single-user shell surface.
 # Use `--features full` to opt back into the upstream-like AI/collab stack.
-default = ["lite", "acp_tabs"]
+default = ["lite", "acp_tabs", "next_edit"]
 lite = []
 acp_tabs = [
     "dep:acp_tools",
@@ -25,21 +25,26 @@ acp_tabs = [
     "dep:web_search_providers",
     "superzent_ui/acp_tabs",
 ]
-calls = ["dep:audio", "dep:call", "title_bar/calls"]
-collab = ["calls", "dep:channel", "dep:collab_ui"]
-ai = [
-    "acp_tabs",
-    "dep:acp_thread",
-    "dep:acp_tools",
-    "dep:agent-client-protocol",
-    "dep:agent_settings",
+next_edit = [
     "dep:codestral",
     "dep:copilot",
     "dep:copilot_chat",
     "dep:edit_prediction",
     "dep:edit_prediction_ui",
-    "git_ui/ai",
     "language_tools/edit-prediction",
+    "settings_ui/edit_prediction",
+]
+calls = ["dep:audio", "dep:call", "title_bar/calls"]
+collab = ["calls", "dep:channel", "dep:collab_ui"]
+ai = [
+    "next_edit",
+    "acp_tabs",
+    "dep:acp_thread",
+    "dep:acp_tools",
+    "dep:agent-client-protocol",
+    "dep:agent_settings",
+    "edit_prediction_ui/zed-hosted-provider",
+    "git_ui/ai",
     "settings_ui/ai",
     "terminal_view/assistant",
 ]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -763,6 +763,7 @@ fn main() {
                 copilot_chat_configuration,
                 cx,
             );
+            language_models::register_copilot_chat_provider(cx);
         }
         #[cfg(feature = "next_edit")]
         {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -71,7 +71,7 @@ use collab_ui::channel_view::ChannelView;
 use gpui::Focusable;
 #[cfg(feature = "acp_tabs")]
 use superzent_ui::NewAcpTab;
-#[cfg(feature = "ai")]
+#[cfg(feature = "next_edit")]
 use zed::edit_prediction_registry;
 
 #[cfg(target_os = "macos")]
@@ -763,6 +763,9 @@ fn main() {
                 copilot_chat_configuration,
                 cx,
             );
+        }
+        #[cfg(feature = "next_edit")]
+        {
             edit_prediction_registry::init(
                 app_state.client.clone(),
                 app_state.user_store.clone(),
@@ -836,7 +839,7 @@ fn main() {
         settings_ui::init(cx);
         keymap_editor::init(cx);
         extensions_ui::init(cx);
-        #[cfg(feature = "ai")]
+        #[cfg(feature = "next_edit")]
         edit_prediction::init(cx);
         inspector_ui::init(app_state.clone(), cx);
         json_schema_store::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -5139,6 +5139,7 @@ mod tests {
                 copilot_chat::CopilotChatConfiguration::default(),
                 cx,
             );
+            language_models::register_copilot_chat_provider(cx);
             image_viewer::init(cx);
             web_search::init(cx);
             git_graph::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1,5 +1,5 @@
 mod app_menus;
-#[cfg(feature = "ai")]
+#[cfg(feature = "next_edit")]
 pub mod edit_prediction_registry;
 #[cfg(target_os = "macos")]
 pub(crate) mod mac_only_instance;
@@ -474,9 +474,9 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             crashes::set_gpu_info(specs);
         }
 
-        #[cfg(feature = "ai")]
+        #[cfg(feature = "next_edit")]
         let edit_prediction_menu_handle = PopoverMenuHandle::default();
-        #[cfg(feature = "ai")]
+        #[cfg(feature = "next_edit")]
         let edit_prediction_ui = cx.new(|cx| {
             edit_prediction_ui::EditPredictionButton::new(
                 app_state.fs.clone(),
@@ -486,7 +486,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
                 cx,
             )
         });
-        #[cfg(feature = "ai")]
+        #[cfg(feature = "next_edit")]
         workspace.register_action({
             move |_, _: &edit_prediction_ui::ToggleMenu, window, cx| {
                 edit_prediction_menu_handle.toggle(window, cx);
@@ -527,6 +527,8 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         workspace
             .center_pane_footer()
             .update(cx, |center_pane_footer, cx| {
+                #[cfg(feature = "next_edit")]
+                center_pane_footer.add_left_item(edit_prediction_ui, window, cx);
                 center_pane_footer.add_left_item(lsp_button, window, cx);
                 center_pane_footer.add_left_item(diagnostic_summary, window, cx);
                 center_pane_footer.add_right_item(cursor_position, window, cx);
@@ -535,8 +537,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         workspace.status_bar().update(cx, |status_bar, cx| {
             status_bar.add_left_item(search_button, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
-            #[cfg(feature = "ai")]
-            status_bar.add_right_item(edit_prediction_ui, window, cx);
             status_bar.add_right_item(active_buffer_encoding, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);
             status_bar.add_right_item(line_ending_indicator, window, cx);
@@ -5173,6 +5173,8 @@ mod tests {
             repl::init(app_state.fs.clone(), cx);
             repl::notebook::init(cx);
             tasks_ui::init(cx);
+            #[cfg(feature = "next_edit")]
+            edit_prediction::init(cx);
             project::debugger::breakpoint_store::BreakpointStore::init(
                 &app_state.client.clone().into(),
             );

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -5139,7 +5139,6 @@ mod tests {
                 copilot_chat::CopilotChatConfiguration::default(),
                 cx,
             );
-            language_models::register_copilot_chat_provider(cx);
             image_viewer::init(cx);
             web_search::init(cx);
             git_graph::init(cx);
@@ -5147,6 +5146,8 @@ mod tests {
             {
                 language_model::init(app_state.user_store.clone(), app_state.client.clone(), cx);
                 language_models::init(app_state.user_store.clone(), app_state.client.clone(), cx);
+                #[cfg(feature = "ai")]
+                language_models::register_copilot_chat_provider(cx);
                 acp_tools::init(cx);
                 web_search_providers::init(
                     app_state.client.clone(),

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -3,6 +3,7 @@ use codestral::{CodestralEditPredictionDelegate, load_codestral_api_key};
 use collections::HashMap;
 use copilot::CopilotEditPredictionDelegate;
 use edit_prediction::{EditPredictionModel, ZedEditPredictionDelegate};
+use edit_prediction_ui::normalize_edit_prediction_provider;
 use editor::Editor;
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{EditPredictionProvider, all_language_settings};
@@ -105,7 +106,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
 
 fn edit_prediction_provider_config_for_settings(cx: &App) -> Option<EditPredictionProviderConfig> {
     let settings = &all_language_settings(None, cx).edit_predictions;
-    let provider = settings.provider;
+    let provider = normalize_edit_prediction_provider(settings.provider);
     match provider {
         EditPredictionProvider::None => None,
         EditPredictionProvider::Copilot => Some(EditPredictionProviderConfig::Copilot),

--- a/docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md
+++ b/docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md
@@ -1,0 +1,116 @@
+---
+date: 2026-04-05
+topic: default-build-next-edit
+---
+
+# Default Build Next Edit
+
+## Problem Frame
+
+`superzent`'s roadmap explicitly calls for next-edit integration, but the current default build is
+intentionally narrow and excludes the inherited hosted AI and edit prediction stack. The repo
+still contains substantial upstream edit prediction UI, provider setup, and runtime code, so the
+highest-leverage move is to bring back next-edit in the default build without reopening Zed-hosted
+AI or the broader upstream product surface.
+
+## Requirements
+
+**Build Surface**
+
+- R1. The default `superzent` build must support next-edit in the general code editor surface.
+- R2. The feature must reuse the existing upstream-like edit prediction experience as much as
+  possible instead of introducing a superzent-specific replacement.
+- R3. Re-enabling next-edit must not implicitly restore Zed-hosted AI surfaces, Zed login
+  requirements, cloud collaboration, or the docked agent/text-thread product surface.
+
+**Provider Scope**
+
+- R4. The default build must support these non-Zed-hosted providers in v1:
+  Ollama, OpenAI-compatible API, GitHub Copilot, Codestral, Sweep, and Mercury.
+- R5. The Zed-hosted provider must not appear in the default-build UI for this feature.
+- R6. Provider-specific setup must keep using the existing provider-auth/config flows where they
+  already exist, rather than inventing a new superzent-only setup flow.
+- R7. If existing user settings still point to the Zed-hosted provider, the default build must
+  treat that state as effectively unconfigured and return the user to the setup path rather than
+  trying to activate Zed-hosted edit prediction.
+
+**User Experience**
+
+- R8. Next-edit must appear as automatic inline prediction in normal editor buffers when a
+  supported provider is configured.
+- R9. The default build must expose the existing status bar edit prediction entry.
+- R10. The status bar menu must continue to support provider switching and setup entry points.
+- R11. The existing dedicated "Configure Providers" settings flow must be available from the
+  default build.
+- R12. When no supported provider is configured, the status bar entry must still be visible and
+  guide the user into setup instead of disappearing.
+- R13. In v1, next-edit support is limited to general code editor buffers and does not extend to
+  agent text threads or arbitrary text inputs.
+
+## Provider Matrix
+
+| Provider              | v1 status in default build | Notes                                     |
+| --------------------- | -------------------------- | ----------------------------------------- |
+| Ollama                | Supported                  | Existing local/self-hosted path           |
+| OpenAI-compatible API | Supported                  | Existing self-hosted/custom path          |
+| GitHub Copilot        | Supported                  | Existing provider/auth flow               |
+| Codestral             | Supported                  | Existing API-key flow                     |
+| Sweep                 | Supported                  | Existing API-key flow                     |
+| Mercury               | Supported                  | Existing API-key flow                     |
+| Zed-hosted / Zeta     | Hidden                     | Requires Zed-hosted login/product surface |
+
+## Success Criteria
+
+- A user on the default build can discover next-edit from the status bar without enabling the full
+  upstream AI surface.
+- A user can configure one of the supported non-Zed-hosted providers from the existing settings
+  flow and start receiving automatic inline predictions in regular code buffers.
+- The default build does not expose Zed-hosted edit prediction as an available choice.
+- A user with stale `provider: "zed"` settings is guided back into provider setup instead of being
+  left in a broken or hidden state.
+- Existing roadmap intent ("next-edit integration") is satisfied without broadening the default
+  product into hosted AI or upstream docked AI surfaces.
+
+## Scope Boundaries
+
+- No support for Zed-hosted edit prediction in the default build.
+- No requirement to support agent text threads or non-editor text fields in v1.
+- No redesign of the upstream edit prediction UX; the goal is controlled reuse.
+- No requirement to bring back the full `ai` feature bundle if a narrower default-build path can
+  deliver the agreed surface.
+
+## Key Decisions
+
+- Reuse the upstream status bar menu and provider setup flow: this is the fastest path to a
+  coherent user experience with the least product invention.
+- Treat next-edit as part of the default shell again: roadmap value is in making it available
+  where users already work, not in hiding it behind an opt-in debug build.
+- Keep the provider set non-Zed-hosted: this preserves superzent's current stance against
+  default-build dependence on Zed-hosted AI/login flows.
+- Interpret legacy/default-build `provider: "zed"` state as unsupported and recover to setup:
+  this avoids a confusing broken state for users carrying old settings into the narrower default
+  build.
+- Keep the initial state off until the user selects/configures a provider: avoids surprising
+  network behavior and keeps the default build explicit.
+
+## Dependencies / Assumptions
+
+- Existing edit prediction runtime, status bar UI, and provider setup page are still present in the
+  repo and primarily need feature-surface reactivation rather than net-new product design.
+- Sweep and Mercury can remain within the allowed provider scope because they use their own
+  provider/API-key flows rather than Zed-hosted auth.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] What is the smallest feature/dependency slice that enables edit
+  prediction in the default build without reintroducing unrelated hosted AI surfaces?
+- [Affects R10][Technical] Which parts of the existing settings UI are gated behind `ai` today and
+  need to move into the default build to preserve the upstream setup flow?
+- [Affects R5][Technical] What is the cleanest way to hide Zed-hosted provider choices in default
+  build UI while preserving upstream behavior for heavier/debug builds?
+
+## Next Steps
+
+-> /prompts:ce-plan for structured implementation planning

--- a/docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md
+++ b/docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md
@@ -135,12 +135,12 @@ separation.
 
 > _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
 
-| Build / state    | Provider in settings       | Entry behavior                                      | Prediction runtime         |
-| ---------------- | -------------------------- | --------------------------------------------------- | -------------------------- |
-| Default build    | `none` or missing          | Visible footer entry; click opens provider setup    | Disabled                   |
-| Default build    | Supported non-Zed provider | Visible footer entry with provider-specific menu    | Enabled in editor buffers  |
-| Default build    | `zed`                      | Visible footer entry; treated like unconfigured     | Disabled                   |
-| Full/debug build | `zed`                      | Existing upstream behavior                          | Existing upstream behavior |
+| Build / state    | Provider in settings       | Entry behavior                                   | Prediction runtime         |
+| ---------------- | -------------------------- | ------------------------------------------------ | -------------------------- |
+| Default build    | `none` or missing          | Visible footer entry; click opens provider setup | Disabled                   |
+| Default build    | Supported non-Zed provider | Visible footer entry with provider-specific menu | Enabled in editor buffers  |
+| Default build    | `zed`                      | Visible footer entry; treated like unconfigured  | Disabled                   |
+| Full/debug build | `zed`                      | Existing upstream behavior                       | Existing upstream behavior |
 
 ## Implementation Units
 
@@ -271,7 +271,7 @@ supported providers from the default build.
 - Change the `EditPredictionProvider::None`/unsupported rendering path so the footer entry stays
   visible and routes the user into provider setup instead of hiding entirely.
 - Reuse the existing menu structure for configured-provider states, including `Predict Edit at
-  Cursor`, mode toggles where they still apply, provider switching, and `Configure Providers`.
+Cursor`, mode toggles where they still apply, provider switching, and `Configure Providers`.
 - Restore or re-add the `edit_predictions.providers` settings subpage path so
   `OpenSettingsAt { path: "edit_predictions.providers" }` works in the default build and aligns
   with the existing visual test expectation.

--- a/docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md
+++ b/docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md
@@ -1,0 +1,393 @@
+---
+title: feat: Restore default-build next edit
+type: feat
+status: completed
+date: 2026-04-05
+origin: docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md
+---
+
+# feat: Restore default-build next edit
+
+## Overview
+
+Re-enable next-edit in the default `superzent` build by carving a narrower edit-prediction
+feature slice out of the current `ai` gate, then reusing the existing provider setup flow,
+edit-prediction runtime, and a footer-mounted shell entry for non-Zed-hosted providers only. The
+default build must gain editor-buffer next-edit without reintroducing Zed-hosted AI, Zed login,
+or the broader upstream docked AI surface.
+
+## Problem Frame
+
+The product roadmap explicitly calls for next-edit integration, but the default app build is still
+`lite + acp_tabs`, and `docs/src/development.md`/`docs/src/getting-started.md` currently say the
+default build excludes edit prediction stacks. At the same time, the repository already contains:
+
+- runtime provider wiring in `crates/zed/src/zed/edit_prediction_registry.rs`
+- an existing edit prediction entry UI in `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- a provider setup page in `crates/settings_ui/src/pages/edit_prediction_provider_setup.rs`
+- a visual test that already expects `edit_predictions.providers` to open a settings subpage in
+  `crates/zed/src/visual_test_runner.rs`
+
+This is not a greenfield feature. The work is primarily controlled reactivation and feature-slice
+separation.
+
+## Requirements Trace
+
+- R1. Default build supports next-edit in general code editor buffers.
+- R2. Reuse the existing upstream-like edit prediction experience instead of inventing a new one.
+- R3. Do not implicitly restore Zed-hosted AI/login, collab, or docked agent/text-thread surfaces.
+- R4. Support Ollama, OpenAI-compatible API, GitHub Copilot, Codestral, Sweep, and Mercury.
+- R5. Hide the Zed-hosted provider in default-build UI.
+- R6. Preserve existing provider-specific auth/config flows.
+- R7. Treat stale `provider: "zed"` config as effectively unconfigured in the default build.
+- R8. Show automatic inline prediction in normal editor buffers when a supported provider is
+  configured.
+- R9. Expose the existing edit prediction entry in the default build.
+- R10. Preserve provider switching and setup entry points in the entry flow.
+- R11. Make the existing "Configure Providers" settings flow available in the default build.
+- R12. Keep the entry visible when no supported provider is configured.
+- R13. Limit v1 support to general code editor buffers.
+
+## Scope Boundaries
+
+- Do not support Zed-hosted/Zeta in the default build.
+- Do not add next-edit to agent text threads or arbitrary text inputs in v1.
+- Do not redesign the edit prediction UX; controlled upstream reuse is the goal.
+- Do not broaden the default build into the full `ai` surface if a narrower feature slice can
+  satisfy the requirements.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/zed/Cargo.toml` currently keeps edit prediction dependencies under the broad `ai`
+  feature, while default remains `lite + acp_tabs`.
+- `crates/zed/src/main.rs` and `crates/zed/src/zed.rs` gate edit prediction init and entry UI
+  behind `#[cfg(feature = "ai")]`.
+- `crates/settings_ui/Cargo.toml` also ties edit prediction setup UI to a broad `ai` feature,
+  but the provider page itself already exists in
+  `crates/settings_ui/src/pages/edit_prediction_provider_setup.rs`.
+- `crates/edit_prediction_ui/src/edit_prediction_button.rs` already contains most of the desired
+  v1 UX: status item rendering, provider switching, "Predict Edit at Cursor", and a
+  `Configure Providers` action that dispatches `OpenSettingsAt { path: "edit_predictions.providers" }`.
+- `crates/zed/src/visual_test_runner.rs` already expects `edit_predictions.providers` to resolve
+  to a single subpage link and auto-open in settings UI. That makes subpage restoration a
+  compatibility fix, not new product invention.
+- `crates/zed/src/zed/edit_prediction_registry.rs` already maps supported providers into runtime
+  delegates. It treats Sweep, Mercury, and OpenAI-compatible/FIM variants as part of the existing
+  edit-prediction runtime rather than as separate product surfaces.
+- `crates/edit_prediction_ui/src/edit_prediction_button.rs:get_available_providers` currently
+  always includes `EditPredictionProvider::Zed`, so default-build provider filtering needs to be
+  centralized there and in the registry.
+- `crates/language/src/language_settings.rs` already resolves a missing provider to
+  `EditPredictionProvider::None`, so "default off until configured" is consistent with current
+  runtime behavior.
+
+### Institutional Learnings
+
+- No `docs/solutions/` corpus is present in this repo, so the plan is grounded in current code and
+  existing docs/tests rather than prior solution notes.
+
+### External References
+
+- None. This is a repo-internal feature-slicing and UX restoration problem.
+
+## Key Technical Decisions
+
+- Introduce a narrower default-build feature slice for next-edit instead of enabling the entire
+  existing `ai` bundle.
+  Rationale: the current `ai` feature also brings back broader hosted/upstream AI surfaces that
+  violate the origin requirements.
+- Preserve `full` as the place where upstream Zed-hosted behavior can still exist.
+  Rationale: the default build and the heavier/debug build need different provider policy without
+  forking the codebase.
+- Normalize unsupported `EditPredictionProvider::Zed` to an effective "unconfigured" runtime state
+  in the default build rather than rewriting the user's settings file.
+  Rationale: this avoids destructive migration while keeping full/debug builds free to honor the
+  same settings file.
+- Reuse the existing edit prediction menu and provider setup page with build-aware filtering.
+  Rationale: the UX already exists and is closer to product intent than inventing a shell-specific
+  replacement.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the implementation maximize reuse or prioritize a bespoke lighter UX?
+  Resolution: maximize upstream reuse and carve a narrower feature slice underneath it.
+- How should stale `provider: "zed"` settings behave in the default build?
+  Resolution: treat them as unsupported/unconfigured at runtime and route the user back into setup.
+- Do Sweep and Mercury belong in the supported provider set?
+  Resolution: yes; they use their own provider/API-key flows and stay within the allowed scope.
+
+### Deferred to Implementation
+
+- What exact feature names best express the split between default-build next-edit and the broader
+  upstream `ai` surface?
+  Why deferred: this is a codebase fit-and-finish decision, but it must land as a narrow slice and
+  not as a broad `ai` re-enable.
+- Whether the settings provider page should be restored as a static `SubPageLink`, a dynamic
+  subpage, or both.
+  Why deferred: the existing code supports both patterns, and the cleanest choice depends on how
+  much of the prior settings wiring still exists.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+| Build / state    | Provider in settings       | Entry behavior                                      | Prediction runtime         |
+| ---------------- | -------------------------- | --------------------------------------------------- | -------------------------- |
+| Default build    | `none` or missing          | Visible footer entry; click opens provider setup    | Disabled                   |
+| Default build    | Supported non-Zed provider | Visible footer entry with provider-specific menu    | Enabled in editor buffers  |
+| Default build    | `zed`                      | Visible footer entry; treated like unconfigured     | Disabled                   |
+| Full/debug build | `zed`                      | Existing upstream behavior                          | Existing upstream behavior |
+
+## Implementation Units
+
+- [x] **Unit 1: Carve a default-build next-edit feature slice**
+
+**Goal:** Separate edit prediction from the broader `ai` feature so the default build can include
+next-edit without reopening unrelated hosted AI surfaces.
+
+**Requirements:** R1, R2, R3, R11
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `crates/zed/Cargo.toml`
+- Modify: `crates/settings_ui/Cargo.toml`
+- Modify: `crates/language_tools/Cargo.toml`
+- Modify: `crates/zed/src/main.rs`
+- Modify: `crates/zed/src/zed.rs`
+- Modify: `crates/settings_ui/src/components.rs`
+- Modify: `crates/settings_ui/src/pages.rs`
+- Test: `crates/zed/src/main.rs` (or the nearest existing app bootstrap coverage)
+- Test: `crates/zed/src/zed.rs`
+
+**Approach:**
+
+- Introduce a narrower feature slice in the app crate for default-build next-edit and make it part
+  of the default build.
+- Move edit-prediction-specific dependency gates from `ai` to that narrower slice where possible,
+  keeping `ai` reserved for hosted/upstream-heavy surfaces.
+- Split `settings_ui` gating so the edit prediction provider setup page and supporting components
+  can exist without pulling in unrelated AI-only settings surfaces such as tool permissions.
+- Re-gate startup init and edit prediction entry creation in `crates/zed/src/main.rs` and
+  `crates/zed/src/zed.rs` to the narrower feature instead of `ai`.
+
+**Patterns to follow:**
+
+- Existing `acp_tabs` vs `ai` feature split in `crates/zed/Cargo.toml`
+- Existing crate-local feature split in `crates/settings_ui/Cargo.toml`
+
+**Test scenarios:**
+
+- Happy path: the default app feature set includes the new next-edit slice and compiles with edit
+  prediction support available.
+- Edge case: enabling `full` still compiles and retains the heavier upstream AI surface.
+- Integration: the default build path initializes edit prediction without re-enabling unrelated
+  hosted AI or agent-panel setup code.
+
+**Verification:**
+
+- The default build can instantiate next-edit surfaces.
+- The `ai` feature remains a broader surface than the new default-build slice.
+
+- [x] **Unit 2: Restore provider policy and runtime assignment for the default build**
+
+**Goal:** Make supported providers work in the default build while hiding or neutralizing the
+Zed-hosted provider.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R13
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Modify: `crates/zed/src/zed/edit_prediction_registry.rs`
+- Modify: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Modify: `crates/settings_content/src/language.rs` or a nearby policy/helper location if needed
+- Test: `crates/zed/src/zed/edit_prediction_registry.rs`
+- Test: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+
+**Approach:**
+
+- Introduce a centralized build-aware provider policy helper so the registry and UI make the same
+  decision about which providers are supported in the default build.
+- In the default build, treat `EditPredictionProvider::Zed` as unsupported and normalize it to an
+  effective unconfigured state rather than assigning a runtime provider.
+- Preserve runtime delegate assignment for Copilot, Codestral, Ollama/OpenAI-compatible FIM,
+  Sweep, and Mercury.
+- Filter `get_available_providers` and any setup/provider lists so Zed-hosted never appears in the
+  default-build UI.
+- Keep full/debug builds free to preserve upstream Zed-provider behavior.
+
+**Patterns to follow:**
+
+- Existing provider assignment flow in `crates/zed/src/zed/edit_prediction_registry.rs`
+- Existing provider availability logic in `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Existing settings-change regression test style in `crates/zed/src/zed/edit_prediction_registry.rs`
+
+**Test scenarios:**
+
+- Happy path: selecting or configuring Codestral/Copilot/Ollama/OpenAI-compatible/Sweep/Mercury
+  in the default build results in an assigned edit prediction provider.
+- Edge case: `provider: "zed"` in user settings leaves the editor without a runtime provider in the
+  default build.
+- Edge case: provider lists used for switching/setup omit Zed in the default build but retain the
+  non-Zed supported providers.
+- Integration: changing settings from unsupported/no provider to a supported provider updates
+  existing editors without reopening windows.
+
+**Verification:**
+
+- Supported providers assign correctly in the default build.
+- Stale Zed-provider settings no longer strand the user in a broken hidden state.
+
+- [x] **Unit 3: Restore the footer entry and settings setup flow in the default build**
+
+**Goal:** Re-enable the edit prediction UX surface so users can discover, configure, and switch
+supported providers from the default build.
+
+**Requirements:** R2, R8, R9, R10, R11, R12
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+
+- Modify: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Modify: `crates/settings_ui/src/pages.rs`
+- Modify: `crates/settings_ui/src/page_data.rs`
+- Modify: `crates/settings_ui/src/settings_ui.rs`
+- Modify: `crates/settings_ui/src/pages/edit_prediction_provider_setup.rs`
+- Modify: `crates/zed/src/visual_test_runner.rs`
+- Test: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Test: `crates/zed/src/visual_test_runner.rs`
+- Test: `crates/settings_ui/src/settings_ui.rs`
+
+**Approach:**
+
+- Change the `EditPredictionProvider::None`/unsupported rendering path so the footer entry stays
+  visible and routes the user into provider setup instead of hiding entirely.
+- Reuse the existing menu structure for configured-provider states, including `Predict Edit at
+  Cursor`, mode toggles where they still apply, provider switching, and `Configure Providers`.
+- Restore or re-add the `edit_predictions.providers` settings subpage path so
+  `OpenSettingsAt { path: "edit_predictions.providers" }` works in the default build and aligns
+  with the existing visual test expectation.
+- Re-enable the provider setup page and its supporting renderers/components under the narrower
+  feature slice rather than the broad `ai` gate.
+- Keep Zed-hosted provider cards/choices out of the default-build settings/setup UX.
+
+**Patterns to follow:**
+
+- Existing status item and menu composition in `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Existing dynamic subpage pattern in `crates/settings_ui/src/pages/tool_permissions_setup.rs`
+- Existing `OpenSettingsAt` subpage auto-open path tested in `crates/zed/src/visual_test_runner.rs`
+
+**Test scenarios:**
+
+- Happy path: with no supported provider configured, the footer edit prediction entry remains
+  visible and opens provider setup.
+- Happy path: `OpenSettingsAt { path: "edit_predictions.providers" }` opens the provider setup
+  subpage in the default build.
+- Edge case: default-build provider setup UI excludes Zed-hosted while keeping the supported
+  provider cards/controls visible.
+- Integration: after configuring a supported provider, the same footer entry transitions from a
+  direct setup affordance to provider-oriented behavior without requiring a build-flavor change.
+
+**Verification:**
+
+- A fresh default-build user can discover next-edit from the footer entry and reach provider setup.
+- The restored setup path matches the current `superzent` shell UX instead of inventing a second,
+  unrelated discoverability surface.
+
+- [x] **Unit 4: Align docs and scope statements with the restored default-build surface**
+
+**Goal:** Update product and development docs so they no longer claim the default build excludes
+edit prediction.
+
+**Requirements:** R1, R3, R4, R5, R11
+
+**Dependencies:** Unit 1, Unit 2, Unit 3
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/src/development.md`
+- Modify: `docs/src/getting-started.md`
+- Modify: `docs/src/ai/edit-prediction.md`
+- Test: none -- documentation-only changes for this unit
+
+**Approach:**
+
+- Remove or refine statements that say the default build excludes edit prediction stacks.
+- Add superzent-specific guidance clarifying that the default build now supports next-edit with
+  non-Zed-hosted providers only.
+- Keep docs clear that this does not bring back Zed-hosted AI or the broader docked AI surface.
+
+**Patterns to follow:**
+
+- Existing scope/roadmap language in `README.md`
+- Existing build-flavor documentation in `docs/src/development.md`
+- Existing product-scope summary in `docs/src/getting-started.md`
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation-only unit, but the text should be internally consistent
+  with the implemented build surface and provider policy.
+
+**Verification:**
+
+- Docs no longer contradict the restored default-build next-edit behavior.
+- Docs clearly preserve the boundary that Zed-hosted AI remains out of scope for the default build.
+
+## System-Wide Impact
+
+- **Interaction graph:** build features now affect app bootstrap, footer/status entry composition, provider
+  registry assignment, settings UI subpage routing, and user-facing docs.
+- **Error propagation:** unsupported-provider states should degrade into visible setup affordances,
+  not hidden UI or silent no-op provider assignment.
+- **State lifecycle risks:** stale `provider: "zed"` settings are the main compatibility hazard in
+  the default build; runtime normalization must be consistent across registry and UI.
+- **API surface parity:** `full` builds must retain the broader upstream provider behavior even as
+  the default build narrows it.
+- **Integration coverage:** compile/build-flavor coverage plus UI/settings navigation coverage are
+  both necessary; unit tests alone will not prove the subpage path or status item behavior.
+- **Unchanged invariants:** the default build still excludes hosted AI, collab, and docked upstream
+  agent/text-thread surfaces.
+
+## Risks & Dependencies
+
+| Risk                                                                              | Mitigation                                                                                             |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| The narrow feature slice still drags in too much of `ai`                          | Audit dependencies crate-by-crate and split gates instead of reusing `ai` wholesale                    |
+| `provider: "zed"` remains selected and hides the feature                          | Normalize unsupported Zed provider to an unconfigured visible-setup state everywhere that matters      |
+| The provider setup page stays unreachable because the wiring is partially removed | Restore the `edit_predictions.providers` path explicitly and keep the visual test expectation in place |
+| Docs drift and still claim edit prediction is absent from the default build       | Ship explicit docs updates in the same change                                                          |
+
+## Documentation / Operational Notes
+
+- This feature changes user-visible default-build scope, so `README.md`,
+  `docs/src/development.md`, and `docs/src/getting-started.md` must be updated in the same work.
+- `docs/src/ai/edit-prediction.md` should gain a superzent-specific note about default-build
+  provider scope so users do not infer Zed-hosted support.
+- No special post-deploy monitoring is expected beyond normal regression testing because this is a
+  desktop feature-surface change rather than a server-side rollout.
+
+## Sources & References
+
+- Origin document: `docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md`
+- Related code: `crates/zed/Cargo.toml`
+- Related code: `crates/zed/src/main.rs`
+- Related code: `crates/zed/src/zed.rs`
+- Related code: `crates/zed/src/zed/edit_prediction_registry.rs`
+- Related code: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+- Related code: `crates/settings_ui/src/pages/edit_prediction_provider_setup.rs`
+- Related code: `crates/settings_ui/src/settings_ui.rs`
+- Related code: `crates/settings_ui/src/page_data.rs`
+- Related code: `crates/zed/src/visual_test_runner.rs`
+- Related docs: `README.md`
+- Related docs: `docs/src/development.md`
+- Related docs: `docs/src/getting-started.md`
+- Related docs: `docs/src/ai/edit-prediction.md`

--- a/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
+++ b/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
@@ -15,7 +15,16 @@ severity: high
 related_components:
   - assistant
   - documentation
-tags: [next-edit, edit-prediction, feature-gating, provider-policy, disable-ai, copilot-chat, footer-entry]
+tags:
+  [
+    next-edit,
+    edit-prediction,
+    feature-gating,
+    provider-policy,
+    disable-ai,
+    copilot-chat,
+    footer-entry,
+  ]
 ---
 
 # Restoring default-build next-edit requires separating it from hosted AI surfaces

--- a/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
+++ b/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
@@ -1,0 +1,155 @@
+---
+title: Restoring default-build next-edit requires separating it from hosted AI surfaces
+date: 2026-04-05
+category: integration-issues
+module: default-build next edit
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - Default `superzent` builds did not expose next-edit even though the runtime, provider setup page, and entry UI already existed in the repo
+  - Re-enabling next-edit through the broad `ai` feature also pulled hosted AI/chat surfaces back into the default build
+  - Provider setup and switching behavior diverged because some call sites treated provider lists as "supported by this build" while others treated them as "ready to use right now"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - assistant
+  - documentation
+tags: [next-edit, edit-prediction, feature-gating, provider-policy, disable-ai, copilot-chat, footer-entry]
+---
+
+# Restoring default-build next-edit requires separating it from hosted AI surfaces
+
+## Problem
+
+`superzent` wanted default-build next-edit in ordinary editor buffers, but the inherited upstream wiring coupled edit prediction to the broader `ai` surface. Turning next-edit back on naïvely either kept it hidden or reopened hosted AI/chat behavior that the default build is explicitly trying to avoid.
+
+## Symptoms
+
+- The default build compiled without a visible next-edit affordance even though edit prediction UI and provider setup code already existed.
+- Treating `EditPredictionProvider::Zed` as the default left users in a hidden or broken state when the default build was not supposed to expose Zed-hosted prediction.
+- Moving too much under the new slice accidentally reintroduced `copilot_chat` initialization and language-model provider registration in the default build.
+- Provider selection UX regressed when one helper started meaning "supported by this build" instead of "available to switch to right now."
+
+## What Didn't Work
+
+- Reusing the upstream `ai` feature wholesale was too broad. It brought hosted AI/chat behavior back with next-edit.
+- Leaving the default upstream provider alone (`provider: "zed"`) made the default build look unconfigured or invisible in the wrong ways instead of guiding users into setup.
+- Using one provider helper for both setup and runtime switching caused UX drift:
+  - Setup wants the full supported list.
+  - Runtime switching wants providers that are actually ready now.
+- Keeping the entry on the hidden global status bar made the feature effectively undiscoverable in the current `superzent` shell.
+
+## Solution
+
+Split next-edit into its own default-build feature slice and then separate three concerns that had been coupled together: hosted AI/chat boot, provider support policy, and provider readiness.
+
+1. Add a narrow `next_edit` feature to the app crate and make it part of the default build:
+
+```toml
+[features]
+default = ["lite", "acp_tabs", "next_edit"]
+
+next_edit = [
+  "dep:codestral",
+  "dep:copilot",
+  "dep:copilot_chat",
+  "dep:edit_prediction",
+  "dep:edit_prediction_ui",
+  "language_tools/edit-prediction",
+  "settings_ui/edit_prediction",
+]
+
+ai = [
+  "next_edit",
+  "acp_tabs",
+  "dep:agent-client-protocol",
+  "dep:agent_settings",
+  "edit_prediction_ui/zed-hosted-provider",
+  "git_ui/ai",
+  "settings_ui/ai",
+  "terminal_view/assistant",
+]
+```
+
+2. Centralize default-build provider policy so stale `provider: "zed"` becomes an effective `None` state outside full builds:
+
+```rust
+pub fn normalize_edit_prediction_provider(
+    provider: EditPredictionProvider,
+) -> EditPredictionProvider {
+    if edit_prediction_provider_supported(provider) {
+        provider
+    } else {
+        EditPredictionProvider::None
+    }
+}
+```
+
+3. Keep hosted chat/model surfaces out of the default build even when Copilot is still a valid next-edit provider:
+
+```rust
+#[cfg(feature = "ai")]
+{
+    copilot_chat::init(..., cx);
+}
+
+#[cfg(feature = "next_edit")]
+{
+    edit_prediction_registry::init(..., cx);
+}
+```
+
+And only register the Copilot Chat language-model provider when `CopilotChat` actually exists:
+
+```rust
+if copilot_chat::CopilotChat::global(cx).is_some() {
+    registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+}
+```
+
+4. Split provider helpers by purpose:
+
+- `supported_edit_prediction_providers()` for setup UI
+- `get_available_providers()` for runtime switching menu
+
+5. Put the discoverability entry where the current `superzent` shell actually shows it: the center-pane footer. For the no-provider state, clicking the icon goes directly to `edit_predictions.providers`.
+
+6. Keep next-edit working even when `disable_ai` is being used to suppress hosted AI/chat surfaces. In `superzent`, next-edit is treated as a narrower exception capability rather than as part of the full hosted AI product surface.
+
+7. Add an explicit `Off` label for `EditPredictionProvider::None` so setup UI can show a first-class disabled state instead of silently omitting it.
+
+## Why This Works
+
+The real problem was not "next-edit is missing." It was that multiple layers had been coupled in ways that were safe upstream but wrong for `superzent`'s default shell:
+
+- build feature gating
+- provider policy
+- provider readiness
+- hosted chat/model boot
+- entry discoverability
+
+The fix works because each layer now has a narrower contract:
+
+- `next_edit` turns on edit prediction without implying hosted AI/chat.
+- Unsupported hosted providers normalize to `None` instead of leaving hidden dead states behind.
+- Setup uses the supported provider list; runtime switching uses the currently ready list.
+- Default builds no longer initialize Copilot Chat just because Copilot is allowed for next-edit.
+- Users can always find the feature from the footer entry and reach setup directly.
+
+## Prevention
+
+- Keep "supported by this build" and "usable right now" as separate helpers. Do not reuse one provider list for both setup and runtime menus.
+- If a feature slice is supposed to exclude hosted AI/chat surfaces, audit boot code and provider registration, not just Cargo features.
+- Add targeted regression coverage for:
+  - default build does not initialize hosted chat/model surfaces
+  - stale `provider: "zed"` normalizes to an unconfigured next-edit state
+  - `disable_ai` policy still does what the product intends after any exception is introduced
+  - the user-visible entry surface matches the actual shell surface (`footer` vs hidden status bar)
+- When documentation or plan language drifts from implementation, fix the contract quickly. "Status bar" vs "footer entry" sounds cosmetic, but it changes discoverability and review outcomes.
+
+## Related Issues
+
+- Related requirements: `docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md`
+- Related plan: `docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md`
+- Related solution with low overlap: `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`

--- a/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
+++ b/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md
@@ -1,6 +1,7 @@
 ---
 title: Restoring default-build next-edit requires separating it from hosted AI surfaces
 date: 2026-04-05
+last_updated: 2026-04-05
 category: integration-issues
 module: default-build next edit
 problem_type: integration_issue
@@ -9,6 +10,7 @@ symptoms:
   - Default `superzent` builds did not expose next-edit even though the runtime, provider setup page, and entry UI already existed in the repo
   - Re-enabling next-edit through the broad `ai` feature also pulled hosted AI/chat surfaces back into the default build
   - Provider setup and switching behavior diverged because some call sites treated provider lists as "supported by this build" while others treated them as "ready to use right now"
+  - Gating `CopilotChat` provider registration on `CopilotChat::global(cx)` during startup broke full `ai` builds because `language_models::init()` runs before `copilot_chat::init()`
 root_cause: logic_error
 resolution_type: code_fix
 severity: high
@@ -47,6 +49,7 @@ tags:
 - Using one provider helper for both setup and runtime switching caused UX drift:
   - Setup wants the full supported list.
   - Runtime switching wants providers that are actually ready now.
+- Guarding `CopilotChat` provider registration on `CopilotChat::global(cx)` inside `language_models::init()` looked like an easy way to keep chat models out of the default build, but it made provider registration depend on startup order and removed Copilot Chat models from full builds too.
 - Keeping the entry on the hidden global status bar made the feature effectively undiscoverable in the current `superzent` shell.
 
 ## Solution
@@ -95,12 +98,13 @@ pub fn normalize_edit_prediction_provider(
 }
 ```
 
-3. Keep hosted chat/model surfaces out of the default build even when Copilot is still a valid next-edit provider:
+3. Keep hosted chat/model surfaces out of the default build while preserving them in full builds by separating chat boot from provider registration:
 
 ```rust
 #[cfg(feature = "ai")]
 {
     copilot_chat::init(..., cx);
+    language_models::register_copilot_chat_provider(cx);
 }
 
 #[cfg(feature = "next_edit")]
@@ -109,11 +113,18 @@ pub fn normalize_edit_prediction_provider(
 }
 ```
 
-And only register the Copilot Chat language-model provider when `CopilotChat` actually exists:
+Inside `language_models`, use an explicit registration hook instead of an order-sensitive `CopilotChat::global(cx)` guard during base provider init:
 
 ```rust
-if copilot_chat::CopilotChat::global(cx).is_some() {
-    registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+pub fn register_copilot_chat_provider(cx: &mut App) {
+    let registry = LanguageModelRegistry::global(cx);
+    registry.update(cx, |registry, cx| {
+        registry.unregister_provider(
+            LanguageModelProviderId::from("copilot_chat".to_string()),
+            cx,
+        );
+        registry.register_provider(Arc::new(CopilotChatLanguageModelProvider::new(cx)), cx);
+    });
 }
 ```
 
@@ -144,14 +155,17 @@ The fix works because each layer now has a narrower contract:
 - Unsupported hosted providers normalize to `None` instead of leaving hidden dead states behind.
 - Setup uses the supported provider list; runtime switching uses the currently ready list.
 - Default builds no longer initialize Copilot Chat just because Copilot is allowed for next-edit.
+- Full builds still recover Copilot Chat models because provider registration happens explicitly after `copilot_chat::init()`, not opportunistically during earlier startup.
 - Users can always find the feature from the footer entry and reach setup directly.
 
 ## Prevention
 
 - Keep "supported by this build" and "usable right now" as separate helpers. Do not reuse one provider list for both setup and runtime menus.
 - If a feature slice is supposed to exclude hosted AI/chat surfaces, audit boot code and provider registration, not just Cargo features.
+- Avoid order-sensitive global-presence guards during startup. If a provider depends on a later init step, expose an explicit `register_*` hook and call it after the dependency is initialized.
 - Add targeted regression coverage for:
   - default build does not initialize hosted chat/model surfaces
+  - full builds still register Copilot Chat providers after `copilot_chat::init()`
   - stale `provider: "zed"` normalizes to an unconfigured next-edit state
   - `disable_ai` policy still does what the product intends after any exception is introduced
   - the user-visible entry surface matches the actual shell surface (`footer` vs hidden status bar)

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -8,9 +8,13 @@ description: Set up AI code completions in Zed with Zeta (built-in), GitHub Copi
 Edit Prediction is how Zed's AI code completions work: an LLM predicts the code you want to write.
 Each keystroke sends a new request to the edit prediction provider, which returns individual or multi-line suggestions that can be quickly accepted by pressing `tab`.
 
-The default provider is [Zeta, a proprietary open source and open dataset model](https://huggingface.co/zed-industries/zeta), but you can also use [other providers](#other-providers) like GitHub Copilot, Sweep, Mercury Coder, and Codestral.
+In upstream Zed, the default provider is [Zeta, a proprietary open source and open dataset model](https://huggingface.co/zed-industries/zeta). In `superzent`'s default build, edit prediction is available in regular editor buffers through non-Zed-hosted providers only: GitHub Copilot, Codestral, Ollama, OpenAI-compatible API, Sweep, and Mercury. Zed-hosted Zeta remains out of the default build and is only available when you explicitly build the broader upstream-like surface with `--features full`.
+
+In the default `superzent` shell, the edit prediction control lives in the center-pane footer. When no provider is configured yet, clicking the footer icon opens provider setup directly. After a provider is configured, the same footer entry exposes the provider-specific menu and switching flow.
 
 ## Configuring Zeta
+
+`superzent` note: this section applies to `--features full` builds. The default `superzent` build hides the Zed-hosted provider and routes you through the non-Zed-hosted setup flow instead.
 
 To use Zeta, [sign in](../authentication.md#what-features-require-signing-in).
 Once signed in, predictions appear as you type.
@@ -311,7 +315,7 @@ To use GitHub Copilot as your provider, set this in your settings file ([how to 
 }
 ```
 
-To sign in to GitHub Copilot, click on the Copilot icon in the status bar. A popup window appears displaying a device code. Click the copy button to copy the code, then click "Connect to GitHub" to open the GitHub verification page in your browser. Paste the code when prompted. The popup window closes automatically after successful authorization.
+To sign in to GitHub Copilot in `superzent`, click the edit prediction icon in the center-pane footer, choose GitHub Copilot, then follow the device-code prompt. Click the copy button to copy the code, then click "Connect to GitHub" to open the GitHub verification page in your browser. Paste the code when prompted. The popup window closes automatically after successful authorization.
 
 #### Using GitHub Copilot Enterprise
 
@@ -330,7 +334,7 @@ If your organization uses GitHub Copilot Enterprise, you can configure Zed to us
 Replace `"https://your.enterprise.domain"` with the URL provided by your GitHub Enterprise administrator (e.g., `https://foo.ghe.com`).
 
 Once set, Zed will route Copilot requests through your enterprise endpoint.
-When you sign in by clicking the Copilot icon in the status bar, you will be redirected to your configured enterprise URL to complete authentication.
+When you sign in from the edit prediction footer entry, you will be redirected to your configured enterprise URL to complete authentication.
 All other Copilot features and usage remain the same.
 
 Copilot can provide multiple completion alternatives, and these can be navigated with the following actions:
@@ -347,10 +351,9 @@ To use [Sweep](https://sweep.dev/) as your provider:
 3. Find the Sweep section and enter your API key from the
    [Sweep dashboard](https://app.sweep.dev/)
 
-Alternatively, click the edit prediction icon in the status bar and select
-**Configure Providers** from the menu.
+Alternatively, if no provider is configured yet, click the edit prediction icon in the center-pane footer to open provider setup directly.
 
-After adding your API key, Sweep will appear in the provider dropdown in the status bar menu, where you can select it. You can also set it directly in your settings file:
+After adding your API key, Sweep will appear in the provider dropdown for the edit prediction footer entry, where you can select it. You can also set it directly in your settings file:
 
 ```json [settings]
 {
@@ -369,10 +372,9 @@ To use [Mercury Coder](https://www.inceptionlabs.ai/) by Inception Labs as your 
 3. Find the Mercury section and enter your API key from the
    [Inception Labs dashboard](https://platform.inceptionlabs.ai/dashboard/api-keys)
 
-Alternatively, click the edit prediction icon in the status bar and select
-**Configure Providers** from the menu.
+Alternatively, if no provider is configured yet, click the edit prediction icon in the center-pane footer to open provider setup directly.
 
-After adding your API key, Mercury Coder will appear in the provider dropdown in the status bar menu, where you can select it. You can also set it directly in your settings file:
+After adding your API key, Mercury Coder will appear in the provider dropdown for the edit prediction footer entry, where you can select it. You can also set it directly in your settings file:
 
 ```json [settings]
 {
@@ -391,10 +393,9 @@ To use Mistral's Codestral as your provider:
 3. Find the Codestral section and enter your API key from the
    [Codestral dashboard](https://console.mistral.ai/codestral)
 
-Alternatively, click the edit prediction icon in the status bar and select
-**Configure Providers** from the menu.
+Alternatively, if no provider is configured yet, click the edit prediction icon in the center-pane footer to open provider setup directly.
 
-After adding your API key, Codestral will appear in the provider dropdown in the status bar menu, where you can select it. You can also set it directly in your settings file:
+After adding your API key, Codestral will appear in the provider dropdown for the edit prediction footer entry, where you can select it. You can also set it directly in your settings file:
 
 ```json [settings]
 {

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -39,16 +39,18 @@ cargo check -p superzent --features full
 
 ## Release Flavors
 
-The default app build is `lite`.
+The default app build is `lite + acp_tabs + next_edit`.
 
 That excludes:
 
 - collab
 - calls / WebRTC
 - inherited agent panel and text-thread UI
-- hosted AI and edit prediction stacks
+- Zed-hosted AI surfaces
 
 `--features full` is still available for debugging inherited upstream behavior.
+
+The default build now includes next-edit in regular editor buffers, but only through the non-Zed-hosted provider paths that already exist in the repo: GitHub Copilot, Codestral, Ollama, OpenAI-compatible API, Sweep, and Mercury.
 
 ## Validation Paths
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -50,6 +50,7 @@ The default build is intentionally narrow:
 - local repositories and worktrees
 - native editor, panes, and diffs
 - terminal-driven agent workflows
+- center-pane footer next-edit in regular editor buffers via non-Zed-hosted providers
 
 Not part of the current public shell surface:
 


### PR DESCRIPTION
Carve next-edit out of the broader AI surface so the default superzent build can use non-Zed-hosted edit prediction without reopening hosted chat flows.

Normalize unsupported Zed-hosted provider state, restore provider setup and switching paths, align the footer entry behavior, and document the integration details in docs/solutions/.

Closes #ISSUE

Before marking this PR ready for review, make sure that you have:
- [ ] Added tests or clear manual verification notes
- [ ] Done a self-review for regressions, security, and release-facing behavior
- [ ] Updated docs or templates if the change affects installation, updates, release flow, or OSS contribution workflow
- [ ] Checked the current guidance in [CONTRIBUTING.md](https://github.com/currybab/superzent/blob/main/CONTRIBUTING.md)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
