### PR TITLE
Add managed workspace lifecycle flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16934,6 +16934,7 @@ dependencies = [
  "gpui",
  "log",
  "menu",
+ "notifications",
  "objc",
  "project",
  "project_panel",

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -696,19 +696,33 @@ fn maybe_apply_superzent_shell_override(shell: Shell, env: &mut HashMap<String, 
     shell
 }
 
+fn superzent_zsh_override_dir() -> PathBuf {
+    paths::data_dir().join("agent-hooks").join("shell").join("zsh")
+}
+
+fn is_superzent_zsh_override_dir(path: &str) -> bool {
+    let candidate = Path::new(path);
+    let override_dir = superzent_zsh_override_dir();
+
+    candidate == override_dir
+        || candidate.canonicalize().ok().as_deref() == Some(override_dir.as_path())
+        || candidate.canonicalize().ok().as_deref() == override_dir.canonicalize().ok().as_deref()
+}
+
 fn resolve_original_zdotdir(env: &HashMap<String, String>) -> Option<String> {
-    env.get("ZDOTDIR")
+    env.get("SUPERZENT_ORIGINAL_ZDOTDIR")
         .cloned()
-        .or_else(|| std::env::var("ZDOTDIR").ok())
+        .or_else(|| {
+            env.get("ZDOTDIR")
+                .cloned()
+                .filter(|path| !is_superzent_zsh_override_dir(path))
+        })
         .or_else(|| env.get("HOME").cloned())
         .or_else(|| std::env::var("HOME").ok())
 }
 
 fn ensure_superzent_zsh_override_dir() -> Result<PathBuf> {
-    let override_dir = paths::data_dir()
-        .join("agent-hooks")
-        .join("shell")
-        .join("zsh");
+    let override_dir = superzent_zsh_override_dir();
     fs::create_dir_all(&override_dir)?;
     fs::write(override_dir.join(".zshenv"), superzent_zshenv_content())?;
     fs::write(override_dir.join(".zprofile"), superzent_zprofile_content())?;
@@ -718,7 +732,12 @@ fn ensure_superzent_zsh_override_dir() -> Result<PathBuf> {
 }
 
 fn superzent_zshenv_content() -> &'static str {
-    r#"if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
+    r#"if [ -n "$SUPERZENT_ZSHENV_GUARD" ]; then
+  return 0 2>/dev/null || true
+fi
+export SUPERZENT_ZSHENV_GUARD=1
+
+if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
   _superzent_original_zdotdir="$SUPERZENT_ORIGINAL_ZDOTDIR"
 else
   _superzent_original_zdotdir="$HOME"
@@ -732,11 +751,17 @@ if [ -f "$_superzent_original_zdotdir/.zshenv" ]; then
 fi
 
 export ZDOTDIR="$_superzent_override_zdotdir"
+unset SUPERZENT_ZSHENV_GUARD
 "#
 }
 
 fn superzent_zshrc_content() -> &'static str {
-    r#"if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
+    r#"if [ -n "$SUPERZENT_ZSHRC_GUARD" ]; then
+  return 0 2>/dev/null || true
+fi
+export SUPERZENT_ZSHRC_GUARD=1
+
+if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
   _superzent_original_zdotdir="$SUPERZENT_ORIGINAL_ZDOTDIR"
 else
   _superzent_original_zdotdir="$HOME"
@@ -756,11 +781,17 @@ if [ -n "$SUPERZENT_AGENT_HOOK_BIN_DIR" ]; then
   path=("$SUPERZENT_AGENT_HOOK_BIN_DIR" $path)
   rehash >/dev/null 2>&1 || true
 fi
+unset SUPERZENT_ZSHRC_GUARD
 "#
 }
 
 fn superzent_zprofile_content() -> &'static str {
-    r#"if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
+    r#"if [ -n "$SUPERZENT_ZPROFILE_GUARD" ]; then
+  return 0 2>/dev/null || true
+fi
+export SUPERZENT_ZPROFILE_GUARD=1
+
+if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
   _superzent_original_zdotdir="$SUPERZENT_ORIGINAL_ZDOTDIR"
 else
   _superzent_original_zdotdir="$HOME"
@@ -780,11 +811,17 @@ if [ -f "$_superzent_original_zdotdir/.zprofile" ]; then
 fi
 
 export ZDOTDIR="$_superzent_override_zdotdir"
+unset SUPERZENT_ZPROFILE_GUARD
 "#
 }
 
 fn superzent_zlogin_content() -> &'static str {
-    r#"if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
+    r#"if [ -n "$SUPERZENT_ZLOGIN_GUARD" ]; then
+  return 0 2>/dev/null || true
+fi
+export SUPERZENT_ZLOGIN_GUARD=1
+
+if [ -n "$SUPERZENT_ORIGINAL_ZDOTDIR" ]; then
   _superzent_original_zdotdir="$SUPERZENT_ORIGINAL_ZDOTDIR"
 else
   _superzent_original_zdotdir="$HOME"
@@ -804,6 +841,7 @@ if [ -n "$SUPERZENT_AGENT_HOOK_BIN_DIR" ]; then
   path=("$SUPERZENT_AGENT_HOOK_BIN_DIR" $path)
   rehash >/dev/null 2>&1 || true
 fi
+unset SUPERZENT_ZLOGIN_GUARD
 "#
 }
 
@@ -885,6 +923,54 @@ mod tests {
             resolve_original_zdotdir(&env).as_deref(),
             Some("/tmp/custom-home")
         );
+    }
+
+    #[test]
+    fn shell_override_prefers_original_zdotdir_env() {
+        let mut env = HashMap::default();
+        env.insert(
+            "SUPERZENT_ORIGINAL_ZDOTDIR".to_string(),
+            "/tmp/original-zdotdir".to_string(),
+        );
+        env.insert(
+            "ZDOTDIR".to_string(),
+            superzent_zsh_override_dir().to_string_lossy().to_string(),
+        );
+        env.insert("HOME".to_string(), "/tmp/custom-home".to_string());
+
+        assert_eq!(
+            resolve_original_zdotdir(&env).as_deref(),
+            Some("/tmp/original-zdotdir")
+        );
+    }
+
+    #[test]
+    fn shell_override_ignores_superzent_override_dir_when_resolving_original_zdotdir() {
+        let mut env = HashMap::default();
+        env.insert(
+            "ZDOTDIR".to_string(),
+            superzent_zsh_override_dir().to_string_lossy().to_string(),
+        );
+        env.insert("HOME".to_string(), "/tmp/custom-home".to_string());
+
+        assert_eq!(
+            resolve_original_zdotdir(&env).as_deref(),
+            Some("/tmp/custom-home")
+        );
+    }
+
+    #[test]
+    fn zsh_startup_scripts_include_reentry_guards() {
+        for (guard, script) in [
+            ("SUPERZENT_ZSHENV_GUARD", superzent_zshenv_content()),
+            ("SUPERZENT_ZPROFILE_GUARD", superzent_zprofile_content()),
+            ("SUPERZENT_ZSHRC_GUARD", superzent_zshrc_content()),
+            ("SUPERZENT_ZLOGIN_GUARD", superzent_zlogin_content()),
+        ] {
+            assert!(script.contains(guard));
+            assert!(script.contains("return 0 2>/dev/null || true"));
+            assert!(script.contains(&format!("unset {guard}")));
+        }
     }
 }
 

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -697,7 +697,10 @@ fn maybe_apply_superzent_shell_override(shell: Shell, env: &mut HashMap<String, 
 }
 
 fn superzent_zsh_override_dir() -> PathBuf {
-    paths::data_dir().join("agent-hooks").join("shell").join("zsh")
+    paths::data_dir()
+        .join("agent-hooks")
+        .join("shell")
+        .join("zsh")
 }
 
 fn is_superzent_zsh_override_dir(path: &str) -> bool {

--- a/crates/superzent_agent/src/runtime.rs
+++ b/crates/superzent_agent/src/runtime.rs
@@ -798,6 +798,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            teardown_script_override: None,
             created_at: Default::default(),
             last_opened_at: Default::default(),
         };
@@ -837,6 +838,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            teardown_script_override: None,
             created_at: Default::default(),
             last_opened_at: Default::default(),
         };

--- a/crates/superzent_git/src/lib.rs
+++ b/crates/superzent_git/src/lib.rs
@@ -38,7 +38,7 @@ pub struct WorkspaceLifecycleDefaults {
     pub teardown_script: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkspaceLifecycleFailure {
     pub phase: WorkspaceLifecyclePhase,
     pub command: String,
@@ -84,6 +84,13 @@ pub enum WorkspaceDeleteOutcome {
     BlockedByTeardown(WorkspaceLifecycleFailure),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkspaceDeleteResolution {
+    RunTeardownScript { script: String },
+    SkipTeardown,
+    BlockedByConfig(WorkspaceLifecycleFailure),
+}
+
 #[derive(Debug)]
 pub struct WorkspaceRefresh {
     pub branch: String,
@@ -114,7 +121,7 @@ pub struct CreateWorkspaceOptions {
     pub base_workspace_path: Option<PathBuf>,
     pub setup_script: Option<String>,
     pub teardown_script: Option<String>,
-    pub persist_lifecycle_scripts: bool,
+    pub save_teardown_script_as_repo_default: bool,
     pub allow_dirty: bool,
 }
 
@@ -174,7 +181,7 @@ pub fn register_project(repo_hint: &Path, preset_id: &str) -> Result<ProjectRegi
         attention_status: WorkspaceAttentionStatus::Idle,
         review_pending: false,
         last_attention_reason: None,
-        lifecycle_teardown_script: None,
+        teardown_script_override: None,
         created_at: now,
         last_opened_at: now,
     };
@@ -238,9 +245,8 @@ fn create_workspace_internal(
     let configured_teardown_script = normalize_command(options.teardown_script.as_deref());
     let config = prepare_superzent_config_for_create(
         &repo_root,
-        configured_setup_script.clone(),
         configured_teardown_script.clone(),
-        options.persist_lifecycle_scripts,
+        options.save_teardown_script_as_repo_default,
     )?;
     let base_branch_resolution = resolve_workspace_base_branch_for_repo(
         &repo_root,
@@ -272,9 +278,7 @@ fn create_workspace_internal(
             &base_branch_resolution.effective_base_branch,
         ],
     )?;
-    let should_persist_lifecycle_scripts = options.persist_lifecycle_scripts
-        && (configured_setup_script.is_some() || configured_teardown_script.is_some());
-    if should_persist_lifecycle_scripts {
+    if options.save_teardown_script_as_repo_default {
         if let Err(error) = write_superzent_config(&repo_root, &config) {
             cleanup_created_worktree(&repo_root, &worktree_path, &branch_name);
             return Err(error);
@@ -305,6 +309,11 @@ fn create_workspace_internal(
         git_status: WorkspaceGitStatus::Available,
         git_summary: None,
     });
+    let teardown_script_override = workspace_teardown_script_override_for_create(
+        &config,
+        configured_teardown_script.as_deref(),
+        options.save_teardown_script_as_repo_default,
+    );
 
     Ok(WorkspaceCreateOutcome {
         workspace: WorkspaceEntry {
@@ -325,11 +334,7 @@ fn create_workspace_internal(
                 .as_ref()
                 .map(WorkspaceLifecycleFailure::summary)
                 .or_else(|| base_branch_resolution.notice.clone()),
-            lifecycle_teardown_script: if options.persist_lifecycle_scripts {
-                None
-            } else {
-                configured_teardown_script
-            },
+            teardown_script_override,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         },
@@ -397,6 +402,49 @@ pub fn delete_workspace(
     repo_root: &Path,
     force: bool,
 ) -> Result<WorkspaceDeleteOutcome> {
+    delete_workspace_with_resolution(workspace, repo_root, force, None)
+}
+
+pub fn resolve_workspace_delete_resolution(
+    workspace: &WorkspaceEntry,
+    repo_root: &Path,
+) -> Result<WorkspaceDeleteResolution> {
+    if !workspace.managed || workspace.kind == WorkspaceKind::Primary {
+        return Ok(WorkspaceDeleteResolution::SkipTeardown);
+    }
+
+    if let Some(teardown_script_override) = workspace.teardown_script_override.as_ref() {
+        return Ok(WorkspaceDeleteResolution::RunTeardownScript {
+            script: teardown_script_override.clone(),
+        });
+    }
+
+    let config = match load_superzent_config(repo_root) {
+        Ok(config) => config,
+        Err(error) => {
+            return Ok(WorkspaceDeleteResolution::BlockedByConfig(
+                workspace_lifecycle_failure_from_error(
+                    WorkspaceLifecyclePhase::Teardown,
+                    "load .superzent/config.json",
+                    error,
+                ),
+            ));
+        }
+    };
+
+    if let Some(script) = commands_to_script(&config.teardown) {
+        Ok(WorkspaceDeleteResolution::RunTeardownScript { script })
+    } else {
+        Ok(WorkspaceDeleteResolution::SkipTeardown)
+    }
+}
+
+pub fn delete_workspace_with_resolution(
+    workspace: &WorkspaceEntry,
+    repo_root: &Path,
+    force: bool,
+    delete_resolution: Option<&WorkspaceDeleteResolution>,
+) -> Result<WorkspaceDeleteOutcome> {
     if !workspace.managed || workspace.kind == WorkspaceKind::Primary {
         return Ok(WorkspaceDeleteOutcome::Deleted);
     }
@@ -408,38 +456,28 @@ pub fn delete_workspace(
     }
 
     if !force {
-        let config = match load_superzent_config(repo_root) {
-            Ok(config) => config,
-            Err(error) if workspace.lifecycle_teardown_script.is_some() => {
-                log::warn!(
-                    "failed to load lifecycle config during delete; using cached teardown script: {error:#}"
-                );
-                SuperzentConfig::default()
-            }
-            Err(error) => {
-                return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(
-                    workspace_lifecycle_failure_from_error(
-                        WorkspaceLifecyclePhase::Teardown,
-                        "load .superzent/config.json",
-                        error,
-                    ),
-                ));
-            }
+        let delete_resolution = match delete_resolution.cloned() {
+            Some(delete_resolution) => delete_resolution,
+            None => resolve_workspace_delete_resolution(workspace, repo_root)?,
         };
-        let teardown_commands = lifecycle_commands(
-            &config,
-            workspace.lifecycle_teardown_script.as_deref(),
-            WorkspaceLifecyclePhase::Teardown,
-        );
-        if let Err(failure) = run_lifecycle_commands(
-            &teardown_commands,
-            repo_root,
-            worktree_path,
-            None,
-            &workspace.name,
-            WorkspaceLifecyclePhase::Teardown,
-        ) {
-            return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(failure));
+        match delete_resolution {
+            WorkspaceDeleteResolution::RunTeardownScript { script } => {
+                let teardown_commands = split_commands(&script);
+                if let Err(failure) = run_lifecycle_commands(
+                    &teardown_commands,
+                    repo_root,
+                    worktree_path,
+                    None,
+                    &workspace.name,
+                    WorkspaceLifecyclePhase::Teardown,
+                ) {
+                    return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(failure));
+                }
+            }
+            WorkspaceDeleteResolution::SkipTeardown => {}
+            WorkspaceDeleteResolution::BlockedByConfig(failure) => {
+                return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(failure));
+            }
         }
     }
 
@@ -704,6 +742,10 @@ fn normalize_command(command: Option<&str>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn commands_to_script(commands: &[String]) -> Option<String> {
+    (!commands.is_empty()).then(|| commands.join("\n"))
+}
+
 fn split_commands(command_text: &str) -> Vec<String> {
     command_text
         .lines()
@@ -954,20 +996,36 @@ fn run_lifecycle_commands(
 
 fn prepare_superzent_config_for_create(
     repo_root: &Path,
-    setup_script: Option<String>,
     teardown_script: Option<String>,
-    persist_lifecycle_scripts: bool,
+    save_teardown_script_as_repo_default: bool,
 ) -> Result<SuperzentConfig> {
     let mut config = load_superzent_config(repo_root)?;
-    if persist_lifecycle_scripts {
-        if let Some(setup_script) = setup_script {
-            config.setup = split_commands(&setup_script);
-        }
-        if let Some(teardown_script) = teardown_script {
-            config.teardown = split_commands(&teardown_script);
-        }
+    if save_teardown_script_as_repo_default {
+        config.teardown = teardown_script
+            .as_deref()
+            .map(split_commands)
+            .unwrap_or_default();
     }
     Ok(config)
+}
+
+fn workspace_teardown_script_override_for_create(
+    config: &SuperzentConfig,
+    teardown_script: Option<&str>,
+    save_teardown_script_as_repo_default: bool,
+) -> Option<String> {
+    if save_teardown_script_as_repo_default {
+        return None;
+    }
+
+    let teardown_script = normalize_command(teardown_script);
+    let repo_default_teardown_script = commands_to_script(&config.teardown);
+
+    if teardown_script == repo_default_teardown_script {
+        None
+    } else {
+        teardown_script
+    }
 }
 
 fn load_superzent_config(repo_root: &Path) -> Result<SuperzentConfig> {
@@ -1112,7 +1170,7 @@ mod tests {
             base_workspace_path: None,
             setup_script: None,
             teardown_script: None,
-            persist_lifecycle_scripts: false,
+            save_teardown_script_as_repo_default: false,
             allow_dirty: false,
         }
     }
@@ -1181,7 +1239,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: true,
             },
         )
@@ -1228,7 +1286,7 @@ mod tests {
                 base_workspace_path: Some(secondary_worktree_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: false,
             },
         )
@@ -1252,21 +1310,23 @@ mod tests {
     }
 
     #[test]
-    fn prepare_superzent_config_for_create_splits_multiline_scripts() {
+    fn prepare_superzent_config_for_create_updates_only_repo_default_teardown() {
         let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"setup":["echo keep setup"]}"#,
+        )
+        .unwrap();
 
         let config = prepare_superzent_config_for_create(
             &repo.repo_path,
-            Some("echo one\necho two".to_string()),
             Some("cargo clean\ncargo test".to_string()),
             true,
         )
         .unwrap();
 
-        assert_eq!(
-            config.setup,
-            vec!["echo one".to_string(), "echo two".to_string()]
-        );
+        assert_eq!(config.setup, vec!["echo keep setup".to_string()]);
         assert_eq!(
             config.teardown,
             vec!["cargo clean".to_string(), "cargo test".to_string()]
@@ -1274,7 +1334,7 @@ mod tests {
     }
 
     #[test]
-    fn create_workspace_persists_lifecycle_scripts_when_requested() {
+    fn create_workspace_saves_repo_default_teardown_without_persisting_setup_script() {
         let repo = init_repo();
         let registration = register_project(&repo.repo_path, "codex").unwrap();
         let outcome = create_workspace(
@@ -1286,22 +1346,102 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup one\necho setup two".to_string()),
                 teardown_script: Some("echo teardown".to_string()),
-                persist_lifecycle_scripts: true,
+                save_teardown_script_as_repo_default: true,
                 allow_dirty: false,
             },
         )
         .unwrap();
 
         let config = load_superzent_config(&repo.repo_path).unwrap();
-        assert_eq!(
-            config.setup,
-            vec!["echo setup one".to_string(), "echo setup two".to_string()]
-        );
+        assert!(config.setup.is_empty());
         assert_eq!(config.teardown, vec!["echo teardown".to_string()]);
+        assert_eq!(outcome.workspace.teardown_script_override, None);
 
         assert_deleted(
             delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
             "persisted-scripts workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_does_not_store_repo_default_teardown_as_workspace_override() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["echo repo default"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add repo default teardown");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/repo-default-teardown".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: Some("echo repo default".to_string()),
+                save_teardown_script_as_repo_default: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(outcome.workspace.teardown_script_override, None);
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "repo-default-teardown workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_stores_unsaved_teardown_as_workspace_override() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["printf repo-default > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add repo default teardown");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/teardown-override".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: Some(
+                    "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"
+                        .to_string(),
+                ),
+                save_teardown_script_as_repo_default: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome.workspace.teardown_script_override,
+            Some(
+                "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt".to_string()
+            )
+        );
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap(),
+            "teardown-override workspace should be deleted",
+        );
+        assert_eq!(
+            fs::read_to_string(repo.repo_path.join("teardown-log.txt")).unwrap(),
+            "workspace-override"
         );
     }
 
@@ -1318,7 +1458,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup".to_string()),
                 teardown_script: Some("echo teardown".to_string()),
-                persist_lifecycle_scripts: true,
+                save_teardown_script_as_repo_default: true,
                 allow_dirty: false,
             },
         )
@@ -1352,7 +1492,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup".to_string()),
                 teardown_script: None,
-                persist_lifecycle_scripts: true,
+                save_teardown_script_as_repo_default: true,
                 allow_dirty: false,
             },
         )
@@ -1390,7 +1530,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: true,
             },
         )
@@ -1495,7 +1635,7 @@ mod tests {
                 base_workspace_path: Some(secondary_worktree_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: false,
             },
         )
@@ -1739,7 +1879,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: false,
             },
         )
@@ -1773,7 +1913,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: false,
             },
         )
@@ -1866,7 +2006,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: false,
             },
         )
@@ -1942,7 +2082,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("cp \"$SUPERZENT_BASE_PATH\"/.env .env".to_string()),
                 teardown_script: None,
-                persist_lifecycle_scripts: false,
+                save_teardown_script_as_repo_default: false,
                 allow_dirty: true,
             },
         )
@@ -2041,6 +2181,98 @@ mod tests {
         assert_deleted(
             delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
             "invalid-config-delete workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_delete_resolution_prefers_workspace_override() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["printf repo-default > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add repo default teardown");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/delete-resolution-override".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: Some(
+                    "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"
+                        .to_string(),
+                ),
+                save_teardown_script_as_repo_default: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        let delete_resolution =
+            resolve_workspace_delete_resolution(&outcome.workspace, repo.repo_path.as_path())
+                .unwrap();
+
+        assert_eq!(
+            delete_resolution,
+            WorkspaceDeleteResolution::RunTeardownScript {
+                script: "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"
+                    .to_string(),
+            }
+        );
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "delete-resolution-override workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn delete_workspace_with_resolution_uses_precomputed_teardown_script() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["printf before-preview > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add initial teardown config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/precomputed-delete-plan"),
+        )
+        .unwrap();
+
+        let delete_resolution =
+            resolve_workspace_delete_resolution(&outcome.workspace, repo.repo_path.as_path())
+                .unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["printf after-preview > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"]}"#,
+        )
+        .unwrap();
+
+        assert_deleted(
+            delete_workspace_with_resolution(
+                &outcome.workspace,
+                repo.repo_path.as_path(),
+                false,
+                Some(&delete_resolution),
+            )
+            .unwrap(),
+            "precomputed-delete-plan workspace should be deleted",
+        );
+        assert_eq!(
+            fs::read_to_string(repo.repo_path.join("teardown-log.txt")).unwrap(),
+            "before-preview"
         );
     }
 

--- a/crates/superzent_git/src/lib.rs
+++ b/crates/superzent_git/src/lib.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     fs,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 use superzent_model::{
     GitChangeSummary, ProjectEntry, ProjectLocation, WorkspaceAttentionStatus, WorkspaceEntry,
@@ -22,7 +22,66 @@ pub struct ProjectRegistration {
 #[derive(Debug)]
 pub struct WorkspaceCreateOutcome {
     pub workspace: WorkspaceEntry,
-    pub warning: Option<String>,
+    pub notice: Option<String>,
+    pub setup_failure: Option<WorkspaceLifecycleFailure>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceBaseBranchResolution {
+    pub effective_base_branch: String,
+    pub notice: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct WorkspaceLifecycleDefaults {
+    pub setup_script: Option<String>,
+    pub teardown_script: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkspaceLifecycleFailure {
+    pub phase: WorkspaceLifecyclePhase,
+    pub command: String,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl WorkspaceLifecycleFailure {
+    pub fn summary(&self) -> String {
+        match self.exit_code {
+            Some(code) => format!(
+                "{} failed while running `{}` (exit code {code}).",
+                self.phase.label(),
+                self.command
+            ),
+            None => format!(
+                "{} failed while running `{}`.",
+                self.phase.label(),
+                self.command
+            ),
+        }
+    }
+
+    pub fn details(&self) -> String {
+        let mut parts = vec![self.summary()];
+
+        if !self.stdout.trim().is_empty() {
+            parts.push(format!("Stdout:\n{}", self.stdout.trim()));
+        }
+
+        if !self.stderr.trim().is_empty() {
+            parts.push(format!("Stderr:\n{}", self.stderr.trim()));
+        }
+
+        parts.join("\n\n")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum WorkspaceDeleteOutcome {
+    Deleted,
+    BlockedByTeardown(WorkspaceLifecycleFailure),
 }
 
 #[derive(Debug)]
@@ -51,13 +110,41 @@ struct LocalProjectMetadata {
 #[derive(Clone, Debug, Default)]
 pub struct CreateWorkspaceOptions {
     pub branch_name: String,
+    pub base_branch_override: Option<String>,
+    pub base_workspace_path: Option<PathBuf>,
+    pub setup_script: Option<String>,
+    pub teardown_script: Option<String>,
+    pub persist_lifecycle_scripts: bool,
+    pub allow_dirty: bool,
 }
 
-#[derive(Default, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceLifecyclePhase {
+    Setup,
+    Teardown,
+}
+
+impl WorkspaceLifecyclePhase {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Setup => "Setup",
+            Self::Teardown => "Teardown",
+        }
+    }
+}
+
+#[derive(Default, Deserialize, Serialize, Clone)]
+#[serde(default)]
 struct SuperzentConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    setup: Vec<String>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     teardown: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_branch: Option<String>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     copy: Vec<String>,
 }
 
@@ -87,6 +174,7 @@ pub fn register_project(repo_hint: &Path, preset_id: &str) -> Result<ProjectRegi
         attention_status: WorkspaceAttentionStatus::Idle,
         review_pending: false,
         last_attention_reason: None,
+        lifecycle_teardown_script: None,
         created_at: now,
         last_opened_at: now,
     };
@@ -113,17 +201,53 @@ pub fn create_workspace(
     preset_id: &str,
     options: CreateWorkspaceOptions,
 ) -> Result<WorkspaceCreateOutcome> {
+    create_workspace_internal(project, preset_id, options, true)
+}
+
+pub fn create_workspace_without_setup(
+    project: &ProjectEntry,
+    preset_id: &str,
+    options: CreateWorkspaceOptions,
+) -> Result<WorkspaceCreateOutcome> {
+    create_workspace_internal(project, preset_id, options, false)
+}
+
+fn create_workspace_internal(
+    project: &ProjectEntry,
+    preset_id: &str,
+    options: CreateWorkspaceOptions,
+    run_setup_now: bool,
+) -> Result<WorkspaceCreateOutcome> {
     let Some(project_repo_root) = project.local_repo_root() else {
         bail!("cannot create a local workspace for a remote project");
     };
     let repo_root = discover_repo_root(project_repo_root)
         .context("initialize Git before creating a managed workspace")?;
-    ensure_clean_worktree(project_repo_root)?;
+    let base_workspace_path = options
+        .base_workspace_path
+        .as_deref()
+        .unwrap_or(project_repo_root);
+    if !options.allow_dirty {
+        ensure_clean_worktree(base_workspace_path)?;
+    }
     let repo_name = repo_root
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("project");
-    let base_ref = current_branch(&repo_root).unwrap_or_else(|| "HEAD".to_string());
+    let configured_setup_script = normalize_command(options.setup_script.as_deref());
+    let configured_teardown_script = normalize_command(options.teardown_script.as_deref());
+    let config = prepare_superzent_config_for_create(
+        &repo_root,
+        configured_setup_script.clone(),
+        configured_teardown_script.clone(),
+        options.persist_lifecycle_scripts,
+    )?;
+    let base_branch_resolution = resolve_workspace_base_branch_for_repo(
+        &repo_root,
+        options.base_workspace_path.as_deref(),
+        &config,
+        options.base_branch_override.as_deref(),
+    )?;
     let branch_name = options.branch_name.trim();
     if branch_name.is_empty() {
         bail!("branch name is required");
@@ -145,17 +269,36 @@ pub fn create_workspace(
             "-b",
             &branch_name,
             worktree_path.to_string_lossy().as_ref(),
-            &base_ref,
+            &base_branch_resolution.effective_base_branch,
         ],
     )?;
-
-    let warning = match prepare_workspace_contents(&repo_root, &worktree_path) {
-        Ok(warnings) => (!warnings.is_empty()).then(|| warnings.join("\n")),
-        Err(error) => {
-            cleanup_worktree(&repo_root, &worktree_path);
+    let should_persist_lifecycle_scripts = options.persist_lifecycle_scripts
+        && (configured_setup_script.is_some() || configured_teardown_script.is_some());
+    if should_persist_lifecycle_scripts {
+        if let Err(error) = write_superzent_config(&repo_root, &config) {
+            cleanup_created_worktree(&repo_root, &worktree_path, &branch_name);
             return Err(error);
         }
-    };
+    }
+
+    let setup_commands = lifecycle_commands(
+        &config,
+        configured_setup_script.as_deref(),
+        WorkspaceLifecyclePhase::Setup,
+    );
+    let setup_failure = run_setup_now
+        .then(|| {
+            run_lifecycle_commands(
+                &setup_commands,
+                &repo_root,
+                &worktree_path,
+                options.base_workspace_path.as_deref(),
+                &branch_name,
+                WorkspaceLifecyclePhase::Setup,
+            )
+            .err()
+        })
+        .flatten();
 
     let refresh = refresh_workspace_path(&worktree_path).unwrap_or(WorkspaceRefresh {
         branch: branch_name.clone(),
@@ -178,31 +321,127 @@ pub fn create_workspace(
             git_summary: refresh.git_summary,
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
-            last_attention_reason: warning.clone(),
+            last_attention_reason: setup_failure
+                .as_ref()
+                .map(WorkspaceLifecycleFailure::summary)
+                .or_else(|| base_branch_resolution.notice.clone()),
+            lifecycle_teardown_script: if options.persist_lifecycle_scripts {
+                None
+            } else {
+                configured_teardown_script
+            },
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         },
-        warning,
+        notice: base_branch_resolution.notice,
+        setup_failure,
     })
 }
 
-pub fn delete_workspace(workspace: &WorkspaceEntry, repo_root: &Path, force: bool) -> Result<()> {
-    if !workspace.managed || workspace.kind == WorkspaceKind::Primary {
+pub fn run_workspace_setup(
+    project: &ProjectEntry,
+    workspace: &WorkspaceEntry,
+    base_workspace_path: Option<&Path>,
+    setup_script: Option<&str>,
+) -> std::result::Result<(), WorkspaceLifecycleFailure> {
+    let Some(project_repo_root) = project.local_repo_root() else {
+        return Err(WorkspaceLifecycleFailure {
+            phase: WorkspaceLifecyclePhase::Setup,
+            command: "resolve local project".to_string(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "cannot run local workspace setup for a remote project".to_string(),
+        });
+    };
+    let repo_root =
+        discover_repo_root(project_repo_root).map_err(|error| WorkspaceLifecycleFailure {
+            phase: WorkspaceLifecyclePhase::Setup,
+            command: "resolve repo root".to_string(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: error.to_string(),
+        })?;
+    let config = load_superzent_config(&repo_root).map_err(|error| WorkspaceLifecycleFailure {
+        phase: WorkspaceLifecyclePhase::Setup,
+        command: "load .superzent/config.json".to_string(),
+        exit_code: None,
+        stdout: String::new(),
+        stderr: error.to_string(),
+    })?;
+    let setup_commands = lifecycle_commands(&config, setup_script, WorkspaceLifecyclePhase::Setup);
+    if setup_commands.is_empty() {
         return Ok(());
+    }
+    let Some(worktree_path) = workspace.local_worktree_path() else {
+        return Err(WorkspaceLifecycleFailure {
+            phase: WorkspaceLifecyclePhase::Setup,
+            command: "resolve local worktree".to_string(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "cannot run local workspace setup for a remote workspace".to_string(),
+        });
+    };
+
+    run_lifecycle_commands(
+        &setup_commands,
+        &repo_root,
+        worktree_path,
+        base_workspace_path,
+        &workspace.name,
+        WorkspaceLifecyclePhase::Setup,
+    )
+}
+
+pub fn delete_workspace(
+    workspace: &WorkspaceEntry,
+    repo_root: &Path,
+    force: bool,
+) -> Result<WorkspaceDeleteOutcome> {
+    if !workspace.managed || workspace.kind == WorkspaceKind::Primary {
+        return Ok(WorkspaceDeleteOutcome::Deleted);
     }
     let Some(worktree_path) = workspace.local_worktree_path() else {
         bail!("cannot delete a local workspace for a remote project");
     };
     if !worktree_path.exists() {
-        return Ok(());
+        return Ok(WorkspaceDeleteOutcome::Deleted);
     }
 
-    run_repo_hooks(
-        repo_root,
-        worktree_path,
-        &workspace.name,
-        HookPhase::Teardown,
-    )?;
+    if !force {
+        let config = match load_superzent_config(repo_root) {
+            Ok(config) => config,
+            Err(error) if workspace.lifecycle_teardown_script.is_some() => {
+                log::warn!(
+                    "failed to load lifecycle config during delete; using cached teardown script: {error:#}"
+                );
+                SuperzentConfig::default()
+            }
+            Err(error) => {
+                return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(
+                    workspace_lifecycle_failure_from_error(
+                        WorkspaceLifecyclePhase::Teardown,
+                        "load .superzent/config.json",
+                        error,
+                    ),
+                ));
+            }
+        };
+        let teardown_commands = lifecycle_commands(
+            &config,
+            workspace.lifecycle_teardown_script.as_deref(),
+            WorkspaceLifecyclePhase::Teardown,
+        );
+        if let Err(failure) = run_lifecycle_commands(
+            &teardown_commands,
+            repo_root,
+            worktree_path,
+            None,
+            &workspace.name,
+            WorkspaceLifecyclePhase::Teardown,
+        ) {
+            return Ok(WorkspaceDeleteOutcome::BlockedByTeardown(failure));
+        }
+    }
 
     let mut args = vec!["worktree", "remove"];
     let force = force || workspace.git_status == WorkspaceGitStatus::Unavailable;
@@ -213,7 +452,7 @@ pub fn delete_workspace(workspace: &WorkspaceEntry, repo_root: &Path, force: boo
     args.push(worktree_path.as_str());
 
     match run_git(repo_root, &args) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(WorkspaceDeleteOutcome::Deleted),
         Err(error)
             if workspace.git_status == WorkspaceGitStatus::Unavailable
                 || should_remove_workspace_path_after_git_failure(&error) =>
@@ -222,10 +461,81 @@ pub fn delete_workspace(workspace: &WorkspaceEntry, repo_root: &Path, force: boo
                 format!(
                     "failed to remove workspace path after git worktree remove failed: {error:#}"
                 )
-            })
+            })?;
+            Ok(WorkspaceDeleteOutcome::Deleted)
         }
         Err(error) => Err(error),
     }
+}
+
+pub fn resolve_workspace_base_branch(
+    project: &ProjectEntry,
+    base_branch_override: Option<&str>,
+) -> Result<WorkspaceBaseBranchResolution> {
+    resolve_workspace_base_branch_from_workspace(project, None, base_branch_override)
+}
+
+pub fn resolve_workspace_base_branch_from_workspace(
+    project: &ProjectEntry,
+    base_workspace_path: Option<&Path>,
+    base_branch_override: Option<&str>,
+) -> Result<WorkspaceBaseBranchResolution> {
+    let Some(project_repo_root) = project.local_repo_root() else {
+        bail!("cannot resolve a local workspace base branch for a remote project");
+    };
+    let repo_root = discover_repo_root(project_repo_root)
+        .context("initialize Git before creating a managed workspace")?;
+    let config = load_superzent_config(&repo_root)?;
+    resolve_workspace_base_branch_for_repo(
+        &repo_root,
+        base_workspace_path,
+        &config,
+        base_branch_override,
+    )
+}
+
+pub fn workspace_lifecycle_defaults(project: &ProjectEntry) -> Result<WorkspaceLifecycleDefaults> {
+    let Some(project_repo_root) = project.local_repo_root() else {
+        bail!("cannot resolve workspace lifecycle defaults for a remote project");
+    };
+    let repo_root = discover_repo_root(project_repo_root)
+        .context("initialize Git before reading workspace lifecycle defaults")?;
+    let config = load_superzent_config(&repo_root)?;
+    Ok(WorkspaceLifecycleDefaults {
+        setup_script: (!config.setup.is_empty()).then(|| config.setup.join("\n")),
+        teardown_script: (!config.teardown.is_empty()).then(|| config.teardown.join("\n")),
+    })
+}
+
+pub fn move_changes_to_workspace(
+    source_repo_root: &Path,
+    target_worktree_path: &Path,
+) -> Result<()> {
+    let stash_output = git_output(
+        source_repo_root,
+        &[
+            "stash",
+            "push",
+            "--include-untracked",
+            "-m",
+            "superzent-move-changes",
+        ],
+    )?;
+
+    if stash_output.contains("No local changes to save") {
+        return Ok(());
+    }
+
+    if let Err(error) = run_git(
+        target_worktree_path,
+        &["stash", "pop", "--index", "stash@{0}"],
+    ) {
+        bail!(
+            "created the workspace, but moving changes failed. Your changes were stashed as `stash@{{0}}` on the source workspace.\n{error}"
+        );
+    }
+
+    Ok(())
 }
 
 pub fn refresh_workspace_path(worktree_path: &Path) -> Result<WorkspaceRefresh> {
@@ -344,6 +654,24 @@ fn remove_workspace_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn cleanup_created_worktree(repo_root: &Path, worktree_path: &Path, branch_name: &str) {
+    let worktree_path = worktree_path.to_string_lossy().to_string();
+    if let Err(error) = run_git(
+        repo_root,
+        &["worktree", "remove", "--force", &worktree_path],
+    ) {
+        log::warn!("failed to remove newly created worktree after create error: {error:#}");
+        if let Err(remove_error) = remove_workspace_path(Path::new(&worktree_path)) {
+            log::warn!(
+                "failed to remove newly created worktree path after create error: {remove_error:#}"
+            );
+        }
+    }
+    if let Err(error) = run_git(repo_root, &["branch", "-D", branch_name]) {
+        log::warn!("failed to delete newly created branch after create error: {error:#}");
+    }
+}
+
 fn should_remove_workspace_path_after_git_failure(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         let message = cause.to_string();
@@ -360,6 +688,130 @@ fn ensure_clean_worktree(repo_hint: &Path) -> Result<()> {
     }
 
     bail!("commit or stash local changes before creating a managed workspace");
+}
+
+fn normalize_branch_name(branch_name: Option<&str>) -> Option<String> {
+    branch_name
+        .map(str::trim)
+        .filter(|branch_name| !branch_name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_command(command: Option<&str>) -> Option<String> {
+    command
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn split_commands(command_text: &str) -> Vec<String> {
+    command_text
+        .lines()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn branch_reference_exists(repo_hint: &Path, branch_name: &str) -> bool {
+    git_output(repo_hint, &["rev-parse", "--verify", branch_name]).is_ok()
+}
+
+fn repository_default_branch(repo_hint: &Path) -> Option<String> {
+    for (symbolic_ref, strip_prefix) in [
+        ("refs/remotes/upstream/HEAD", "refs/remotes/upstream/"),
+        ("refs/remotes/origin/HEAD", "refs/remotes/origin/"),
+    ] {
+        if let Ok(output) = git_output(repo_hint, &["symbolic-ref", symbolic_ref]) {
+            if let Some(branch_name) = output.strip_prefix(strip_prefix) {
+                return Some(branch_name.to_string());
+            }
+        }
+    }
+
+    if let Ok(configured_default_branch) = git_output(repo_hint, &["config", "init.defaultBranch"])
+        && branch_reference_exists(repo_hint, &configured_default_branch)
+    {
+        return Some(configured_default_branch);
+    }
+
+    for branch_name in ["main", "master"] {
+        if branch_reference_exists(repo_hint, branch_name) {
+            return Some(branch_name.to_string());
+        }
+    }
+
+    None
+}
+
+fn resolve_workspace_base_branch_for_repo(
+    repo_root: &Path,
+    base_workspace_path: Option<&Path>,
+    config: &SuperzentConfig,
+    base_branch_override: Option<&str>,
+) -> Result<WorkspaceBaseBranchResolution> {
+    if let Some(base_branch_override) = normalize_branch_name(base_branch_override) {
+        if !branch_reference_exists(repo_root, &base_branch_override) {
+            bail!("base branch `{base_branch_override}` was not found");
+        }
+
+        return Ok(WorkspaceBaseBranchResolution {
+            effective_base_branch: base_branch_override,
+            notice: None,
+        });
+    }
+
+    let current_base_workspace_branch = current_branch(base_workspace_path.unwrap_or(repo_root));
+    let repository_default_branch = repository_default_branch(repo_root);
+
+    let configured_base_branch = normalize_branch_name(config.base_branch.as_deref());
+    if let Some(configured_base_branch) = configured_base_branch {
+        if branch_reference_exists(repo_root, &configured_base_branch) {
+            return Ok(WorkspaceBaseBranchResolution {
+                effective_base_branch: configured_base_branch,
+                notice: None,
+            });
+        }
+
+        if let Some(current_base_workspace_branch) = current_base_workspace_branch.clone() {
+            return Ok(WorkspaceBaseBranchResolution {
+                effective_base_branch: current_base_workspace_branch.clone(),
+                notice: Some(format!(
+                    "Configured base branch `{configured_base_branch}` was not found. Using the base workspace current branch `{current_base_workspace_branch}`."
+                )),
+            });
+        }
+
+        let repository_default_branch = repository_default_branch.ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not determine the repository default branch; configure `.superzent/config.json` `base_branch` or choose an override"
+            )
+        })?;
+        return Ok(WorkspaceBaseBranchResolution {
+            effective_base_branch: repository_default_branch.clone(),
+            notice: Some(format!(
+                "Configured base branch `{configured_base_branch}` was not found. The base workspace has no current branch, so using repository default `{repository_default_branch}`."
+            )),
+        });
+    }
+
+    if let Some(current_base_workspace_branch) = current_base_workspace_branch {
+        return Ok(WorkspaceBaseBranchResolution {
+            effective_base_branch: current_base_workspace_branch,
+            notice: None,
+        });
+    }
+
+    let repository_default_branch = repository_default_branch.ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not determine the repository default branch; configure `.superzent/config.json` `base_branch` or choose an override"
+        )
+    })?;
+
+    Ok(WorkspaceBaseBranchResolution {
+        effective_base_branch: repository_default_branch,
+        notice: None,
+    })
 }
 
 fn git_change_summary(repo_hint: &Path) -> Result<GitChangeSummary> {
@@ -463,51 +915,59 @@ fn git_output(repo_root: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-#[derive(Copy, Clone)]
-enum HookPhase {
-    Teardown,
+fn lifecycle_commands(
+    config: &SuperzentConfig,
+    command_override: Option<&str>,
+    phase: WorkspaceLifecyclePhase,
+) -> Vec<String> {
+    if let Some(command_override) = normalize_command(command_override) {
+        return split_commands(&command_override);
+    }
+
+    match phase {
+        WorkspaceLifecyclePhase::Setup => config.setup.clone(),
+        WorkspaceLifecyclePhase::Teardown => config.teardown.clone(),
+    }
 }
 
-fn run_repo_hooks(
+fn run_lifecycle_commands(
+    commands: &[String],
     repo_root: &Path,
     worktree_path: &Path,
+    base_workspace_path: Option<&Path>,
     workspace_name: &str,
-    phase: HookPhase,
-) -> Result<()> {
-    let config = load_superzent_config(repo_root)?;
-    let commands = match phase {
-        HookPhase::Teardown => config.teardown,
-    };
-
+    phase: WorkspaceLifecyclePhase,
+) -> std::result::Result<(), WorkspaceLifecycleFailure> {
     for command in commands {
-        run_shell_command(&command, worktree_path, workspace_name, repo_root)?;
+        run_shell_command(
+            command,
+            worktree_path,
+            base_workspace_path,
+            workspace_name,
+            repo_root,
+            phase,
+        )?;
     }
 
     Ok(())
 }
 
-fn prepare_workspace_contents(repo_root: &Path, worktree_path: &Path) -> Result<Vec<String>> {
-    let config = load_superzent_config(repo_root)?;
-    let mut warnings = Vec::new();
-
-    let superzent_source = repo_root.join(".superzent");
-    if superzent_source.exists() {
-        copy_repo_path(&superzent_source, &worktree_path.join(".superzent"))
-            .with_context(|| format!("failed to copy {}", superzent_source.display()))?;
+fn prepare_superzent_config_for_create(
+    repo_root: &Path,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+    persist_lifecycle_scripts: bool,
+) -> Result<SuperzentConfig> {
+    let mut config = load_superzent_config(repo_root)?;
+    if persist_lifecycle_scripts {
+        if let Some(setup_script) = setup_script {
+            config.setup = split_commands(&setup_script);
+        }
+        if let Some(teardown_script) = teardown_script {
+            config.teardown = split_commands(&teardown_script);
+        }
     }
-
-    for copy_entry in &config.copy {
-        let Some(source_path) = resolve_repo_relative_path(repo_root, copy_entry)? else {
-            warnings.push(format!("Skipped missing copy source `{copy_entry}`."));
-            continue;
-        };
-
-        let destination_path = worktree_path.join(copy_entry);
-        copy_repo_path(&source_path, &destination_path)
-            .with_context(|| format!("failed to copy {}", source_path.display()))?;
-    }
-
-    Ok(warnings)
+    Ok(config)
 }
 
 fn load_superzent_config(repo_root: &Path) -> Result<SuperzentConfig> {
@@ -518,125 +978,96 @@ fn load_superzent_config(repo_root: &Path) -> Result<SuperzentConfig> {
 
     let contents = fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
-    serde_json::from_str(&contents)
-        .with_context(|| format!("failed to parse {}", config_path.display()))
-}
-
-fn resolve_repo_relative_path(repo_root: &Path, relative_path: &str) -> Result<Option<PathBuf>> {
-    let relative_path = Path::new(relative_path);
-    if relative_path.is_absolute() {
+    let config: SuperzentConfig = serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+    if !config.copy.is_empty() {
         bail!(
-            "copy path `{}` must be relative to the repository root",
-            relative_path.display()
+            "`.superzent/config.json` `copy` is no longer supported; move this logic into `setup` commands"
         );
     }
 
-    for component in relative_path.components() {
-        match component {
-            Component::CurDir | Component::Normal(_) => {}
-            Component::ParentDir => {
-                bail!(
-                    "copy path `{}` cannot leave the repository root",
-                    relative_path.display()
-                )
-            }
-            Component::Prefix(_) | Component::RootDir => {
-                bail!(
-                    "copy path `{}` must be relative to the repository root",
-                    relative_path.display()
-                )
-            }
-        }
-    }
-
-    let source_path = repo_root.join(relative_path);
-    if !source_path.exists() {
-        return Ok(None);
-    }
-
-    Ok(Some(source_path))
+    Ok(config)
 }
 
-fn copy_repo_path(source_path: &Path, destination_path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(source_path)
-        .with_context(|| format!("failed to read {}", source_path.display()))?;
-
-    if metadata.is_dir() {
-        fs::create_dir_all(destination_path)
-            .with_context(|| format!("failed to create {}", destination_path.display()))?;
-
-        for entry in fs::read_dir(source_path)
-            .with_context(|| format!("failed to read {}", source_path.display()))?
-        {
-            let entry = entry?;
-            copy_repo_path(&entry.path(), &destination_path.join(entry.file_name()))?;
-        }
-
-        return Ok(());
-    }
-
-    if let Some(parent_directory) = destination_path.parent() {
-        fs::create_dir_all(parent_directory)
-            .with_context(|| format!("failed to create {}", parent_directory.display()))?;
-    }
-
-    fs::copy(source_path, destination_path).with_context(|| {
-        format!(
-            "failed to copy {} to {}",
-            source_path.display(),
-            destination_path.display()
-        )
-    })?;
-
-    Ok(())
-}
-
-fn cleanup_worktree(repo_root: &Path, worktree_path: &Path) {
-    let worktree_path = worktree_path.to_string_lossy().to_string();
-    if let Err(error) = run_git(
-        repo_root,
-        &["worktree", "remove", "--force", &worktree_path],
-    ) {
-        log::error!("failed to clean up worktree {}: {error:#}", worktree_path);
-    }
+fn write_superzent_config(repo_root: &Path, config: &SuperzentConfig) -> Result<()> {
+    let superzent_directory = repo_root.join(".superzent");
+    fs::create_dir_all(&superzent_directory)
+        .with_context(|| format!("failed to create {}", superzent_directory.display()))?;
+    let config_path = superzent_directory.join("config.json");
+    let contents = serde_json::to_string_pretty(config)
+        .context("failed to serialize .superzent/config.json")?;
+    fs::write(&config_path, contents)
+        .with_context(|| format!("failed to write {}", config_path.display()))
 }
 
 fn run_shell_command(
     command: &str,
     cwd: &Path,
+    base_workspace_path: Option<&Path>,
     workspace_name: &str,
     repo_root: &Path,
-) -> Result<()> {
+    phase: WorkspaceLifecyclePhase,
+) -> std::result::Result<(), WorkspaceLifecycleFailure> {
     let mut shell_command = smol::process::Command::new("/bin/zsh");
     shell_command
         .arg("-lc")
         .arg(command)
         .current_dir(cwd)
+        .env("SUPERZENT_ROOT_PATH", repo_root)
+        .env("SUPERZENT_WORKTREE_PATH", cwd)
+        .envs(
+            base_workspace_path
+                .map(|base_workspace_path| {
+                    [
+                        ("SUPERZENT_BASE_PATH", base_workspace_path.as_os_str()),
+                        (
+                            "SUPERZENT_SOURCE_WORKSPACE_PATH",
+                            base_workspace_path.as_os_str(),
+                        ),
+                    ]
+                })
+                .into_iter()
+                .flatten(),
+        )
+        .env("SUPERZENT_WORKSPACE_NAME", workspace_name)
         .env("SUPERSET_WORKSPACE_NAME", workspace_name)
         .env("SUPERSET_ROOT_PATH", repo_root);
     let output = run_command_output(shell_command, || {
         format!("failed to run hook command: {command}")
+    })
+    .map_err(|error| WorkspaceLifecycleFailure {
+        phase,
+        command: command.to_string(),
+        exit_code: None,
+        stdout: String::new(),
+        stderr: error.to_string(),
     })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        bail!(
-            "hook command `{command}` failed{}\n{}",
-            output
-                .status
-                .code()
-                .map(|code| format!(" with exit code {code}"))
-                .unwrap_or_default(),
-            [stdout.trim(), stderr.trim()]
-                .into_iter()
-                .filter(|text| !text.is_empty())
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+        return Err(WorkspaceLifecycleFailure {
+            phase,
+            command: command.to_string(),
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
     }
 
     Ok(())
+}
+
+fn workspace_lifecycle_failure_from_error(
+    phase: WorkspaceLifecyclePhase,
+    command: &str,
+    error: anyhow::Error,
+) -> WorkspaceLifecycleFailure {
+    WorkspaceLifecycleFailure {
+        phase,
+        command: command.to_string(),
+        exit_code: None,
+        stdout: String::new(),
+        stderr: error.to_string(),
+    }
 }
 
 fn unique_worktree_directory_name(worktree_root: &Path, branch_name: &str) -> String {
@@ -674,6 +1105,25 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
+    fn create_workspace_options(branch_name: &str) -> CreateWorkspaceOptions {
+        CreateWorkspaceOptions {
+            branch_name: branch_name.to_string(),
+            base_branch_override: None,
+            base_workspace_path: None,
+            setup_script: None,
+            teardown_script: None,
+            persist_lifecycle_scripts: false,
+            allow_dirty: false,
+        }
+    }
+
+    fn assert_deleted(outcome: WorkspaceDeleteOutcome, context: &str) {
+        assert!(
+            matches!(outcome, WorkspaceDeleteOutcome::Deleted),
+            "{context}"
+        );
+    }
+
     #[test]
     fn discover_repo_root_uses_common_git_dir_for_linked_worktrees() {
         let repo = init_repo();
@@ -705,8 +1155,81 @@ mod tests {
         let error = create_workspace(
             &registration.project,
             "codex",
+            create_workspace_options("feature/dirty-worktree"),
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("commit or stash local changes before creating a managed workspace")
+        );
+    }
+
+    #[test]
+    fn create_workspace_can_override_dirty_worktree_guard() {
+        let repo = init_repo();
+        fs::write(repo.repo_path.join("dirty.txt"), "dirty\n").unwrap();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
             CreateWorkspaceOptions {
-                branch_name: "feature/dirty-worktree".to_string(),
+                branch_name: "feature/dirty-override".to_string(),
+                base_branch_override: None,
+                base_workspace_path: None,
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: true,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            outcome
+                .workspace
+                .local_worktree_path()
+                .expect("workspace should be local")
+                .exists()
+        );
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "dirty override workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_blocks_dirty_active_base_workspace() {
+        let repo = init_repo();
+        let secondary_worktree_path = repo.repo_path.parent().unwrap().join("dirty-secondary");
+        git(
+            &repo.repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature/dirty-secondary-source",
+                secondary_worktree_path.to_str().unwrap(),
+                "main",
+            ],
+        );
+        fs::write(secondary_worktree_path.join("dirty.txt"), "dirty\n").unwrap();
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let error = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/dirty-secondary-target".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(secondary_worktree_path.clone()),
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: false,
             },
         )
         .unwrap_err();
@@ -715,6 +1238,183 @@ mod tests {
             error
                 .to_string()
                 .contains("commit or stash local changes before creating a managed workspace")
+        );
+
+        git(
+            &repo.repo_path,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                secondary_worktree_path.to_str().unwrap(),
+            ],
+        );
+    }
+
+    #[test]
+    fn prepare_superzent_config_for_create_splits_multiline_scripts() {
+        let repo = init_repo();
+
+        let config = prepare_superzent_config_for_create(
+            &repo.repo_path,
+            Some("echo one\necho two".to_string()),
+            Some("cargo clean\ncargo test".to_string()),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.setup,
+            vec!["echo one".to_string(), "echo two".to_string()]
+        );
+        assert_eq!(
+            config.teardown,
+            vec!["cargo clean".to_string(), "cargo test".to_string()]
+        );
+    }
+
+    #[test]
+    fn create_workspace_persists_lifecycle_scripts_when_requested() {
+        let repo = init_repo();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/persisted-scripts".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: Some("echo setup one\necho setup two".to_string()),
+                teardown_script: Some("echo teardown".to_string()),
+                persist_lifecycle_scripts: true,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        let config = load_superzent_config(&repo.repo_path).unwrap();
+        assert_eq!(
+            config.setup,
+            vec!["echo setup one".to_string(), "echo setup two".to_string()]
+        );
+        assert_eq!(config.teardown, vec!["echo teardown".to_string()]);
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "persisted-scripts workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_does_not_persist_config_when_validation_fails() {
+        let repo = init_repo();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let error = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/persist-validation-fail".to_string(),
+                base_branch_override: Some("missing".to_string()),
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: Some("echo setup".to_string()),
+                teardown_script: Some("echo teardown".to_string()),
+                persist_lifecycle_scripts: true,
+                allow_dirty: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("base branch `missing` was not found")
+        );
+        assert!(
+            !repo
+                .repo_path
+                .join(".superzent")
+                .join("config.json")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn create_workspace_cleans_up_worktree_when_persisted_config_write_fails() {
+        let repo = init_repo();
+        fs::write(repo.repo_path.join(".superzent"), "not a directory").unwrap();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let error = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/persist-write-fail".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: Some("echo setup".to_string()),
+                teardown_script: None,
+                persist_lifecycle_scripts: true,
+                allow_dirty: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(!error.to_string().is_empty());
+        let expected_worktree_path = repo
+            .repo_path
+            .parent()
+            .unwrap()
+            .join(".superzent-worktrees")
+            .join("repo")
+            .join("feature-persist-write-fail");
+        assert!(!expected_worktree_path.exists());
+        assert!(!branch_reference_exists(
+            &repo.repo_path,
+            "feature/persist-write-fail"
+        ));
+    }
+
+    #[test]
+    fn move_changes_to_workspace_moves_tracked_and_untracked_changes() {
+        let repo = init_repo();
+        fs::write(repo.repo_path.join("tracked.txt"), "tracked\n").unwrap();
+        fs::write(repo.repo_path.join("untracked.txt"), "untracked\n").unwrap();
+        git(&repo.repo_path, &["add", "tracked.txt"]);
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/move-changes".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: true,
+            },
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local")
+            .to_path_buf();
+
+        move_changes_to_workspace(&repo.repo_path, &worktree_path).unwrap();
+
+        assert!(!repo.repo_path.join("tracked.txt").exists());
+        assert!(!repo.repo_path.join("untracked.txt").exists());
+        assert!(worktree_path.join("tracked.txt").exists());
+        assert!(worktree_path.join("untracked.txt").exists());
+
+        let source_status = git_output(&repo.repo_path, &["status", "--porcelain"]).unwrap();
+        assert!(source_status.is_empty());
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "move-changes workspace should be deleted",
         );
     }
 
@@ -739,9 +1439,7 @@ mod tests {
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/linked-root".to_string(),
-            },
+            create_workspace_options("feature/linked-root"),
         )
         .unwrap();
         let expected_root = repo
@@ -762,7 +1460,69 @@ mod tests {
                 .is_some_and(|worktree_path| worktree_path.starts_with(&expected_root))
         );
 
-        delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap();
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "linked-root workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_uses_active_base_workspace_branch_when_provided() {
+        let repo = init_repo();
+        git(&repo.repo_path, &["checkout", "-b", "develop"]);
+        fs::write(repo.repo_path.join("develop.txt"), "from develop\n").unwrap();
+        commit_all_changes(&repo.repo_path, "add develop marker");
+        git(&repo.repo_path, &["checkout", "main"]);
+
+        let secondary_worktree_path = repo.repo_path.parent().unwrap().join("develop-worktree");
+        git(
+            &repo.repo_path,
+            &[
+                "worktree",
+                "add",
+                secondary_worktree_path.to_str().unwrap(),
+                "develop",
+            ],
+        );
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/from-secondary-base".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(secondary_worktree_path.clone()),
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            outcome
+                .workspace
+                .local_worktree_path()
+                .expect("workspace should be local")
+                .join("develop.txt")
+                .exists()
+        );
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "secondary-base workspace should be deleted",
+        );
+        git(
+            &repo.repo_path,
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                secondary_worktree_path.to_str().unwrap(),
+            ],
+        );
     }
 
     #[test]
@@ -772,9 +1532,7 @@ mod tests {
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/superzent-test".to_string(),
-            },
+            create_workspace_options("feature/superzent-test"),
         )
         .unwrap();
 
@@ -790,38 +1548,36 @@ mod tests {
             Some("feature-superzent-test")
         );
 
-        delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap();
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "superzent-test workspace should be deleted",
+        );
     }
 
     #[test]
-    fn create_workspace_copies_superzent_directory_and_extra_paths() {
+    fn create_workspace_uses_configured_base_branch_instead_of_current_branch() {
         let repo = init_repo();
         fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
         fs::write(
             repo.repo_path.join(".superzent").join("config.json"),
-            r#"{"copy":["templates"]}"#,
+            r#"{"base_branch":"develop"}"#,
         )
         .unwrap();
-        fs::write(
-            repo.repo_path.join(".superzent").join("setup.sh"),
-            "#!/bin/zsh\necho setup\n",
-        )
-        .unwrap();
-        fs::create_dir_all(repo.repo_path.join("templates")).unwrap();
-        fs::write(
-            repo.repo_path.join("templates").join("agent.txt"),
-            "preset\n",
-        )
-        .unwrap();
-        commit_all_changes(&repo.repo_path, "add superzent files");
+        commit_all_changes(&repo.repo_path, "add lifecycle config");
+
+        git(&repo.repo_path, &["checkout", "-b", "develop"]);
+        fs::write(repo.repo_path.join("develop.txt"), "from develop\n").unwrap();
+        commit_all_changes(&repo.repo_path, "add develop marker");
+        git(
+            &repo.repo_path,
+            &["checkout", "-b", "feature/current", "main"],
+        );
 
         let registration = register_project(&repo.repo_path, "codex").unwrap();
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/copy-paths".to_string(),
-            },
+            create_workspace_options("feature/configured-base"),
         )
         .unwrap();
 
@@ -830,48 +1586,13 @@ mod tests {
                 .workspace
                 .local_worktree_path()
                 .expect("workspace should be local")
-                .join(".superzent")
-                .join("setup.sh")
-                .exists()
-        );
-        assert!(
-            outcome
-                .workspace
-                .local_worktree_path()
-                .expect("workspace should be local")
-                .join("templates")
-                .join("agent.txt")
+                .join("develop.txt")
                 .exists()
         );
 
-        delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap();
-    }
-
-    #[test]
-    fn create_workspace_rejects_copy_paths_outside_repo() {
-        let repo = init_repo();
-        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
-        fs::write(
-            repo.repo_path.join(".superzent").join("config.json"),
-            r#"{"copy":["../outside"]}"#,
-        )
-        .unwrap();
-        commit_all_changes(&repo.repo_path, "add invalid copy config");
-
-        let registration = register_project(&repo.repo_path, "codex").unwrap();
-        let error = create_workspace(
-            &registration.project,
-            "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/reject-copy".to_string(),
-            },
-        )
-        .unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("cannot leave the repository root")
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "configured-base workspace should be deleted",
         );
     }
 
@@ -990,34 +1711,373 @@ mod tests {
     }
 
     #[test]
-    fn create_workspace_reports_missing_copy_sources_as_warning() {
+    fn create_workspace_override_base_branch_wins_over_configured_base_branch() {
         let repo = init_repo();
         fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
         fs::write(
             repo.repo_path.join(".superzent").join("config.json"),
-            r#"{"copy":["missing-directory"]}"#,
+            r#"{"base_branch":"develop"}"#,
         )
         .unwrap();
-        commit_all_changes(&repo.repo_path, "add missing copy config");
+        commit_all_changes(&repo.repo_path, "add lifecycle config");
+
+        git(&repo.repo_path, &["checkout", "-b", "develop"]);
+        fs::write(repo.repo_path.join("develop.txt"), "from develop\n").unwrap();
+        commit_all_changes(&repo.repo_path, "add develop marker");
+        git(
+            &repo.repo_path,
+            &["checkout", "-b", "feature/current", "main"],
+        );
 
         let registration = register_project(&repo.repo_path, "codex").unwrap();
         let outcome = create_workspace(
             &registration.project,
             "codex",
             CreateWorkspaceOptions {
-                branch_name: "feature/missing-copy-warning".to_string(),
+                branch_name: "feature/override-base".to_string(),
+                base_branch_override: Some("main".to_string()),
+                base_workspace_path: None,
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: false,
             },
         )
         .unwrap();
 
         assert!(
-            outcome
-                .warning
-                .as_deref()
-                .is_some_and(|warning| warning.contains("missing-directory"))
+            !outcome
+                .workspace
+                .local_worktree_path()
+                .expect("workspace should be local")
+                .join("develop.txt")
+                .exists()
         );
 
-        delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap();
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "override-base workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_rejects_invalid_base_branch_override() {
+        let repo = init_repo();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let error = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/invalid-override".to_string(),
+                base_branch_override: Some("missing".to_string()),
+                base_workspace_path: None,
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("base branch `missing` was not found")
+        );
+    }
+
+    #[test]
+    fn resolve_workspace_base_branch_prefers_current_base_workspace_branch_when_config_is_absent() {
+        let repo = init_repo();
+        git(&repo.repo_path, &["checkout", "-b", "develop"]);
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let resolution = resolve_workspace_base_branch(&registration.project, None).unwrap();
+
+        assert_eq!(resolution.effective_base_branch, "develop");
+        assert!(resolution.notice.is_none());
+    }
+
+    #[test]
+    fn resolve_workspace_base_branch_falls_back_to_current_base_workspace_branch_when_configured_branch_is_missing()
+     {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"base_branch":"missing"}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add lifecycle config");
+        git(&repo.repo_path, &["checkout", "-b", "develop"]);
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let resolution = resolve_workspace_base_branch(&registration.project, None).unwrap();
+
+        assert_eq!(resolution.effective_base_branch, "develop");
+        assert!(
+            resolution
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice.contains("base workspace current branch `develop`"))
+        );
+    }
+
+    #[test]
+    fn create_workspace_rejects_deprecated_copy_config() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"copy":["templates"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add deprecated copy config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let error = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/deprecated-copy"),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("`copy` is no longer supported"));
+    }
+
+    #[test]
+    fn create_workspace_runs_setup_commands_with_superzent_and_legacy_env_vars() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"setup":["printf '%s\n%s\n%s\n%s\n%s\n%s' \"$SUPERZENT_ROOT_PATH\" \"$SUPERZENT_WORKTREE_PATH\" \"$SUPERZENT_BASE_PATH\" \"$SUPERZENT_WORKSPACE_NAME\" \"$SUPERSET_ROOT_PATH\" \"$SUPERSET_WORKSPACE_NAME\" > lifecycle-env.txt"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add setup env config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/setup-env".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local");
+        let env_file = fs::read_to_string(worktree_path.join("lifecycle-env.txt")).unwrap();
+        let env_lines = env_file.lines().collect::<Vec<_>>();
+        assert_eq!(env_lines[0], repo.repo_path.to_string_lossy());
+        assert_eq!(env_lines[1], worktree_path.to_string_lossy());
+        assert_eq!(env_lines[2], repo.repo_path.to_string_lossy());
+        assert_eq!(env_lines[3], "feature/setup-env");
+        assert_eq!(env_lines[4], repo.repo_path.to_string_lossy());
+        assert_eq!(env_lines[5], "feature/setup-env");
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "setup-env workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_keeps_worktree_when_setup_fails() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"setup":["echo partial > setup-output.txt","false"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add failing setup config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/setup-failure"),
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local");
+        assert!(worktree_path.exists());
+        assert!(worktree_path.join("setup-output.txt").exists());
+        let setup_failure = outcome
+            .setup_failure
+            .expect("setup failure should be captured");
+        assert_eq!(setup_failure.phase, WorkspaceLifecyclePhase::Setup);
+        assert!(setup_failure.summary().contains("Setup failed"));
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "setup-failure workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn run_workspace_setup_can_copy_from_superzent_base_path() {
+        let repo = init_repo();
+        fs::write(repo.repo_path.join(".env"), "API_KEY=test\n").unwrap();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace_without_setup(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/base-path-copy".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: Some("cp \"$SUPERZENT_BASE_PATH\"/.env .env".to_string()),
+                teardown_script: None,
+                persist_lifecycle_scripts: false,
+                allow_dirty: true,
+            },
+        )
+        .unwrap();
+
+        run_workspace_setup(
+            &registration.project,
+            &outcome.workspace,
+            Some(repo.repo_path.as_path()),
+            Some("cp \"$SUPERZENT_BASE_PATH\"/.env .env"),
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local");
+        let copied_env = fs::read_to_string(worktree_path.join(".env")).unwrap();
+        assert_eq!(copied_env, "API_KEY=test\n");
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "base-path-copy workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn delete_workspace_blocks_on_teardown_failure_until_force_delete() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["echo teardown > teardown-log.txt","false"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add failing teardown config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/teardown-failure"),
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local")
+            .to_path_buf();
+
+        let delete_outcome =
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap();
+        let teardown_failure = match delete_outcome {
+            WorkspaceDeleteOutcome::Deleted => panic!("delete should have been blocked"),
+            WorkspaceDeleteOutcome::BlockedByTeardown(failure) => failure,
+        };
+        assert_eq!(teardown_failure.phase, WorkspaceLifecyclePhase::Teardown);
+        assert!(worktree_path.exists());
+        assert!(worktree_path.join("teardown-log.txt").exists());
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "force delete should skip teardown and remove the workspace",
+        );
+        assert!(!worktree_path.exists());
+    }
+
+    #[test]
+    fn delete_workspace_blocks_on_invalid_lifecycle_config_until_force_delete() {
+        let repo = init_repo();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/invalid-config-delete"),
+        )
+        .unwrap();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"copy":["templates"]}"#,
+        )
+        .unwrap();
+
+        let delete_outcome =
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap();
+        let failure = match delete_outcome {
+            WorkspaceDeleteOutcome::Deleted => panic!("delete should have been blocked"),
+            WorkspaceDeleteOutcome::BlockedByTeardown(failure) => failure,
+        };
+        assert_eq!(failure.phase, WorkspaceLifecyclePhase::Teardown);
+        assert_eq!(failure.command, "load .superzent/config.json");
+        assert!(failure.stderr.contains("`copy` is no longer supported"));
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "invalid-config-delete workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn delete_workspace_runs_teardown_before_removing_worktree() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"teardown":["printf teardown > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add teardown config");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            create_workspace_options("feature/teardown-success"),
+        )
+        .unwrap();
+
+        let worktree_path = outcome
+            .workspace
+            .local_worktree_path()
+            .expect("workspace should be local")
+            .to_path_buf();
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap(),
+            "teardown-success workspace should be deleted",
+        );
+        assert_eq!(
+            fs::read_to_string(repo.repo_path.join("teardown-log.txt")).unwrap(),
+            "teardown"
+        );
+        assert!(!worktree_path.exists());
     }
 
     #[test]
@@ -1027,9 +2087,7 @@ mod tests {
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/stale-delete".to_string(),
-            },
+            create_workspace_options("feature/stale-delete"),
         )
         .unwrap();
 
@@ -1043,7 +2101,10 @@ mod tests {
 
         fs::remove_dir_all(repo.repo_path.join(".git")).unwrap();
 
-        delete_workspace(&unavailable_workspace, repo.repo_path.as_path(), false).unwrap();
+        assert_deleted(
+            delete_workspace(&unavailable_workspace, repo.repo_path.as_path(), false).unwrap(),
+            "stale workspace should be deleted when git is unavailable",
+        );
 
         assert!(!worktree_path.exists());
     }
@@ -1055,9 +2116,7 @@ mod tests {
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/stale-delete-metadata".to_string(),
-            },
+            create_workspace_options("feature/stale-delete-metadata"),
         )
         .unwrap();
 
@@ -1069,7 +2128,10 @@ mod tests {
 
         fs::remove_dir_all(repo.repo_path.join(".git")).unwrap();
 
-        delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap();
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), false).unwrap(),
+            "stale metadata workspace should be deleted",
+        );
 
         assert!(!worktree_path.exists());
     }
@@ -1081,9 +2143,7 @@ mod tests {
         let outcome = create_workspace(
             &registration.project,
             "codex",
-            CreateWorkspaceOptions {
-                branch_name: "feature/discover-worktrees".to_string(),
-            },
+            create_workspace_options("feature/discover-worktrees"),
         )
         .unwrap();
 

--- a/crates/superzent_model/src/lib.rs
+++ b/crates/superzent_model/src/lib.rs
@@ -321,8 +321,8 @@ pub struct WorkspaceEntry {
     pub review_pending: bool,
     #[serde(default)]
     pub last_attention_reason: Option<String>,
-    #[serde(default)]
-    pub lifecycle_teardown_script: Option<String>,
+    #[serde(default, alias = "lifecycle_teardown_script")]
+    pub teardown_script_override: Option<String>,
     pub created_at: DateTime<Utc>,
     pub last_opened_at: DateTime<Utc>,
 }
@@ -1616,8 +1616,8 @@ struct LegacyWorkspaceEntry {
     review_pending: bool,
     #[serde(default)]
     last_attention_reason: Option<String>,
-    #[serde(default)]
-    lifecycle_teardown_script: Option<String>,
+    #[serde(default, alias = "lifecycle_teardown_script")]
+    teardown_script_override: Option<String>,
     created_at: DateTime<Utc>,
     last_opened_at: DateTime<Utc>,
 }
@@ -1661,7 +1661,7 @@ impl From<LegacySuperzentState> for SuperzentState {
                     attention_status: workspace.attention_status,
                     review_pending: workspace.review_pending,
                     last_attention_reason: workspace.last_attention_reason,
-                    lifecycle_teardown_script: workspace.lifecycle_teardown_script,
+                    teardown_script_override: workspace.teardown_script_override,
                     created_at: workspace.created_at,
                     last_opened_at: workspace.last_opened_at,
                 })
@@ -1778,7 +1778,7 @@ fn load_legacy_state() -> Option<SuperzentState> {
                 attention_status: WorkspaceAttentionStatus::Idle,
                 review_pending: false,
                 last_attention_reason: None,
-                lifecycle_teardown_script: None,
+                teardown_script_override: None,
                 created_at: task.created_at,
                 last_opened_at: task.last_event_at,
             });
@@ -1809,7 +1809,7 @@ fn load_legacy_state() -> Option<SuperzentState> {
                 TaskStatus::Completed | TaskStatus::Failed | TaskStatus::NeedsAttention
             ),
             last_attention_reason: task.last_attention_reason.clone(),
-            lifecycle_teardown_script: None,
+            teardown_script_override: None,
             created_at: task.created_at,
             last_opened_at: task.last_event_at,
         });
@@ -2040,6 +2040,7 @@ pub fn aggregate_workspace_attention_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn project_entry(id: &str, repo_root: &str) -> ProjectEntry {
         ProjectEntry {
@@ -2077,6 +2078,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -2125,6 +2127,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -2175,6 +2178,51 @@ mod tests {
         ));
         assert_eq!(workspace.branch, "feature/fast");
         assert_eq!(workspace.git_summary, Some(summary));
+    }
+
+    #[test]
+    fn workspace_entry_deserializes_legacy_lifecycle_teardown_field_into_override() {
+        let workspace: WorkspaceEntry = serde_json::from_value(json!({
+            "id": "workspace",
+            "project_id": "project",
+            "kind": "worktree",
+            "name": "workspace",
+            "branch": "main",
+            "location": {
+                "transport": "local",
+                "worktree_path": "/tmp/workspace"
+            },
+            "agent_preset_id": "codex",
+            "managed": true,
+            "created_at": "2026-04-10T00:00:00Z",
+            "last_opened_at": "2026-04-10T00:00:00Z",
+            "lifecycle_teardown_script": "echo teardown"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            workspace.teardown_script_override,
+            Some("echo teardown".to_string())
+        );
+    }
+
+    #[test]
+    fn workspace_entry_serializes_override_under_narrow_field_name() {
+        let mut workspace = workspace_entry(
+            "workspace",
+            "project",
+            WorkspaceKind::Worktree,
+            "/tmp/workspace",
+        );
+        workspace.teardown_script_override = Some("echo teardown".to_string());
+
+        let value = serde_json::to_value(&workspace).unwrap();
+
+        assert_eq!(
+            value.get("teardown_script_override"),
+            Some(&json!("echo teardown"))
+        );
+        assert_eq!(value.get("lifecycle_teardown_script"), None);
     }
 
     #[test]
@@ -2483,6 +2531,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         };

--- a/crates/superzent_model/src/lib.rs
+++ b/crates/superzent_model/src/lib.rs
@@ -321,6 +321,8 @@ pub struct WorkspaceEntry {
     pub review_pending: bool,
     #[serde(default)]
     pub last_attention_reason: Option<String>,
+    #[serde(default)]
+    pub lifecycle_teardown_script: Option<String>,
     pub created_at: DateTime<Utc>,
     pub last_opened_at: DateTime<Utc>,
 }
@@ -1614,6 +1616,8 @@ struct LegacyWorkspaceEntry {
     review_pending: bool,
     #[serde(default)]
     last_attention_reason: Option<String>,
+    #[serde(default)]
+    lifecycle_teardown_script: Option<String>,
     created_at: DateTime<Utc>,
     last_opened_at: DateTime<Utc>,
 }
@@ -1657,6 +1661,7 @@ impl From<LegacySuperzentState> for SuperzentState {
                     attention_status: workspace.attention_status,
                     review_pending: workspace.review_pending,
                     last_attention_reason: workspace.last_attention_reason,
+                    lifecycle_teardown_script: workspace.lifecycle_teardown_script,
                     created_at: workspace.created_at,
                     last_opened_at: workspace.last_opened_at,
                 })
@@ -1773,6 +1778,7 @@ fn load_legacy_state() -> Option<SuperzentState> {
                 attention_status: WorkspaceAttentionStatus::Idle,
                 review_pending: false,
                 last_attention_reason: None,
+                lifecycle_teardown_script: None,
                 created_at: task.created_at,
                 last_opened_at: task.last_event_at,
             });
@@ -1803,6 +1809,7 @@ fn load_legacy_state() -> Option<SuperzentState> {
                 TaskStatus::Completed | TaskStatus::Failed | TaskStatus::NeedsAttention
             ),
             last_attention_reason: task.last_attention_reason.clone(),
+            lifecycle_teardown_script: None,
             created_at: task.created_at,
             last_opened_at: task.last_event_at,
         });

--- a/crates/superzent_ui/Cargo.toml
+++ b/crates/superzent_ui/Cargo.toml
@@ -25,6 +25,7 @@ git_ui.workspace = true
 gpui.workspace = true
 log.workspace = true
 menu.workspace = true
+notifications.workspace = true
 project.workspace = true
 project_panel.workspace = true
 recent_projects.workspace = true

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -9,7 +9,7 @@ use crate::acp_tabs::{CLAUDE_AGENT_NAME, CODEX_NAME, GEMINI_NAME};
 use agent_ui::{
     AgentNotification, AgentNotificationEvent, open_external_acp_tab, pane_has_external_acp_item,
 };
-use anyhow::Result;
+use anyhow::{Result, bail};
 use chrono::Utc;
 #[cfg(target_os = "macos")]
 use cocoa::base::{id, nil};
@@ -19,10 +19,11 @@ use git_ui::git_panel::GitPanel;
 use gpui::{
     Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, DismissEvent, Entity,
     EntityId, EventEmitter, FocusHandle, Focusable, MouseButton, MouseDownEvent, PathPromptOptions,
-    Point, PromptLevel, SharedString, Subscription, Task, WeakEntity, WindowHandle, actions,
-    anchored, deferred, px,
+    Point, PromptLevel, ScrollHandle, SharedString, Subscription, Task, WeakEntity, WindowHandle,
+    actions, anchored, deferred, px,
 };
 use menu;
+use notifications::status_toast::{StatusToast, ToastIcon};
 #[cfg(target_os = "macos")]
 use objc::{
     class,
@@ -73,8 +74,9 @@ use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 #[cfg(feature = "acp_tabs")]
 use ui::ContextMenuEntry;
 use ui::{
-    ButtonLike, Chip, CommonAnimationExt, ContextMenu, DropdownMenu, DropdownStyle, Icon,
-    Indicator, ListItem, Tab, Tooltip, prelude::*,
+    ButtonLike, Checkbox, Chip, CommonAnimationExt, ContextMenu, CopyButton, Disclosure,
+    DropdownMenu, DropdownStyle, ElevationIndex, Icon, Indicator, ListItem, Modal, ModalFooter,
+    ModalHeader, Section, Tab, ToggleState, Tooltip, prelude::*,
 };
 use uuid::Uuid;
 use workspace::{
@@ -1769,6 +1771,81 @@ fn show_workspace_toast_async(
     }
 }
 
+fn show_workspace_status_toast(
+    workspace_handle: &Entity<Workspace>,
+    message: impl Into<SharedString>,
+    icon: ToastIcon,
+    cx: &mut App,
+) {
+    let message: SharedString = message.into();
+    let status_toast = StatusToast::new(message, cx, move |this: StatusToast, _cx| {
+        this.icon(icon).dismiss_button(true)
+    });
+    workspace_handle.update(cx, |workspace, cx| {
+        workspace.toggle_status_toast(status_toast, cx);
+    });
+}
+
+fn clear_workspace_setup_attention(
+    store: &mut SuperzentStore,
+    workspace_id: &str,
+    cx: &mut Context<SuperzentStore>,
+) {
+    let should_clear = store
+        .workspace(workspace_id)
+        .and_then(|workspace| workspace.last_attention_reason.as_deref())
+        == Some(WORKSPACE_SETUP_IN_PROGRESS_REASON);
+
+    if should_clear {
+        store.set_workspace_attention(
+            workspace_id,
+            WorkspaceAttentionStatus::Idle,
+            false,
+            None,
+            cx,
+        );
+    }
+}
+
+fn can_mark_workspace_setup_attention(workspace: &WorkspaceEntry) -> bool {
+    workspace.attention_status == WorkspaceAttentionStatus::Idle && !workspace.review_pending
+}
+
+fn mark_workspace_setup_attention(
+    store: &mut SuperzentStore,
+    workspace_id: &str,
+    cx: &mut Context<SuperzentStore>,
+) {
+    let should_mark = store
+        .workspace(workspace_id)
+        .is_some_and(can_mark_workspace_setup_attention);
+
+    if should_mark {
+        store.set_workspace_attention(
+            workspace_id,
+            WorkspaceAttentionStatus::Working,
+            false,
+            Some(WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string()),
+            cx,
+        );
+    }
+}
+
+fn show_current_window_status_toast(
+    message: impl Into<SharedString>,
+    icon: ToastIcon,
+    cx: &mut AsyncWindowContext,
+) {
+    if let Err(error) = cx.update(|window, cx| {
+        let Some(workspace) = workspace_from_window(window, cx) else {
+            return;
+        };
+        show_workspace_status_toast(&workspace, message, icon, cx);
+    }) {
+        log::error!("failed to show current window status toast: {error:#}");
+    }
+}
+
 fn update_store_async<R>(
     store: &Entity<SuperzentStore>,
     cx: &mut AsyncWindowContext,
@@ -1785,7 +1862,42 @@ fn update_store_async<R>(
 
 struct WorkspaceCreationResult {
     workspace: WorkspaceEntry,
-    warning: Option<String>,
+    notice: Option<String>,
+}
+
+fn workspace_lifecycle_failure_prompt_detail(
+    workspace_entry: &WorkspaceEntry,
+    failure: &superzent_git::WorkspaceLifecycleFailure,
+    notice: Option<&str>,
+    force_delete: bool,
+) -> String {
+    let mut sections = vec![format!(
+        "Workspace `{}` at {} hit a {} failure.",
+        workspace_entry.name,
+        workspace_entry.display_path(),
+        failure.phase.label().to_lowercase()
+    )];
+
+    if let Some(notice) = notice.filter(|notice| !notice.trim().is_empty()) {
+        sections.push(notice.trim().to_string());
+    }
+
+    if force_delete {
+        sections.push(
+            "Choose `Delete Anyway` to retry deletion without running teardown again.".to_string(),
+        );
+    }
+
+    sections.push(failure.details());
+    sections.join("\n\n")
+}
+
+const WORKSPACE_SETUP_IN_PROGRESS_REASON: &str = "Setting up workspace…";
+fn workspace_setup_row_state(workspace: &WorkspaceEntry) -> Option<WorkspaceSetupRowState> {
+    match workspace.last_attention_reason.as_deref() {
+        Some(WORKSPACE_SETUP_IN_PROGRESS_REASON) => Some(WorkspaceSetupRowState::InProgress),
+        _ => None,
+    }
 }
 
 async fn resolve_remote_project_workspace(
@@ -1922,6 +2034,9 @@ async fn create_remote_workspace(
             last_attention_reason: existing_workspace
                 .as_ref()
                 .and_then(|workspace| workspace.last_attention_reason.clone()),
+            lifecycle_teardown_script: existing_workspace
+                .as_ref()
+                .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
             created_at: existing_workspace
                 .as_ref()
                 .map(|workspace| workspace.created_at)
@@ -1932,8 +2047,124 @@ async fn create_remote_workspace(
 
     Ok(WorkspaceCreationResult {
         workspace,
-        warning: None,
+        notice: None,
     })
+}
+
+async fn resolve_opened_workspace(
+    workspace_entry: &WorkspaceEntry,
+    _window_handle: gpui::AnyWindowHandle,
+    cx: &mut AsyncWindowContext,
+) -> Option<Entity<Workspace>> {
+    for _ in 0..20 {
+        let resolved = cx
+            .update(|window, cx| workspace_for_entry_in_window(window, cx, workspace_entry))
+            .ok()
+            .flatten();
+
+        if resolved.is_some() {
+            return resolved;
+        }
+
+        cx.background_executor()
+            .timer(Duration::from_millis(100))
+            .await;
+    }
+
+    cx.update(|window, cx| workspace_from_window(window, cx))
+        .ok()
+        .flatten()
+}
+
+async fn create_local_workspace(
+    project: ProjectEntry,
+    preset_id: String,
+    branch_name: String,
+    base_branch_override: Option<String>,
+    base_workspace_path: Option<PathBuf>,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+    persist_lifecycle_scripts: bool,
+    allow_dirty: bool,
+    cx: &mut AsyncWindowContext,
+) -> anyhow::Result<WorkspaceCreationResult> {
+    cx.background_spawn(async move {
+        superzent_git::create_workspace_without_setup(
+            &project,
+            &preset_id,
+            superzent_git::CreateWorkspaceOptions {
+                branch_name,
+                base_branch_override,
+                base_workspace_path,
+                setup_script,
+                teardown_script,
+                persist_lifecycle_scripts,
+                allow_dirty,
+            },
+        )
+        .map(|outcome| WorkspaceCreationResult {
+            workspace: outcome.workspace,
+            notice: outcome.notice,
+        })
+    })
+    .await
+}
+
+fn local_base_workspace_path_for_create_request(
+    workspace_handle: &Entity<Workspace>,
+    project: &ProjectEntry,
+    store: &SuperzentStore,
+    cx: &App,
+) -> Option<PathBuf> {
+    single_workspace_location_snapshot(workspace_handle, cx)
+        .and_then(|location| match location {
+            WorkspaceLocation::Local { worktree_path } => Some(worktree_path),
+            WorkspaceLocation::Ssh { .. } => None,
+        })
+        .or_else(|| {
+            store
+                .active_workspace()
+                .filter(|workspace_entry| workspace_entry.project_id == project.id)
+                .and_then(|workspace_entry| workspace_entry.local_worktree_path())
+                .map(Path::to_path_buf)
+        })
+        .or_else(|| {
+            workspace_handle
+                .read(cx)
+                .project()
+                .read(cx)
+                .visible_worktrees(cx)
+                .next()
+                .and_then(|worktree| {
+                    worktree
+                        .read(cx)
+                        .as_local()
+                        .map(|local| local.abs_path().to_path_buf())
+                })
+        })
+}
+
+fn move_changes_source_path(
+    base_workspace_path: Option<&Path>,
+    project: &ProjectEntry,
+) -> Option<PathBuf> {
+    base_workspace_path
+        .map(Path::to_path_buf)
+        .or_else(|| project.local_repo_root().map(Path::to_path_buf))
+}
+
+fn is_dirty_workspace_create_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .to_string()
+            .contains("commit or stash local changes before creating a managed workspace")
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DirtyWorkspaceCreateChoice {
+    CreateOnly,
+    CreateAndMoveChanges,
 }
 
 fn spawn_new_workspace_request(
@@ -1941,32 +2172,107 @@ fn spawn_new_workspace_request(
     app_state: Arc<WorkspaceAppState>,
     project: ProjectEntry,
     branch_name: String,
+    base_branch_override: Option<String>,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+    persist_lifecycle_scripts: bool,
     window: &mut Window,
     cx: &mut App,
 ) {
     let store = SuperzentStore::global(cx);
     let preset_id = store.read(cx).default_preset().id.clone();
+    let base_workspace_path = {
+        let store = store.read(cx);
+        local_base_workspace_path_for_create_request(&workspace_handle, &project, &store, cx)
+    };
     window
         .spawn(cx, async move |cx| {
+            let mut move_changes_failure: Option<String> = None;
             let outcome = match &project.location {
                 ProjectLocation::Local { .. } => {
-                    cx.background_spawn({
-                        let project = project.clone();
-                        let branch_name = branch_name.clone();
-                        let preset_id = preset_id.clone();
-                        async move {
-                            superzent_git::create_workspace(
-                                &project,
-                                &preset_id,
-                                superzent_git::CreateWorkspaceOptions { branch_name },
-                            )
-                            .map(|outcome| WorkspaceCreationResult {
-                                workspace: outcome.workspace,
-                                warning: outcome.warning,
-                            })
-                        }
-                    })
+                    match create_local_workspace(
+                        project.clone(),
+                        preset_id.clone(),
+                        branch_name.clone(),
+                        base_branch_override.clone(),
+                        base_workspace_path.clone(),
+                        setup_script.clone(),
+                        teardown_script.clone(),
+                        persist_lifecycle_scripts,
+                        false,
+                        cx,
+                    )
                     .await
+                    {
+                        Ok(outcome) => Ok(outcome),
+                        Err(error) if is_dirty_workspace_create_error(&error) => {
+                            let prompt = cx.update(|window, cx| {
+                                window.prompt(
+                                    PromptLevel::Warning,
+                                    "Create workspace with local changes?",
+                                    Some(
+                                        "The current workspace has uncommitted changes.\n\n`Create Only` makes the new workspace from the selected base branch and leaves your current changes where they are.\n\n`Create And Move Changes` makes the new workspace and then moves your tracked and untracked local changes into it.",
+                                    ),
+                                    &["Cancel", "Create Only", "Create And Move Changes"],
+                                    cx,
+                                )
+                            })?;
+
+                            let dirty_choice = match prompt.await {
+                                Ok(1) => Some(DirtyWorkspaceCreateChoice::CreateOnly),
+                                Ok(2) => Some(DirtyWorkspaceCreateChoice::CreateAndMoveChanges),
+                                _ => None,
+                            };
+
+                            let Some(dirty_choice) = dirty_choice else {
+                                return Ok::<(), anyhow::Error>(());
+                            };
+
+                            let outcome = create_local_workspace(
+                                project.clone(),
+                                preset_id.clone(),
+                                branch_name.clone(),
+                                base_branch_override.clone(),
+                                base_workspace_path.clone(),
+                                setup_script.clone(),
+                                teardown_script.clone(),
+                                persist_lifecycle_scripts,
+                                true,
+                                cx,
+                            )
+                            .await?;
+
+                            if dirty_choice == DirtyWorkspaceCreateChoice::CreateAndMoveChanges {
+                                let source_workspace_path = move_changes_source_path(
+                                    base_workspace_path.as_deref(),
+                                    &project,
+                                );
+                                let target_worktree_path = outcome
+                                    .workspace
+                                    .local_worktree_path()
+                                    .map(Path::to_path_buf);
+
+                                if let (Some(source_workspace_path), Some(target_worktree_path)) =
+                                    (source_workspace_path, target_worktree_path)
+                                {
+                                    if let Err(error) = cx
+                                        .background_spawn(async move {
+                                            superzent_git::move_changes_to_workspace(
+                                                &source_workspace_path,
+                                                &target_worktree_path,
+                                            )
+                                        })
+                                        .await
+                                    {
+                                        move_changes_failure = Some(error.to_string());
+                                    }
+                                }
+                            }
+
+                            Ok(outcome)
+                        }
+                        Err(error) => Err(error),
+                    }
                 }
                 ProjectLocation::Ssh { .. } => {
                     create_remote_workspace(
@@ -2016,28 +2322,195 @@ fn spawn_new_workspace_request(
                 return Ok::<(), anyhow::Error>(());
             }
 
-            if let Some(target_workspace) =
-                cx.update(|window, cx| workspace_for_entry_in_window(window, cx, &workspace_entry))?
+            let current_window_handle = cx.update(|window, _| window.window_handle())?;
+            let visible_workspace =
+                resolve_opened_workspace(&workspace_entry, current_window_handle, cx).await;
+
+            if let (Some(visible_workspace), Some(notice)) =
+                (visible_workspace.as_ref(), outcome.notice.clone())
             {
-                cx.update(|window, cx| {
-                    launch_workspace_preset(
-                        target_workspace,
-                        workspace_entry.clone(),
-                        preset_id.clone(),
-                        None,
-                        window,
-                        cx,
-                    );
-                    if let Some(warning) = outcome.warning.clone() {
-                        show_workspace_toast(&workspace_handle, warning, cx);
-                    }
+                cx.update(|_, cx| {
+                    show_workspace_toast(&visible_workspace, notice, cx);
                 })?;
+            }
+
+            let should_launch_preset = if matches!(project.location, ProjectLocation::Local { .. }) {
+                let project = project.clone();
+                let workspace_entry_for_setup = workspace_entry.clone();
+                let base_workspace_path = base_workspace_path.clone();
+                let setup_script = setup_script.clone();
+                if setup_script
+                    .as_ref()
+                    .map(|script| !script.trim().is_empty())
+                    .unwrap_or(false)
+                {
+                    let _ = update_store_async(&store, cx, |store, cx| {
+                        mark_workspace_setup_attention(store, &workspace_entry.id, cx);
+                    });
+                    let setup_result = cx
+                        .background_spawn(async move {
+                            superzent_git::run_workspace_setup(
+                                &project,
+                                &workspace_entry_for_setup,
+                                base_workspace_path.as_deref(),
+                                setup_script.as_deref(),
+                            )
+                        })
+                        .await;
+                    // Always resolve the currently *active* workspace at completion
+                    // time: the handle captured before setup may now point to a
+                    // hidden tab if the user navigated away, and toasts attached
+                    // to a hidden tab are never drawn. When nothing is active for
+                    // this entry we fall back to the current window so the user
+                    // still sees the result.
+                    //
+                    // The current window must be checked via `workspace_from_window`
+                    // (using the `Window` arg) because it's already on the stack
+                    // inside `cx.update`, so any `read_window`-based lookup
+                    // (including `WindowHandle::read_with`) would panic. The
+                    // iteration helper uses `WindowHandle::read` which skips the
+                    // stack-locked current window gracefully.
+                    let setup_visible_workspace = cx
+                        .update(|window, cx| {
+                            workspace_from_window(window, cx)
+                                .filter(|active| {
+                                    workspace_matches_entry(active, &workspace_entry, cx)
+                                })
+                                .or_else(|| {
+                                    currently_active_workspace_for_entry(&workspace_entry, cx)
+                                })
+                        })
+                        .ok()
+                        .flatten();
+
+                    match setup_result {
+                        Ok(()) => {
+                            let _ = update_store_async(&store, cx, |store, cx| {
+                                clear_workspace_setup_attention(store, &workspace_entry.id, cx);
+                            });
+                            if let Some(visible_workspace) = setup_visible_workspace.as_ref() {
+                                if let Err(error) = cx.update(|_, cx| {
+                                    show_workspace_status_toast(
+                                        visible_workspace,
+                                        format!("Setup finished for `{}`.", workspace_entry.name),
+                                        ToastIcon::new(IconName::Check).color(Color::Success),
+                                        cx,
+                                    );
+                                }) {
+                                    log::error!("failed to show workspace setup success toast: {error:#}");
+                                }
+                            } else {
+                                show_current_window_status_toast(
+                                    format!("Setup finished for `{}`.", workspace_entry.name),
+                                    ToastIcon::new(IconName::Check).color(Color::Success),
+                                    cx,
+                                );
+                            }
+                            true
+                        }
+                        Err(setup_failure) => {
+                            let _ = update_store_async(&store, cx, |store, cx| {
+                                clear_workspace_setup_attention(store, &workspace_entry.id, cx);
+                            });
+                            let prompt_detail = workspace_lifecycle_failure_prompt_detail(
+                                &workspace_entry,
+                                &setup_failure,
+                                outcome.notice.as_deref(),
+                                false,
+                            );
+                            let setup_prompt = cx.update(|window, cx| {
+                                // Prefer toasting the workspace where setup ran
+                                // when it's still the active tab; otherwise pop
+                                // the notice on the current window so the user
+                                // sees the failure regardless of navigation.
+                                if let Some(visible_workspace) =
+                                    setup_visible_workspace.as_ref()
+                                {
+                                    show_workspace_toast(
+                                        visible_workspace,
+                                        setup_failure.summary(),
+                                        cx,
+                                    );
+                                } else if let Some(current_workspace) =
+                                    workspace_from_window(window, cx)
+                                {
+                                    show_workspace_toast(
+                                        &current_workspace,
+                                        setup_failure.summary(),
+                                        cx,
+                                    );
+                                } else {
+                                    log::warn!(
+                                        "workspace setup failed and no window is available to show the error: {}",
+                                        setup_failure.summary()
+                                    );
+                                }
+                                window.prompt(
+                                    PromptLevel::Warning,
+                                    "Workspace created, but setup failed",
+                                    Some(&prompt_detail),
+                                    &["OK"],
+                                    cx,
+                                )
+                            })?;
+                            let _ = setup_prompt.await;
+                            false
+                        }
+                    }
+                } else {
+                    true
+                }
             } else {
-                show_workspace_toast_async(
-                    &workspace_handle,
-                    "Workspace opened, but its window could not be resolved.",
-                    cx,
-                );
+                true
+            };
+
+            if should_launch_preset {
+                let target_workspace = if let Some(visible_workspace) = visible_workspace.clone() {
+                    Some(visible_workspace)
+                } else {
+                    resolve_opened_workspace(&workspace_entry, current_window_handle, cx).await
+                };
+
+                if let Some(target_workspace) = target_workspace {
+                    cx.update(|window, cx| {
+                        launch_workspace_preset(
+                            target_workspace,
+                            workspace_entry.clone(),
+                            preset_id.clone(),
+                            None,
+                            window,
+                            cx,
+                        );
+                    })?;
+                } else {
+                    log::warn!(
+                        "workspace opened, but the new workspace view could not be resolved for preset launch"
+                    );
+                }
+            }
+
+            if let Some(move_changes_failure) = move_changes_failure.clone() {
+                if let Some(visible_workspace) = visible_workspace.as_ref() {
+                    let move_prompt = cx.update(|window, cx| {
+                        show_workspace_toast(
+                            visible_workspace,
+                            "Workspace created, but moving changes failed.",
+                            cx,
+                        );
+                        window.prompt(
+                            PromptLevel::Warning,
+                            "Workspace created, but moving changes failed",
+                            Some(&move_changes_failure),
+                            &["OK"],
+                            cx,
+                        )
+                    })?;
+                    let _ = move_prompt.await;
+                } else {
+                    log::warn!(
+                        "workspace change move failed before the new workspace view could be resolved: {move_changes_failure}"
+                    );
+                }
             }
 
             Ok::<(), anyhow::Error>(())
@@ -2203,7 +2676,23 @@ struct NewWorkspaceModal {
     workspace: WeakEntity<Workspace>,
     project: ProjectEntry,
     branch_name_editor: Entity<Editor>,
+    base_branch_editor: Entity<Editor>,
+    setup_script_editor: Entity<Editor>,
+    teardown_script_editor: Entity<Editor>,
+    show_more_options: bool,
+    save_lifecycle_scripts: bool,
+    active_script_target: Option<ScriptEditorTarget>,
+    scroll_handle: ScrollHandle,
+    base_branch_notice: Option<SharedString>,
+    base_branch_error: Option<SharedString>,
+    _subscriptions: Vec<Subscription>,
     last_error: Option<SharedString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScriptEditorTarget {
+    Setup,
+    Teardown,
 }
 
 impl EventEmitter<DismissEvent> for NewWorkspaceModal {}
@@ -2219,6 +2708,7 @@ impl NewWorkspaceModal {
     fn new(
         workspace: WeakEntity<Workspace>,
         project: ProjectEntry,
+        initial_base_workspace_path: Option<PathBuf>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -2227,13 +2717,220 @@ impl NewWorkspaceModal {
             editor.set_placeholder_text("feature/my-branch", window, cx);
             editor
         });
+        let base_branch_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("main", window, cx);
+            editor
+        });
+        let setup_script_editor = cx.new(|cx| {
+            let mut editor = Editor::auto_height(2, 6, window, cx);
+            editor.set_placeholder_text("cp \"$SUPERZENT_BASE_PATH\"/.env .env", window, cx);
+            editor
+        });
+        let teardown_script_editor = cx.new(|cx| {
+            let mut editor = Editor::auto_height(2, 6, window, cx);
+            editor.set_placeholder_text("cargo clean", window, cx);
+            editor
+        });
+
+        let mut subscriptions = Vec::new();
+        subscriptions.push(cx.subscribe(
+            &branch_name_editor,
+            |this, _, event: &EditorEvent, cx| {
+                let EditorEvent::Edited { .. } = event else {
+                    return;
+                };
+                if this.last_error.take().is_some() {
+                    cx.notify();
+                }
+            },
+        ));
+        subscriptions.push(cx.subscribe(
+            &base_branch_editor,
+            |this, _, event: &EditorEvent, cx| {
+                let EditorEvent::Edited { .. } = event else {
+                    return;
+                };
+                if this.last_error.take().is_some() {
+                    cx.notify();
+                }
+                if this.base_branch_notice.take().is_some()
+                    || this.base_branch_error.take().is_some()
+                {
+                    cx.notify();
+                }
+            },
+        ));
+        subscriptions.push(cx.subscribe(
+            &setup_script_editor,
+            |this, _, event: &EditorEvent, cx| match event {
+                EditorEvent::Edited { .. } => {
+                    if this.last_error.take().is_some() {
+                        cx.notify();
+                    }
+                }
+                EditorEvent::Focused | EditorEvent::FocusedIn => {
+                    this.active_script_target = Some(ScriptEditorTarget::Setup);
+                    cx.notify();
+                }
+                EditorEvent::Blurred => {
+                    if this.active_script_target == Some(ScriptEditorTarget::Setup) {
+                        this.active_script_target = None;
+                        cx.notify();
+                    }
+                }
+                _ => {}
+            },
+        ));
+        subscriptions.push(cx.subscribe(
+            &teardown_script_editor,
+            |this, _, event: &EditorEvent, cx| match event {
+                EditorEvent::Edited { .. } => {
+                    if this.last_error.take().is_some() {
+                        cx.notify();
+                    }
+                }
+                EditorEvent::Focused | EditorEvent::FocusedIn => {
+                    this.active_script_target = Some(ScriptEditorTarget::Teardown);
+                    cx.notify();
+                }
+                EditorEvent::Blurred => {
+                    if this.active_script_target == Some(ScriptEditorTarget::Teardown) {
+                        this.active_script_target = None;
+                        cx.notify();
+                    }
+                }
+                _ => {}
+            },
+        ));
+
+        let mut base_branch_notice = None;
+        let mut base_branch_error = None;
+        if matches!(project.location, ProjectLocation::Local { .. }) {
+            match superzent_git::resolve_workspace_base_branch_from_workspace(
+                &project,
+                initial_base_workspace_path.as_deref(),
+                None,
+            ) {
+                Ok(resolution) => {
+                    base_branch_editor.update(cx, |editor, cx| {
+                        editor.set_text(resolution.effective_base_branch.as_str(), window, cx);
+                    });
+                    base_branch_notice = resolution.notice.map(Into::into);
+                }
+                Err(error) => {
+                    base_branch_error = Some(error.to_string().into());
+                }
+            }
+            if let Ok(defaults) = superzent_git::workspace_lifecycle_defaults(&project) {
+                if let Some(setup_script) = defaults.setup_script {
+                    setup_script_editor.update(cx, |editor, cx| {
+                        editor.set_text(setup_script.as_str(), window, cx);
+                    });
+                }
+                if let Some(teardown_script) = defaults.teardown_script {
+                    teardown_script_editor.update(cx, |editor, cx| {
+                        editor.set_text(teardown_script.as_str(), window, cx);
+                    });
+                }
+            }
+        }
 
         Self {
             workspace,
             project,
             branch_name_editor,
+            base_branch_editor,
+            setup_script_editor,
+            teardown_script_editor,
+            show_more_options: false,
+            save_lifecycle_scripts: true,
+            active_script_target: None,
+            scroll_handle: ScrollHandle::new(),
+            base_branch_notice,
+            base_branch_error,
+            _subscriptions: subscriptions,
             last_error: None,
         }
+    }
+
+    fn base_branch(&self, cx: &App) -> Option<String> {
+        let base_branch = self.base_branch_editor.read(cx).text(cx);
+        let base_branch = base_branch.trim();
+        if base_branch.is_empty() {
+            None
+        } else {
+            Some(base_branch.to_string())
+        }
+    }
+
+    fn setup_script(&self, cx: &App) -> Option<String> {
+        let setup_script = self.setup_script_editor.read(cx).text(cx);
+        let setup_script = setup_script.trim();
+        if setup_script.is_empty() {
+            None
+        } else {
+            Some(setup_script.to_string())
+        }
+    }
+
+    fn teardown_script(&self, cx: &App) -> Option<String> {
+        let teardown_script = self.teardown_script_editor.read(cx).text(cx);
+        let teardown_script = teardown_script.trim();
+        if teardown_script.is_empty() {
+            None
+        } else {
+            Some(teardown_script.to_string())
+        }
+    }
+
+    fn insert_variable(&mut self, variable: &str, window: &mut Window, cx: &mut Context<Self>) {
+        let target = self
+            .active_script_target
+            .unwrap_or(ScriptEditorTarget::Setup);
+        let editor = match target {
+            ScriptEditorTarget::Setup => self.setup_script_editor.clone(),
+            ScriptEditorTarget::Teardown => self.teardown_script_editor.clone(),
+        };
+
+        editor.update(cx, |editor, cx| {
+            let existing_text = editor.text(cx);
+            let separator = if existing_text.is_empty()
+                || existing_text.ends_with(' ')
+                || existing_text.ends_with('\n')
+            {
+                ""
+            } else {
+                " "
+            };
+            let next_text = format!("{existing_text}{separator}{variable}");
+            editor.set_text(next_text.as_str(), window, cx);
+            editor.focus_handle(cx).focus(window, cx);
+        });
+    }
+
+    fn render_variable_helper(
+        &self,
+        id: &'static str,
+        variable: &'static str,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        h_flex()
+            .gap_1()
+            .items_center()
+            .child(
+                ButtonLike::new(format!("{id}-insert"))
+                    .style(ButtonStyle::Subtle)
+                    .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                        this.insert_variable(variable, window, cx);
+                    }))
+                    .child(Chip::new(variable).label_color(Color::Accent)),
+            )
+            .child(
+                CopyButton::new(format!("{id}-copy"), variable)
+                    .tooltip_label("Copy variable")
+                    .icon_size(IconSize::XSmall),
+            )
     }
 
     fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
@@ -2255,6 +2952,12 @@ impl NewWorkspaceModal {
             return;
         }
 
+        if let Some(base_branch_error) = self.base_branch_error.clone() {
+            self.last_error = Some(base_branch_error);
+            cx.notify();
+            return;
+        }
+
         let app_state = workspace_handle.read(cx).app_state().clone();
 
         spawn_new_workspace_request(
@@ -2262,6 +2965,10 @@ impl NewWorkspaceModal {
             app_state,
             self.project.clone(),
             branch_name,
+            self.base_branch(cx),
+            self.setup_script(cx),
+            self.teardown_script(cx),
+            self.save_lifecycle_scripts,
             window,
             cx,
         );
@@ -2271,64 +2978,193 @@ impl NewWorkspaceModal {
 }
 
 impl Render for NewWorkspaceModal {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .key_context("SuperzentNewWorkspaceModal")
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::confirm))
             .elevation_3(cx)
             .w(px(480.))
+            .max_h(vh(0.8, window))
             .overflow_hidden()
-            .bg(cx.theme().colors().editor_background)
-            .border_1()
-            .border_color(cx.theme().colors().border)
-            .rounded_lg()
             .child(
-                v_flex()
-                    .gap_3()
-                    .p_4()
-                    .child(
-                        v_flex()
-                            .gap_1()
-                            .child(Label::new("Create Workspace").size(LabelSize::Large))
-                            .child(
-                                Label::new(format!(
-                                    "Create a managed workspace for {}.",
-                                    self.project.name
-                                ))
-                                .size(LabelSize::Small)
-                                .color(Color::Muted),
-                            ),
+                Modal::new("superzent-new-workspace-modal", Some(self.scroll_handle.clone()))
+                    .header(
+                        ModalHeader::new()
+                            .headline("Create Workspace")
+                            .description(format!(
+                                "Create a managed workspace for {}.",
+                                self.project.name
+                            )),
                     )
-                    .child(
-                        v_flex()
-                            .gap_1()
-                            .child(Label::new("Branch Name").size(LabelSize::Small))
-                            .child(self.branch_name_editor.clone()),
+                    .section(
+                        Section::new().child(
+                            v_flex()
+                                .gap_3()
+                                .child(
+                                    v_flex()
+                                        .gap_1()
+                                        .child(Label::new("Branch Name").size(LabelSize::Small))
+                                        .child(self.branch_name_editor.clone()),
+                                )
+                                .when(
+                                    matches!(self.project.location, ProjectLocation::Local { .. }),
+                                    |this| {
+                                        this.child(
+                                            v_flex()
+                                                .gap_1()
+                                                .child(Label::new("Base Branch").size(LabelSize::Small))
+                                                .child(self.base_branch_editor.clone())
+                                                .when_some(self.base_branch_notice.clone(), |this, notice| {
+                                                    this.child(
+                                                        Label::new(notice)
+                                                            .size(LabelSize::Small)
+                                                            .color(Color::Warning),
+                                                    )
+                                                })
+                                                .when_some(self.base_branch_error.clone(), |this, error| {
+                                                    this.child(
+                                                        Label::new(error)
+                                                            .size(LabelSize::Small)
+                                                            .color(Color::Error),
+                                                    )
+                                                })
+                                                .child(
+                                                    div()
+                                                        .w_full()
+                                                        .my_2()
+                                                        .border_t_1()
+                                                        .border_color(
+                                                            cx.theme().colors().border_variant,
+                                                        ),
+                                                )
+                                                .child(
+                                                    h_flex()
+                                                        .gap_1()
+                                                        .items_center()
+                                                        .child(
+                                                            Disclosure::new(
+                                                                "superzent-new-workspace-more",
+                                                                self.show_more_options,
+                                                            )
+                                                            .on_click(cx.listener(
+                                                                |this, _: &ClickEvent, _, cx| {
+                                                                    this.show_more_options =
+                                                                        !this.show_more_options;
+                                                                    cx.notify();
+                                                                },
+                                                            )),
+                                                        )
+                                                        .child(
+                                                            Label::new("More")
+                                                                .size(LabelSize::Small)
+                                                                .color(Color::Muted),
+                                                        ),
+                                                )
+                                                .when(self.show_more_options, |this| {
+                                                    this.child(
+                                                        v_flex()
+                                                            .gap_2()
+                                                            .pt_2()
+                                                            .child(
+                                                                v_flex()
+                                                                    .gap_1()
+                                                                    .child(
+                                                                        Label::new("Setup Script")
+                                                                            .size(LabelSize::Small),
+                                                                    )
+                                                                    .child(self.setup_script_editor.clone()),
+                                                            )
+                                                            .child(
+                                                                v_flex()
+                                                                    .gap_1()
+                                                                    .child(
+                                                                        Label::new("Teardown Script")
+                                                                            .size(LabelSize::Small),
+                                                                    )
+                                                                    .child(self.teardown_script_editor.clone()),
+                                                            )
+                                                            .child(
+                                                                v_flex()
+                                                                    .gap_1()
+                                                                    .child(
+                                                                        Label::new("Available Variables")
+                                                                            .size(LabelSize::Small)
+                                                                            .color(Color::Muted),
+                                                                    )
+                                                                    .child(
+                                                                        h_flex()
+                                                                            .gap_2()
+                                                                            .flex_wrap()
+                                                                            .child(self.render_variable_helper(
+                                                                                "superzent-base-path",
+                                                                                "$SUPERZENT_BASE_PATH",
+                                                                                cx,
+                                                                            ))
+                                                                            .child(self.render_variable_helper(
+                                                                                "superzent-worktree-path",
+                                                                                "$SUPERZENT_WORKTREE_PATH",
+                                                                                cx,
+                                                                            ))
+                                                                            .child(self.render_variable_helper(
+                                                                                "superzent-root-path",
+                                                                                "$SUPERZENT_ROOT_PATH",
+                                                                                cx,
+                                                                            )),
+                                                                    ),
+                                                            )
+                                                            .child(
+                                                                Checkbox::new(
+                                                                    "superzent-new-workspace-save-lifecycle",
+                                                                    self.save_lifecycle_scripts.into(),
+                                                                )
+                                                                .label(
+                                                                    "Save these script commands as the default for this repository",
+                                                                )
+                                                                .fill()
+                                                                .elevation(ElevationIndex::Surface)
+                                                                .label_size(LabelSize::Small)
+                                                                .on_click(cx.listener(
+                                                                    |this, selection, _, cx| {
+                                                                        this.save_lifecycle_scripts =
+                                                                            *selection == ToggleState::Selected;
+                                                                        cx.notify();
+                                                                    },
+                                                                )),
+                                                            ),
+                                                    )
+                                                }),
+                                        )
+                                    },
+                                )
+                                .when_some(self.last_error.clone(), |this, error| {
+                                    this.child(
+                                        Label::new(error)
+                                            .size(LabelSize::Small)
+                                            .color(Color::Error),
+                                    )
+                                }),
+                        ),
                     )
-                    .when_some(self.last_error.clone(), |this, error| {
-                        this.child(Label::new(error).size(LabelSize::Small).color(Color::Error))
-                    }),
-            )
-            .child(
-                h_flex()
-                    .justify_end()
-                    .gap_2()
-                    .px_4()
-                    .pb_4()
-                    .child(
-                        Button::new("superzent-new-workspace-cancel", "Cancel")
-                            .style(ButtonStyle::Subtle)
-                            .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
-                                this.cancel(&menu::Cancel, window, cx);
-                            })),
-                    )
-                    .child(
-                        Button::new("superzent-new-workspace-create", "Create")
-                            .style(ButtonStyle::Filled)
-                            .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
-                                this.confirm(&menu::Confirm, window, cx);
-                            })),
+                    .footer(
+                        ModalFooter::new().end_slot(
+                            h_flex()
+                                .gap_2()
+                                .child(
+                                    Button::new("superzent-new-workspace-cancel", "Cancel")
+                                        .style(ButtonStyle::Subtle)
+                                        .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                                            this.cancel(&menu::Cancel, window, cx);
+                                        })),
+                                )
+                                .child(
+                                    Button::new("superzent-new-workspace-create", "Create")
+                                        .style(ButtonStyle::Filled)
+                                        .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                                            this.confirm(&menu::Confirm, window, cx);
+                                        })),
+                                ),
+                        ),
                     ),
             )
     }
@@ -3295,6 +4131,15 @@ impl SuperzentSidebar {
         let row_status_pill = match workspace_row_status_kind(workspace, is_open_in_current_window)
         {
             WorkspaceRowStatusKind::Hidden => None,
+            WorkspaceRowStatusKind::SetupInProgress => Some(render_workspace_setup_status_pill(
+                "Setting up…",
+                Color::Warning,
+                workspace
+                    .last_attention_reason
+                    .clone()
+                    .unwrap_or_else(|| WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string()),
+                cx,
+            )),
             WorkspaceRowStatusKind::Open => Some(render_workspace_open_pill(cx)),
             WorkspaceRowStatusKind::GitChanges => render_workspace_git_status_pill(workspace, cx),
         };
@@ -4615,8 +5460,20 @@ fn open_new_workspace_modal(
     cx: &mut Context<Workspace>,
 ) {
     let workspace_handle = cx.entity().downgrade();
+    let initial_base_workspace_path = SuperzentStore::global(cx)
+        .read(cx)
+        .active_workspace()
+        .filter(|workspace_entry| workspace_entry.project_id == project.id)
+        .and_then(|workspace_entry| workspace_entry.local_worktree_path())
+        .map(Path::to_path_buf);
     workspace.toggle_modal(window, cx, move |window, cx| {
-        NewWorkspaceModal::new(workspace_handle.clone(), project, window, cx)
+        NewWorkspaceModal::new(
+            workspace_handle.clone(),
+            project,
+            initial_base_workspace_path,
+            window,
+            cx,
+        )
     });
 }
 
@@ -4845,7 +5702,21 @@ fn run_delete_workspace_entry(
     );
     let app_state = workspace.app_state().clone();
 
+    // Block any new opens of this workspace for the duration of the delete
+    // flow — including while the confirmation prompt is showing. Without this
+    // guard, a late open during the prompt (or while the background delete
+    // is running) would leave a stale tab behind: once the worktree files
+    // are gone the post-delete re-scan can't rediscover that instance
+    // because it matches by path via `visible_worktrees()`.
+    let delete_location = workspace_entry.location.clone();
+    register_in_flight_workspace_delete(delete_location.clone(), cx);
+
     cx.spawn_in(window, async move |this, cx| {
+        enum DeleteWorkspaceResult {
+            Deleted { cleanup_error: Option<String> },
+            BlockedByTeardown(superzent_git::WorkspaceLifecycleFailure),
+        }
+
         if prompt.await != Ok(1) {
             if let Some(sidebar) = deleting_sidebar.as_ref() {
                 sidebar
@@ -4854,20 +5725,39 @@ fn run_delete_workspace_entry(
                     })
                     .ok();
             }
+            cx.update(|_, cx| {
+                unregister_in_flight_workspace_delete(&delete_location, cx);
+            })
+            .ok();
             return anyhow::Ok(());
         }
 
-        let delete_result: anyhow::Result<()> = async {
+        let removal_targets =
+            cx.update(|_, cx| workspace_removal_targets_for_entry(&workspace_entry, cx))?;
+
+        let delete_result: anyhow::Result<DeleteWorkspaceResult> = async {
             let workspace_to_delete = workspace_entry.clone();
             match &project.location {
                 ProjectLocation::Local { repo_root } => {
-                    cx.background_spawn({
-                        let repo_root = repo_root.clone();
-                        async move {
-                            superzent_git::delete_workspace(&workspace_to_delete, &repo_root, false)
+                    let delete_outcome = cx
+                        .background_spawn({
+                            let repo_root = repo_root.clone();
+                            async move {
+                                superzent_git::delete_workspace(
+                                    &workspace_to_delete,
+                                    &repo_root,
+                                    false,
+                                )
+                            }
+                        })
+                        .await?;
+
+                    match delete_outcome {
+                        superzent_git::WorkspaceDeleteOutcome::Deleted => {}
+                        superzent_git::WorkspaceDeleteOutcome::BlockedByTeardown(failure) => {
+                            return Ok(DeleteWorkspaceResult::BlockedByTeardown(failure));
                         }
-                    })
-                    .await?;
+                    }
                 }
                 ProjectLocation::Ssh { .. } => {
                     let (project_workspace, _) = resolve_remote_project_workspace(
@@ -4895,31 +5785,122 @@ fn run_delete_workspace_entry(
                 }
             }
 
-            close_workspace_in_all_windows(
+            let cleanup_error = close_workspace_in_all_windows(
                 workspace_entry.clone(),
                 fallback_workspace.clone(),
                 app_state.clone(),
+                Some(removal_targets.clone()),
                 cx,
             )
-            .await?;
+            .await
+            .err()
+            .map(|error| error.to_string());
 
-            Ok(())
+            Ok(DeleteWorkspaceResult::Deleted { cleanup_error })
         }
         .await;
 
-        this.update_in(cx, |workspace, _window, cx| match delete_result {
-            Ok(()) => {
-                store.update(cx, |store, cx| {
-                    store.remove_workspace(&workspace_entry.id, cx);
-                });
+        let mut force_delete_result: Option<anyhow::Result<DeleteWorkspaceResult>> = None;
+        if let Ok(DeleteWorkspaceResult::BlockedByTeardown(failure)) = &delete_result {
+            let prompt_detail =
+                workspace_lifecycle_failure_prompt_detail(&workspace_entry, failure, None, true);
+            let retry_prompt = this.update_in(cx, |workspace, window, cx| {
                 workspace.show_toast(
                     Toast::new(
                         NotificationId::unique::<SuperzentSidebar>(),
-                        format!("Deleted {}", workspace_entry.name),
+                        failure.summary(),
                     ),
                     cx,
                 );
+                window.prompt(
+                    PromptLevel::Warning,
+                    "Workspace teardown failed",
+                    Some(&prompt_detail),
+                    &["Cancel", "Delete Anyway"],
+                    cx,
+                )
+            })?;
+
+            if retry_prompt.await == Ok(1) {
+                force_delete_result = Some(
+                    async {
+                        let workspace_to_delete = workspace_entry.clone();
+                        match &project.location {
+                            ProjectLocation::Local { repo_root } => {
+                                let delete_outcome = cx
+                                    .background_spawn({
+                                        let repo_root = repo_root.clone();
+                                        async move {
+                                            superzent_git::delete_workspace(
+                                                &workspace_to_delete,
+                                                &repo_root,
+                                                true,
+                                            )
+                                        }
+                                    })
+                                    .await?;
+                                match delete_outcome {
+                                    superzent_git::WorkspaceDeleteOutcome::Deleted => {}
+                                    superzent_git::WorkspaceDeleteOutcome::BlockedByTeardown(_) => {
+                                        bail!("force delete unexpectedly retried teardown")
+                                    }
+                                }
+                            }
+                            ProjectLocation::Ssh { .. } => {
+                                bail!("force delete is only supported for local workspaces")
+                            }
+                        }
+
+                        let cleanup_error = close_workspace_in_all_windows(
+                            workspace_entry.clone(),
+                            fallback_workspace.clone(),
+                            app_state.clone(),
+                            Some(removal_targets.clone()),
+                            cx,
+                        )
+                        .await
+                        .err()
+                        .map(|error| error.to_string());
+
+                        Ok(DeleteWorkspaceResult::Deleted { cleanup_error })
+                    }
+                    .await,
+                );
             }
+        }
+
+        let delete_result = force_delete_result.unwrap_or(delete_result);
+
+        this.update_in(cx, |workspace, _window, cx| match delete_result {
+            Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
+                store.update(cx, |store, cx| {
+                    store.remove_workspace(&workspace_entry.id, cx);
+                });
+                if let Some(cleanup_error) = cleanup_error {
+                    log::error!(
+                        "workspace delete succeeded on disk but cleanup failed: {cleanup_error}"
+                    );
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<SuperzentSidebar>(),
+                            format!(
+                                "Deleted {}, but some open windows may need manual cleanup.",
+                                workspace_entry.name
+                            ),
+                        ),
+                        cx,
+                    );
+                } else {
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<SuperzentSidebar>(),
+                            format!("Deleted {}", workspace_entry.name),
+                        ),
+                        cx,
+                    );
+                }
+            }
+            Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
             Err(error) => {
                 workspace.show_toast(
                     Toast::new(
@@ -4939,6 +5920,11 @@ fn run_delete_workspace_entry(
                 })
                 .ok();
         }
+
+        cx.update(|_, cx| {
+            unregister_in_flight_workspace_delete(&delete_location, cx);
+        })
+        .ok();
 
         anyhow::Ok(())
     })
@@ -5034,6 +6020,7 @@ fn run_sync_project_worktrees(
                     removed_workspace.clone(),
                     fallback_workspace.clone(),
                     app_state.clone(),
+                    None,
                     cx,
                 )
                 .await?;
@@ -5253,18 +6240,24 @@ async fn close_workspace_in_all_windows(
     workspace_entry: WorkspaceEntry,
     fallback_workspace: Option<WorkspaceEntry>,
     app_state: Arc<WorkspaceAppState>,
+    removal_targets: Option<Vec<WorkspaceWindowRemovalTarget>>,
     cx: &mut gpui::AsyncApp,
 ) -> anyhow::Result<()> {
-    let Some(serialized_location) = serialized_workspace_location_for_workspace(&workspace_entry)
-    else {
-        return Ok(());
-    };
-    let workspace_windows =
-        cx.update(|cx| workspace_windows_for_location(&serialized_location, cx));
+    let mut removal_targets = removal_targets.unwrap_or_default();
+    let current_removal_targets =
+        cx.update(|cx| workspace_removal_targets_for_entry(&workspace_entry, cx));
+    if removal_targets.is_empty() {
+        removal_targets = current_removal_targets;
+    } else {
+        removal_targets.extend(current_removal_targets);
+    }
 
-    for workspace_window in workspace_windows {
-        let matching_indexes = match workspace_window.update(cx, |multi_workspace, _, cx| {
-            matching_workspace_indexes(multi_workspace, std::slice::from_ref(&workspace_entry), cx)
+    for removal_target in removal_targets {
+        let workspace_window = removal_target.window;
+        let workspace_ids = removal_target.workspace_ids;
+
+        let matching_indexes = match workspace_window.update(cx, |multi_workspace, _, _| {
+            matching_workspace_indexes_for_ids(multi_workspace, &workspace_ids)
         }) {
             Ok(matching_indexes) => matching_indexes,
             Err(_) => continue,
@@ -5291,8 +6284,8 @@ async fn close_workspace_in_all_windows(
             .await?;
         }
 
-        let matching_indexes = match workspace_window.update(cx, |multi_workspace, _, cx| {
-            matching_workspace_indexes(multi_workspace, std::slice::from_ref(&workspace_entry), cx)
+        let matching_indexes = match workspace_window.update(cx, |multi_workspace, _, _| {
+            matching_workspace_indexes_for_ids(multi_workspace, &workspace_ids)
         }) {
             Ok(matching_indexes) => matching_indexes,
             Err(_) => continue,
@@ -5372,6 +6365,60 @@ fn matching_workspace_indexes(
                 .any(|workspace_entry| {
                     workspace_matches_entry(workspace_handle, workspace_entry, cx)
                 })
+                .then_some(index)
+        })
+        .collect()
+}
+
+#[derive(Clone)]
+struct WorkspaceWindowRemovalTarget {
+    window: WindowHandle<MultiWorkspace>,
+    workspace_ids: Vec<EntityId>,
+}
+
+fn workspace_removal_targets_for_entry(
+    workspace_entry: &WorkspaceEntry,
+    cx: &App,
+) -> Vec<WorkspaceWindowRemovalTarget> {
+    let Some(serialized_location) = serialized_workspace_location_for_workspace(workspace_entry)
+    else {
+        return Vec::new();
+    };
+
+    workspace_windows_for_location(&serialized_location, cx)
+        .into_iter()
+        .filter_map(|window| {
+            // `WindowHandle::read` returns Err for a stack-locked current
+            // window instead of panicking (unlike `read_with`), so this
+            // iteration is safe even when called from inside `cx.update`.
+            let multi_workspace = window.read(cx).ok()?;
+            let workspace_ids: Vec<_> = multi_workspace
+                .workspaces()
+                .iter()
+                .filter(|workspace| workspace_matches_entry(workspace, workspace_entry, cx))
+                .map(|workspace| workspace.entity_id())
+                .collect();
+
+            (!workspace_ids.is_empty()).then_some(WorkspaceWindowRemovalTarget {
+                window,
+                workspace_ids,
+            })
+        })
+        .collect()
+}
+
+fn matching_workspace_indexes_for_ids(
+    multi_workspace: &MultiWorkspace,
+    workspace_ids: &[EntityId],
+) -> Vec<usize> {
+    multi_workspace
+        .workspaces()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, workspace_handle)| {
+            workspace_ids
+                .iter()
+                .any(|workspace_id| *workspace_id == workspace_handle.entity_id())
                 .then_some(index)
         })
         .collect()
@@ -5529,6 +6576,20 @@ fn open_workspace_entry(
     window: &mut gpui::Window,
     cx: &mut App,
 ) -> Task<anyhow::Result<()>> {
+    if is_workspace_location_being_deleted(&workspace_entry.location, cx) {
+        if let Some(current_workspace) = workspace_from_window(window, cx) {
+            show_workspace_toast(
+                &current_workspace,
+                format!("Workspace `{}` is being deleted.", workspace_entry.name),
+                cx,
+            );
+        }
+        return Task::ready(Err(anyhow::anyhow!(
+            "workspace `{}` is being deleted",
+            workspace_entry.name
+        )));
+    }
+
     match &workspace_entry.location {
         WorkspaceLocation::Local { worktree_path } => {
             open_local_workspace_path(worktree_path.clone(), app_state, window, cx)
@@ -5802,19 +6863,45 @@ fn workspace_for_entry_in_any_window(
     workspace_entry: &WorkspaceEntry,
     cx: &App,
 ) -> Option<Entity<Workspace>> {
+    // Uses `WindowHandle::read` (graceful Err on stack-lock) so this helper
+    // is safe to call from inside `cx.update(|_, cx| ...)` — the current
+    // window is skipped rather than panicking. Callers that must also match
+    // the current window should check it first via `workspace_for_entry_in_window`.
     ordered_multi_workspace_windows(cx)
         .into_iter()
-        .find_map(|window| {
-            window
-                .read_with(cx, |multi_workspace, cx| {
-                    multi_workspace
-                        .workspaces()
-                        .iter()
-                        .find(|workspace| workspace_matches_entry(workspace, workspace_entry, cx))
-                        .cloned()
-                })
-                .ok()
-                .flatten()
+        .find_map(|handle| {
+            let multi_workspace = handle.read(cx).ok()?;
+            multi_workspace
+                .workspaces()
+                .iter()
+                .find(|workspace| workspace_matches_entry(workspace, workspace_entry, cx))
+                .cloned()
+        })
+}
+
+/// Returns the workspace entity only if it's the *currently visible* (active)
+/// tab inside some MultiWorkspace window **other than the current one**.
+/// Toasts attached to a workspace are only rendered by the bottom-right
+/// status layer when that workspace is the active tab, so callers that need
+/// to guarantee visibility must use this helper (combined with a separate
+/// current-window check) instead of `workspace_for_entry_in_any_window`,
+/// which would also match hidden tabs.
+///
+/// Uses `WindowHandle::read` (which returns `Err` for stack-locked windows)
+/// rather than `read_with` (which panics via `cx.read_window`). This means
+/// the current window is automatically skipped when called from inside
+/// `cx.update(|_, cx| ...)` — callers must check the current window
+/// separately.
+fn currently_active_workspace_for_entry(
+    workspace_entry: &WorkspaceEntry,
+    cx: &App,
+) -> Option<Entity<Workspace>> {
+    ordered_multi_workspace_windows(cx)
+        .into_iter()
+        .find_map(|handle| {
+            let multi_workspace = handle.read(cx).ok()?;
+            let active = multi_workspace.workspace().clone();
+            workspace_matches_entry(&active, workspace_entry, cx).then_some(active)
         })
 }
 
@@ -5829,23 +6916,20 @@ fn workspace_for_project_in_any_window(
         .cloned()
         .collect::<Vec<_>>();
 
+    // Uses `WindowHandle::read` (graceful Err on stack-lock) so this helper
+    // is safe to call from inside `cx.update(|_, cx| ...)` — the current
+    // window is skipped rather than panicking.
     ordered_multi_workspace_windows(cx)
         .into_iter()
-        .find_map(|window| {
-            window
-                .read_with(cx, |multi_workspace, cx| {
-                    project_workspaces.iter().find_map(|workspace_entry| {
-                        multi_workspace
-                            .workspaces()
-                            .iter()
-                            .find(|workspace| {
-                                workspace_matches_entry(workspace, workspace_entry, cx)
-                            })
-                            .cloned()
-                    })
-                })
-                .ok()
-                .flatten()
+        .find_map(|handle| {
+            let multi_workspace = handle.read(cx).ok()?;
+            project_workspaces.iter().find_map(|workspace_entry| {
+                multi_workspace
+                    .workspaces()
+                    .iter()
+                    .find(|workspace| workspace_matches_entry(workspace, workspace_entry, cx))
+                    .cloned()
+            })
         })
 }
 
@@ -5855,6 +6939,46 @@ fn ordered_multi_workspace_windows(cx: &App) -> Vec<WindowHandle<MultiWorkspace>
         .into_iter()
         .filter_map(|window| window.downcast::<MultiWorkspace>())
         .collect()
+}
+
+/// Locations of workspaces that are currently in the middle of a delete flow
+/// (from the moment the confirmation prompt is shown until cleanup finishes).
+///
+/// We track these so that `open_workspace_entry` can refuse to open a workspace
+/// whose worktree is about to be (or has just been) removed. Without this
+/// guard, a late open during the delete prompt could leave a stale tab behind:
+/// the post-delete re-scan in `close_workspace_in_all_windows` depends on
+/// `visible_worktrees()`, which no longer contains the deleted path, so late
+/// instances would escape cleanup.
+#[derive(Default)]
+struct InFlightWorkspaceDeletes {
+    locations: Vec<WorkspaceLocation>,
+}
+
+impl gpui::Global for InFlightWorkspaceDeletes {}
+
+fn register_in_flight_workspace_delete(location: WorkspaceLocation, cx: &mut App) {
+    cx.default_global::<InFlightWorkspaceDeletes>()
+        .locations
+        .push(location);
+}
+
+fn unregister_in_flight_workspace_delete(location: &WorkspaceLocation, cx: &mut App) {
+    if cx.has_global::<InFlightWorkspaceDeletes>() {
+        cx.global_mut::<InFlightWorkspaceDeletes>()
+            .locations
+            .retain(|existing| existing != location);
+    }
+}
+
+fn is_workspace_location_being_deleted(location: &WorkspaceLocation, cx: &App) -> bool {
+    cx.try_global::<InFlightWorkspaceDeletes>()
+        .is_some_and(|in_flight| {
+            in_flight
+                .locations
+                .iter()
+                .any(|existing| existing == location)
+        })
 }
 
 fn fallback_notification_window(cx: &App) -> Option<WindowHandle<MultiWorkspace>> {
@@ -6136,6 +7260,9 @@ fn build_synced_local_workspace_entry(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
+        lifecycle_teardown_script: existing_workspace
+            .as_ref()
+            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -6187,6 +7314,9 @@ fn build_local_workspace_bundle(
     let WorkspaceLocation::Local { worktree_path } = &workspace_location else {
         return None;
     };
+    if !worktree_path.exists() {
+        return None;
+    }
 
     let project_handle = workspace.read(cx).project();
     let project = project_handle.read(cx);
@@ -6305,6 +7435,9 @@ fn build_local_workspace_bundle(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
+        lifecycle_teardown_script: existing_workspace
+            .as_ref()
+            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -6452,6 +7585,9 @@ fn build_remote_workspace_bundle(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
+        lifecycle_teardown_script: existing_workspace
+            .as_ref()
+            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -6521,6 +7657,12 @@ fn workspace_row_status_kind(
         return WorkspaceRowStatusKind::Hidden;
     }
 
+    if let Some(setup_state) = workspace_setup_row_state(workspace) {
+        return match setup_state {
+            WorkspaceSetupRowState::InProgress => WorkspaceRowStatusKind::SetupInProgress,
+        };
+    }
+
     if workspace_git_status_visual_summary(workspace).is_some() {
         WorkspaceRowStatusKind::GitChanges
     } else {
@@ -6531,8 +7673,14 @@ fn workspace_row_status_kind(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WorkspaceRowStatusKind {
     Hidden,
+    SetupInProgress,
     Open,
     GitChanges,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WorkspaceSetupRowState {
+    InProgress,
 }
 
 fn render_workspace_open_pill(cx: &mut Context<SuperzentSidebar>) -> gpui::AnyElement {
@@ -6540,6 +7688,20 @@ fn render_workspace_open_pill(cx: &mut Context<SuperzentSidebar>) -> gpui::AnyEl
         .label_color(Color::Muted)
         .bg_color(cx.theme().colors().element_background)
         .border_color(cx.theme().colors().border_variant)
+        .into_any_element()
+}
+
+fn render_workspace_setup_status_pill(
+    label: &'static str,
+    color: Color,
+    tooltip: String,
+    cx: &mut Context<SuperzentSidebar>,
+) -> gpui::AnyElement {
+    Chip::new(label)
+        .label_color(color)
+        .bg_color(cx.theme().colors().element_background)
+        .border_color(cx.theme().colors().border_variant)
+        .tooltip(move |window, cx| ui::Tooltip::text(tooltip.clone())(window, cx))
         .into_any_element()
 }
 
@@ -7008,6 +8170,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            lifecycle_teardown_script: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -7031,6 +8194,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            lifecycle_teardown_script: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -7068,9 +8232,60 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
+            lifecycle_teardown_script: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
+    }
+
+    fn lifecycle_failure(
+        phase: superzent_git::WorkspaceLifecyclePhase,
+    ) -> superzent_git::WorkspaceLifecycleFailure {
+        superzent_git::WorkspaceLifecycleFailure {
+            phase,
+            command: "echo failure".to_string(),
+            exit_code: Some(1),
+            stdout: "stdout".to_string(),
+            stderr: "stderr".to_string(),
+        }
+    }
+
+    #[test]
+    fn move_changes_source_path_prefers_base_workspace_path() {
+        let project = ProjectEntry {
+            id: "project".to_string(),
+            name: "project".to_string(),
+            location: ProjectLocation::Local {
+                repo_root: PathBuf::from("/tmp/repo"),
+            },
+            collapsed: false,
+            created_at: Utc::now(),
+            last_opened_at: Utc::now(),
+        };
+
+        assert_eq!(
+            move_changes_source_path(Some(Path::new("/tmp/repo/worktrees/feature")), &project),
+            Some(PathBuf::from("/tmp/repo/worktrees/feature"))
+        );
+    }
+
+    #[test]
+    fn move_changes_source_path_falls_back_to_project_root() {
+        let project = ProjectEntry {
+            id: "project".to_string(),
+            name: "project".to_string(),
+            location: ProjectLocation::Local {
+                repo_root: PathBuf::from("/tmp/repo"),
+            },
+            collapsed: false,
+            created_at: Utc::now(),
+            last_opened_at: Utc::now(),
+        };
+
+        assert_eq!(
+            move_changes_source_path(None, &project),
+            Some(PathBuf::from("/tmp/repo"))
+        );
     }
 
     #[test]
@@ -7080,6 +8295,36 @@ mod tests {
             next_terminal_input_attention_status(Some(&WorkspaceAttentionStatus::Working)),
             Some(WorkspaceAttentionStatus::Working)
         );
+    }
+
+    #[test]
+    fn workspace_lifecycle_failure_prompt_detail_includes_notice_and_logs() {
+        let workspace = local_workspace_entry("workspace", "project", "/tmp/workspace");
+        let detail = workspace_lifecycle_failure_prompt_detail(
+            &workspace,
+            &lifecycle_failure(superzent_git::WorkspaceLifecyclePhase::Setup),
+            Some("Configured base branch `missing` was not found."),
+            false,
+        );
+
+        assert!(detail.contains("workspace"));
+        assert!(detail.contains("Configured base branch `missing` was not found."));
+        assert!(detail.contains("Stdout:\nstdout"));
+        assert!(detail.contains("Stderr:\nstderr"));
+    }
+
+    #[test]
+    fn workspace_lifecycle_failure_prompt_detail_mentions_force_delete_when_requested() {
+        let workspace = local_workspace_entry("workspace", "project", "/tmp/workspace");
+        let detail = workspace_lifecycle_failure_prompt_detail(
+            &workspace,
+            &lifecycle_failure(superzent_git::WorkspaceLifecyclePhase::Teardown),
+            None,
+            true,
+        );
+
+        assert!(detail.contains("Delete Anyway"));
+        assert!(detail.contains("teardown failure"));
     }
 
     #[test]
@@ -7353,6 +8598,32 @@ mod tests {
             workspace_row_status_kind(&workspace, true),
             WorkspaceRowStatusKind::GitChanges
         );
+    }
+
+    #[test]
+    fn workspace_row_status_kind_shows_setup_in_progress_before_open_pill() {
+        let mut workspace = workspace_entry(WorkspaceKind::Primary);
+        workspace.attention_status = WorkspaceAttentionStatus::Working;
+        workspace.last_attention_reason = Some(WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string());
+
+        assert_eq!(
+            workspace_row_status_kind(&workspace, true),
+            WorkspaceRowStatusKind::SetupInProgress
+        );
+    }
+
+    #[test]
+    fn can_mark_workspace_setup_attention_only_when_idle_without_review_pending() {
+        let workspace = workspace_entry(WorkspaceKind::Primary);
+        assert!(can_mark_workspace_setup_attention(&workspace));
+
+        let mut permission_workspace = workspace_entry(WorkspaceKind::Primary);
+        permission_workspace.attention_status = WorkspaceAttentionStatus::Permission;
+        assert!(!can_mark_workspace_setup_attention(&permission_workspace));
+
+        let mut review_workspace = workspace_entry(WorkspaceKind::Primary);
+        review_workspace.review_pending = true;
+        assert!(!can_mark_workspace_setup_attention(&review_workspace));
     }
 
     #[test]

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -9,7 +9,7 @@ use crate::acp_tabs::{CLAUDE_AGENT_NAME, CODEX_NAME, GEMINI_NAME};
 use agent_ui::{
     AgentNotification, AgentNotificationEvent, open_external_acp_tab, pane_has_external_acp_item,
 };
-use anyhow::{Result, bail};
+use anyhow::Result;
 use chrono::Utc;
 #[cfg(target_os = "macos")]
 use cocoa::base::{id, nil};
@@ -42,9 +42,7 @@ use project_panel::ProjectPanel;
 use recent_projects::open_remote_project;
 use remote::{RemoteConnectionOptions, SshConnectionOptions};
 use settings::Settings;
-use smol::channel::Receiver as SmolReceiver;
-#[cfg(target_os = "macos")]
-use smol::channel::Sender as SmolSender;
+use smol::channel::{Receiver as SmolReceiver, Sender as SmolSender};
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
@@ -1865,6 +1863,77 @@ struct WorkspaceCreationResult {
     notice: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct NewWorkspaceModalBootstrap {
+    base_branch: Option<String>,
+    base_branch_notice: Option<String>,
+    base_branch_error: Option<String>,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+}
+
+fn new_workspace_create_options(
+    branch_name: String,
+    base_branch_override: Option<String>,
+    base_workspace_path: Option<PathBuf>,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+    save_teardown_script_as_repo_default: bool,
+    allow_dirty: bool,
+) -> superzent_git::CreateWorkspaceOptions {
+    superzent_git::CreateWorkspaceOptions {
+        branch_name,
+        base_branch_override,
+        base_workspace_path,
+        setup_script,
+        teardown_script,
+        save_teardown_script_as_repo_default,
+        allow_dirty,
+    }
+}
+
+fn new_workspace_modal_bootstrap(
+    base_branch_resolution: Result<superzent_git::WorkspaceBaseBranchResolution>,
+    lifecycle_defaults: superzent_git::WorkspaceLifecycleDefaults,
+) -> NewWorkspaceModalBootstrap {
+    let mut bootstrap = NewWorkspaceModalBootstrap {
+        setup_script: lifecycle_defaults.setup_script,
+        teardown_script: lifecycle_defaults.teardown_script,
+        ..Default::default()
+    };
+
+    match base_branch_resolution {
+        Ok(resolution) => {
+            bootstrap.base_branch = Some(resolution.effective_base_branch);
+            bootstrap.base_branch_notice = resolution.notice;
+        }
+        Err(error) => {
+            bootstrap.base_branch_error = Some(error.to_string());
+        }
+    }
+
+    bootstrap
+}
+
+fn build_new_workspace_modal_bootstrap(
+    project: &ProjectEntry,
+    initial_base_workspace_path: Option<&Path>,
+) -> NewWorkspaceModalBootstrap {
+    if !matches!(project.location, ProjectLocation::Local { .. }) {
+        return NewWorkspaceModalBootstrap::default();
+    }
+
+    let lifecycle_defaults =
+        superzent_git::workspace_lifecycle_defaults(project).unwrap_or_default();
+    let base_branch_resolution = superzent_git::resolve_workspace_base_branch_from_workspace(
+        project,
+        initial_base_workspace_path,
+        None,
+    );
+
+    new_workspace_modal_bootstrap(base_branch_resolution, lifecycle_defaults)
+}
+
 fn workspace_lifecycle_failure_prompt_detail(
     workspace_entry: &WorkspaceEntry,
     failure: &superzent_git::WorkspaceLifecycleFailure,
@@ -1890,6 +1959,64 @@ fn workspace_lifecycle_failure_prompt_detail(
 
     sections.push(failure.details());
     sections.join("\n\n")
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DeleteWorkspacePromptDetails {
+    title: &'static str,
+    confirm_label: &'static str,
+    confirm_decision: DeleteWorkspaceModalDecision,
+    prompt_message: String,
+    teardown_message: String,
+    teardown_script: Option<String>,
+    failure_details: Option<String>,
+}
+
+fn delete_workspace_prompt_details(
+    workspace_entry: &WorkspaceEntry,
+    delete_resolution: &superzent_git::WorkspaceDeleteResolution,
+) -> DeleteWorkspacePromptDetails {
+    let prompt_message = format!(
+        "Delete `{}` and remove its worktree at {}?",
+        workspace_entry.name,
+        workspace_entry.display_path()
+    );
+
+    match delete_resolution {
+        superzent_git::WorkspaceDeleteResolution::RunTeardownScript { script } => {
+            DeleteWorkspacePromptDetails {
+                title: "Delete workspace?",
+                confirm_label: "Delete",
+                confirm_decision: DeleteWorkspaceModalDecision::Delete,
+                prompt_message,
+                teardown_message: "This teardown script will run before deletion.".to_string(),
+                teardown_script: Some(script.clone()),
+                failure_details: None,
+            }
+        }
+        superzent_git::WorkspaceDeleteResolution::SkipTeardown => DeleteWorkspacePromptDetails {
+            title: "Delete workspace?",
+            confirm_label: "Delete",
+            confirm_decision: DeleteWorkspaceModalDecision::Delete,
+            prompt_message,
+            teardown_message: "No teardown script will run before deletion.".to_string(),
+            teardown_script: None,
+            failure_details: None,
+        },
+        superzent_git::WorkspaceDeleteResolution::BlockedByConfig(failure) => {
+            DeleteWorkspacePromptDetails {
+                title: "Delete blocked",
+                confirm_label: "Delete Anyway",
+                confirm_decision: DeleteWorkspaceModalDecision::DeleteAnyway,
+                prompt_message,
+                teardown_message:
+                    "Superzent could not read `.superzent/config.json`, so normal delete is blocked. If you continue, teardown will be skipped."
+                        .to_string(),
+                teardown_script: None,
+                failure_details: Some(failure.details()),
+            }
+        }
+    }
 }
 
 const WORKSPACE_SETUP_IN_PROGRESS_REASON: &str = "Setting up workspace…";
@@ -2034,9 +2161,9 @@ async fn create_remote_workspace(
             last_attention_reason: existing_workspace
                 .as_ref()
                 .and_then(|workspace| workspace.last_attention_reason.clone()),
-            lifecycle_teardown_script: existing_workspace
+            teardown_script_override: existing_workspace
                 .as_ref()
-                .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
+                .and_then(|workspace| workspace.teardown_script_override.clone()),
             created_at: existing_workspace
                 .as_ref()
                 .map(|workspace| workspace.created_at)
@@ -2079,33 +2206,16 @@ async fn resolve_opened_workspace(
 async fn create_local_workspace(
     project: ProjectEntry,
     preset_id: String,
-    branch_name: String,
-    base_branch_override: Option<String>,
-    base_workspace_path: Option<PathBuf>,
-    setup_script: Option<String>,
-    teardown_script: Option<String>,
-    persist_lifecycle_scripts: bool,
-    allow_dirty: bool,
+    create_options: superzent_git::CreateWorkspaceOptions,
     cx: &mut AsyncWindowContext,
 ) -> anyhow::Result<WorkspaceCreationResult> {
     cx.background_spawn(async move {
-        superzent_git::create_workspace_without_setup(
-            &project,
-            &preset_id,
-            superzent_git::CreateWorkspaceOptions {
-                branch_name,
-                base_branch_override,
-                base_workspace_path,
-                setup_script,
-                teardown_script,
-                persist_lifecycle_scripts,
-                allow_dirty,
+        superzent_git::create_workspace_without_setup(&project, &preset_id, create_options).map(
+            |outcome| WorkspaceCreationResult {
+                workspace: outcome.workspace,
+                notice: outcome.notice,
             },
         )
-        .map(|outcome| WorkspaceCreationResult {
-            workspace: outcome.workspace,
-            notice: outcome.notice,
-        })
     })
     .await
 }
@@ -2175,7 +2285,7 @@ fn spawn_new_workspace_request(
     base_branch_override: Option<String>,
     setup_script: Option<String>,
     teardown_script: Option<String>,
-    persist_lifecycle_scripts: bool,
+    save_teardown_script_as_repo_default: bool,
     window: &mut Window,
     cx: &mut App,
 ) {
@@ -2193,13 +2303,15 @@ fn spawn_new_workspace_request(
                     match create_local_workspace(
                         project.clone(),
                         preset_id.clone(),
-                        branch_name.clone(),
-                        base_branch_override.clone(),
-                        base_workspace_path.clone(),
-                        setup_script.clone(),
-                        teardown_script.clone(),
-                        persist_lifecycle_scripts,
-                        false,
+                        new_workspace_create_options(
+                            branch_name.clone(),
+                            base_branch_override.clone(),
+                            base_workspace_path.clone(),
+                            setup_script.clone(),
+                            teardown_script.clone(),
+                            save_teardown_script_as_repo_default,
+                            false,
+                        ),
                         cx,
                     )
                     .await
@@ -2231,13 +2343,15 @@ fn spawn_new_workspace_request(
                             let outcome = create_local_workspace(
                                 project.clone(),
                                 preset_id.clone(),
-                                branch_name.clone(),
-                                base_branch_override.clone(),
-                                base_workspace_path.clone(),
-                                setup_script.clone(),
-                                teardown_script.clone(),
-                                persist_lifecycle_scripts,
-                                true,
+                                new_workspace_create_options(
+                                    branch_name.clone(),
+                                    base_branch_override.clone(),
+                                    base_workspace_path.clone(),
+                                    setup_script.clone(),
+                                    teardown_script.clone(),
+                                    save_teardown_script_as_repo_default,
+                                    true,
+                                ),
                                 cx,
                             )
                             .await?;
@@ -2680,7 +2794,7 @@ struct NewWorkspaceModal {
     setup_script_editor: Entity<Editor>,
     teardown_script_editor: Entity<Editor>,
     show_more_options: bool,
-    save_lifecycle_scripts: bool,
+    save_teardown_script_as_repo_default: bool,
     active_script_target: Option<ScriptEditorTarget>,
     scroll_handle: ScrollHandle,
     base_branch_notice: Option<SharedString>,
@@ -2708,7 +2822,7 @@ impl NewWorkspaceModal {
     fn new(
         workspace: WeakEntity<Workspace>,
         project: ProjectEntry,
-        initial_base_workspace_path: Option<PathBuf>,
+        bootstrap: NewWorkspaceModalBootstrap,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -2804,36 +2918,20 @@ impl NewWorkspaceModal {
             },
         ));
 
-        let mut base_branch_notice = None;
-        let mut base_branch_error = None;
-        if matches!(project.location, ProjectLocation::Local { .. }) {
-            match superzent_git::resolve_workspace_base_branch_from_workspace(
-                &project,
-                initial_base_workspace_path.as_deref(),
-                None,
-            ) {
-                Ok(resolution) => {
-                    base_branch_editor.update(cx, |editor, cx| {
-                        editor.set_text(resolution.effective_base_branch.as_str(), window, cx);
-                    });
-                    base_branch_notice = resolution.notice.map(Into::into);
-                }
-                Err(error) => {
-                    base_branch_error = Some(error.to_string().into());
-                }
-            }
-            if let Ok(defaults) = superzent_git::workspace_lifecycle_defaults(&project) {
-                if let Some(setup_script) = defaults.setup_script {
-                    setup_script_editor.update(cx, |editor, cx| {
-                        editor.set_text(setup_script.as_str(), window, cx);
-                    });
-                }
-                if let Some(teardown_script) = defaults.teardown_script {
-                    teardown_script_editor.update(cx, |editor, cx| {
-                        editor.set_text(teardown_script.as_str(), window, cx);
-                    });
-                }
-            }
+        if let Some(base_branch) = bootstrap.base_branch.as_deref() {
+            base_branch_editor.update(cx, |editor, cx| {
+                editor.set_text(base_branch, window, cx);
+            });
+        }
+        if let Some(setup_script) = bootstrap.setup_script.as_deref() {
+            setup_script_editor.update(cx, |editor, cx| {
+                editor.set_text(setup_script, window, cx);
+            });
+        }
+        if let Some(teardown_script) = bootstrap.teardown_script.as_deref() {
+            teardown_script_editor.update(cx, |editor, cx| {
+                editor.set_text(teardown_script, window, cx);
+            });
         }
 
         Self {
@@ -2844,11 +2942,11 @@ impl NewWorkspaceModal {
             setup_script_editor,
             teardown_script_editor,
             show_more_options: false,
-            save_lifecycle_scripts: true,
+            save_teardown_script_as_repo_default: true,
             active_script_target: None,
             scroll_handle: ScrollHandle::new(),
-            base_branch_notice,
-            base_branch_error,
+            base_branch_notice: bootstrap.base_branch_notice.map(Into::into),
+            base_branch_error: bootstrap.base_branch_error.map(Into::into),
             _subscriptions: subscriptions,
             last_error: None,
         }
@@ -2968,7 +3066,7 @@ impl NewWorkspaceModal {
             self.base_branch(cx),
             self.setup_script(cx),
             self.teardown_script(cx),
-            self.save_lifecycle_scripts,
+            self.save_teardown_script_as_repo_default,
             window,
             cx,
         );
@@ -3073,6 +3171,13 @@ impl Render for NewWorkspaceModal {
                                                                         Label::new("Setup Script")
                                                                             .size(LabelSize::Small),
                                                                     )
+                                                                    .child(
+                                                                        Label::new(
+                                                                            "Runs once after creation for this workspace. Changes here are never saved as repo defaults.",
+                                                                        )
+                                                                        .size(LabelSize::Small)
+                                                                        .color(Color::Muted),
+                                                                    )
                                                                     .child(self.setup_script_editor.clone()),
                                                             )
                                                             .child(
@@ -3116,17 +3221,17 @@ impl Render for NewWorkspaceModal {
                                                             .child(
                                                                 Checkbox::new(
                                                                     "superzent-new-workspace-save-lifecycle",
-                                                                    self.save_lifecycle_scripts.into(),
+                                                                    self.save_teardown_script_as_repo_default.into(),
                                                                 )
                                                                 .label(
-                                                                    "Save these script commands as the default for this repository",
+                                                                    "Save teardown script as the default for this repository",
                                                                 )
                                                                 .fill()
                                                                 .elevation(ElevationIndex::Surface)
                                                                 .label_size(LabelSize::Small)
                                                                 .on_click(cx.listener(
                                                                     |this, selection, _, cx| {
-                                                                        this.save_lifecycle_scripts =
+                                                                        this.save_teardown_script_as_repo_default =
                                                                             *selection == ToggleState::Selected;
                                                                         cx.notify();
                                                                     },
@@ -3166,6 +3271,168 @@ impl Render for NewWorkspaceModal {
                                 ),
                         ),
                     ),
+            )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DeleteWorkspaceModalDecision {
+    Cancel,
+    Delete,
+    DeleteAnyway,
+}
+
+struct DeleteWorkspaceModal {
+    prompt_details: DeleteWorkspacePromptDetails,
+    sender: SmolSender<DeleteWorkspaceModalDecision>,
+    scroll_handle: ScrollHandle,
+    focus_handle: FocusHandle,
+}
+
+impl EventEmitter<DismissEvent> for DeleteWorkspaceModal {}
+impl ModalView for DeleteWorkspaceModal {}
+
+impl Focusable for DeleteWorkspaceModal {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl DeleteWorkspaceModal {
+    fn new(
+        prompt_details: DeleteWorkspacePromptDetails,
+        sender: SmolSender<DeleteWorkspaceModalDecision>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            prompt_details,
+            sender,
+            scroll_handle: ScrollHandle::new(),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    fn send_decision(&mut self, decision: DeleteWorkspaceModalDecision, cx: &mut Context<Self>) {
+        let _ = self.sender.try_send(decision);
+        cx.emit(DismissEvent);
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        self.send_decision(DeleteWorkspaceModalDecision::Cancel, cx);
+    }
+
+    fn confirm(&mut self, _: &menu::Confirm, _: &mut Window, cx: &mut Context<Self>) {
+        self.send_decision(self.prompt_details.confirm_decision, cx);
+    }
+
+    fn render_code_block(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        text: SharedString,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        v_flex()
+            .gap_1()
+            .child(Label::new(label).size(LabelSize::Small).color(Color::Muted))
+            .child(
+                div()
+                    .id(id)
+                    .max_h(px(180.))
+                    .overflow_y_scroll()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .bg(cx.theme().colors().editor_background)
+                    .p_2()
+                    .child(
+                        Label::new(text)
+                            .size(LabelSize::Small)
+                            .buffer_font(cx)
+                            .color(Color::Default),
+                    ),
+            )
+    }
+}
+
+impl Render for DeleteWorkspaceModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("SuperzentDeleteWorkspaceModal")
+            .on_action(cx.listener(Self::cancel))
+            .on_action(cx.listener(Self::confirm))
+            .elevation_3(cx)
+            .w(px(560.))
+            .max_h(px(576.))
+            .overflow_hidden()
+            .child(
+                Modal::new(
+                    "superzent-delete-workspace-modal",
+                    Some(self.scroll_handle.clone()),
+                )
+                .header(ModalHeader::new().headline(self.prompt_details.title))
+                .section(
+                    Section::new().child(
+                        v_flex()
+                            .gap_3()
+                            .child(
+                                Label::new(self.prompt_details.prompt_message.clone())
+                                    .size(LabelSize::Small)
+                                    .color(Color::Muted),
+                            )
+                            .child(
+                                Label::new(self.prompt_details.teardown_message.clone())
+                                    .size(LabelSize::Small),
+                            )
+                            .when_some(
+                                self.prompt_details.teardown_script.clone(),
+                                |this, teardown_script| {
+                                    this.child(self.render_code_block(
+                                        "superzent-delete-workspace-teardown-preview",
+                                        "Teardown Script",
+                                        teardown_script.into(),
+                                        cx,
+                                    ))
+                                },
+                            )
+                            .when_some(
+                                self.prompt_details.failure_details.clone(),
+                                |this, failure_details| {
+                                    this.child(self.render_code_block(
+                                        "superzent-delete-workspace-blocked-detail",
+                                        "Config Read Failure",
+                                        failure_details.into(),
+                                        cx,
+                                    ))
+                                },
+                            ),
+                    ),
+                )
+                .footer(
+                    ModalFooter::new().end_slot(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("superzent-delete-workspace-cancel", "Cancel")
+                                    .style(ButtonStyle::Subtle)
+                                    .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                                        this.cancel(&menu::Cancel, window, cx);
+                                    })),
+                            )
+                            .child(
+                                Button::new(
+                                    "superzent-delete-workspace-confirm",
+                                    self.prompt_details.confirm_label,
+                                )
+                                .style(ButtonStyle::Filled)
+                                .on_click(cx.listener(
+                                    |this, _: &ClickEvent, window, cx| {
+                                        this.confirm(&menu::Confirm, window, cx);
+                                    },
+                                )),
+                            ),
+                    ),
+                ),
             )
     }
 }
@@ -5466,14 +5733,10 @@ fn open_new_workspace_modal(
         .filter(|workspace_entry| workspace_entry.project_id == project.id)
         .and_then(|workspace_entry| workspace_entry.local_worktree_path())
         .map(Path::to_path_buf);
+    let bootstrap =
+        build_new_workspace_modal_bootstrap(&project, initial_base_workspace_path.as_deref());
     workspace.toggle_modal(window, cx, move |window, cx| {
-        NewWorkspaceModal::new(
-            workspace_handle.clone(),
-            project,
-            initial_base_workspace_path,
-            window,
-            cx,
-        )
+        NewWorkspaceModal::new(workspace_handle.clone(), project, bootstrap, window, cx)
     });
 }
 
@@ -5641,6 +5904,184 @@ fn run_close_workspace(
     }
 }
 
+#[derive(Clone)]
+struct DeleteWorkspaceSession {
+    project: ProjectEntry,
+    workspace_entry: WorkspaceEntry,
+    fallback_workspace: Option<WorkspaceEntry>,
+    deleting_sidebar: Option<WeakEntity<SuperzentSidebar>>,
+    delete_location: WorkspaceLocation,
+    removal_targets: Vec<WorkspaceWindowRemovalTarget>,
+    app_state: Arc<WorkspaceAppState>,
+}
+
+enum DeleteWorkspaceResult {
+    Deleted { cleanup_error: Option<String> },
+    BlockedByTeardown(superzent_git::WorkspaceLifecycleFailure),
+}
+
+impl DeleteWorkspaceSession {
+    fn set_sidebar_deleting(&self, deleting: bool, cx: &mut App) {
+        if let Some(sidebar) = self.deleting_sidebar.as_ref() {
+            sidebar
+                .update(cx, |sidebar, cx| {
+                    sidebar.mark_workspace_deleting(&self.workspace_entry.id, deleting, cx);
+                })
+                .ok();
+        }
+    }
+
+    fn register_in_flight(&self, cx: &mut App) {
+        register_in_flight_workspace_delete(self.delete_location.clone(), cx);
+    }
+
+    fn finish_interaction(&self, cx: &mut AsyncWindowContext) {
+        cx.update(|_, cx| {
+            self.set_sidebar_deleting(false, cx);
+            unregister_in_flight_workspace_delete(&self.delete_location, cx);
+        })
+        .ok();
+    }
+
+    async fn close_open_windows(&self, cx: &mut AsyncWindowContext) -> Option<String> {
+        close_workspace_in_all_windows(
+            self.workspace_entry.clone(),
+            self.fallback_workspace.clone(),
+            self.app_state.clone(),
+            Some(self.removal_targets.clone()),
+            cx,
+        )
+        .await
+        .err()
+        .map(|error| error.to_string())
+    }
+
+    fn finalize_deleted(
+        &self,
+        store: &Entity<SuperzentStore>,
+        workspace: &mut Workspace,
+        cleanup_error: Option<String>,
+        cx: &mut Context<Workspace>,
+    ) {
+        store.update(cx, |store, cx| {
+            store.remove_workspace(&self.workspace_entry.id, cx);
+        });
+        if let Some(cleanup_error) = cleanup_error {
+            log::error!("workspace delete succeeded on disk but cleanup failed: {cleanup_error}");
+            workspace.show_toast(
+                Toast::new(
+                    NotificationId::unique::<SuperzentSidebar>(),
+                    format!(
+                        "Deleted {}, but some open windows may need manual cleanup.",
+                        self.workspace_entry.name
+                    ),
+                ),
+                cx,
+            );
+        } else {
+            workspace.show_toast(
+                Toast::new(
+                    NotificationId::unique::<SuperzentSidebar>(),
+                    format!("Deleted {}", self.workspace_entry.name),
+                ),
+                cx,
+            );
+        }
+    }
+}
+
+fn show_delete_workspace_modal(
+    workspace: &mut Workspace,
+    workspace_entry: WorkspaceEntry,
+    delete_resolution: superzent_git::WorkspaceDeleteResolution,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) -> SmolReceiver<DeleteWorkspaceModalDecision> {
+    let prompt_details = delete_workspace_prompt_details(&workspace_entry, &delete_resolution);
+    let (sender, receiver) = smol::channel::bounded(1);
+    let dismiss_sender = sender;
+    let modal_sender = dismiss_sender.clone();
+
+    workspace.toggle_modal(window, cx, move |_window, cx| {
+        DeleteWorkspaceModal::new(prompt_details.clone(), modal_sender, cx)
+    });
+
+    if let Some(modal) = workspace.active_modal::<DeleteWorkspaceModal>(cx) {
+        cx.subscribe_in(&modal, window, move |_, _, _: &DismissEvent, _, _| {
+            let _ = dismiss_sender.try_send(DeleteWorkspaceModalDecision::Cancel);
+        })
+        .detach();
+    } else {
+        let _ = dismiss_sender.try_send(DeleteWorkspaceModalDecision::Cancel);
+    }
+
+    receiver
+}
+
+async fn perform_workspace_delete(
+    session: &DeleteWorkspaceSession,
+    store: &Entity<SuperzentStore>,
+    delete_resolution: Option<&superzent_git::WorkspaceDeleteResolution>,
+    force: bool,
+    cx: &mut AsyncWindowContext,
+) -> anyhow::Result<DeleteWorkspaceResult> {
+    match &session.project.location {
+        ProjectLocation::Local { repo_root } => {
+            let workspace_to_delete = session.workspace_entry.clone();
+            let delete_resolution = delete_resolution.cloned();
+            let delete_outcome = cx
+                .background_spawn({
+                    let repo_root = repo_root.clone();
+                    async move {
+                        superzent_git::delete_workspace_with_resolution(
+                            &workspace_to_delete,
+                            &repo_root,
+                            force,
+                            delete_resolution.as_ref(),
+                        )
+                    }
+                })
+                .await?;
+
+            match delete_outcome {
+                superzent_git::WorkspaceDeleteOutcome::Deleted => {}
+                superzent_git::WorkspaceDeleteOutcome::BlockedByTeardown(failure) => {
+                    return Ok(DeleteWorkspaceResult::BlockedByTeardown(failure));
+                }
+            }
+        }
+        ProjectLocation::Ssh { .. } => {
+            let (project_workspace, _) = resolve_remote_project_workspace(
+                &session.project,
+                store,
+                session.app_state.clone(),
+                false,
+                cx,
+            )
+            .await?;
+
+            let repository = cx.update(|_, cx| {
+                active_repository_for_workspace(&project_workspace, cx)
+                    .ok_or_else(|| anyhow::anyhow!("no active repository found"))
+            })??;
+            let target_path = PathBuf::from(
+                session
+                    .workspace_entry
+                    .ssh_worktree_path()
+                    .ok_or_else(|| anyhow::anyhow!("missing remote worktree path"))?,
+            );
+            let receiver = repository.update(cx, |repository, _| {
+                repository.remove_worktree(target_path, false)
+            });
+            receiver.await??;
+        }
+    }
+
+    Ok(DeleteWorkspaceResult::Deleted {
+        cleanup_error: session.close_open_windows(cx).await,
+    })
+}
+
 fn run_delete_workspace_entry(
     workspace: &mut Workspace,
     workspace_entry: WorkspaceEntry,
@@ -5649,6 +6090,16 @@ fn run_delete_workspace_entry(
     cx: &mut Context<Workspace>,
 ) {
     let store = SuperzentStore::global(cx);
+    let clear_sidebar_deleting = |cx: &mut App| {
+        if let Some(sidebar) = deleting_sidebar.as_ref() {
+            sidebar
+                .update(cx, |sidebar, cx| {
+                    sidebar.mark_workspace_deleting(&workspace_entry.id, false, cx);
+                })
+                .ok();
+        }
+    };
+
     if workspace_entry.kind == WorkspaceKind::Primary || !workspace_entry.managed {
         workspace.show_toast(
             Toast::new(
@@ -5657,13 +6108,7 @@ fn run_delete_workspace_entry(
             ),
             cx,
         );
-        if let Some(sidebar) = deleting_sidebar.as_ref() {
-            sidebar
-                .update(cx, |sidebar, cx| {
-                    sidebar.mark_workspace_deleting(&workspace_entry.id, false, cx);
-                })
-                .ok();
-        }
+        clear_sidebar_deleting(cx);
         return;
     }
     let Some(project) = store.read(cx).project(&workspace_entry.project_id).cloned() else {
@@ -5674,261 +6119,180 @@ fn run_delete_workspace_entry(
             ),
             cx,
         );
-        if let Some(sidebar) = deleting_sidebar.as_ref() {
-            sidebar
-                .update(cx, |sidebar, cx| {
-                    sidebar.mark_workspace_deleting(&workspace_entry.id, false, cx);
-                })
-                .ok();
-        }
+        clear_sidebar_deleting(cx);
         return;
     };
-    let fallback_workspace = store
-        .read(cx)
-        .primary_workspace_for_project(&project.id)
-        .filter(|fallback_workspace| fallback_workspace.id != workspace_entry.id)
-        .cloned();
+    let session = DeleteWorkspaceSession {
+        project,
+        workspace_entry: workspace_entry.clone(),
+        fallback_workspace: store
+            .read(cx)
+            .primary_workspace_for_project(&workspace_entry.project_id)
+            .filter(|fallback_workspace| fallback_workspace.id != workspace_entry.id)
+            .cloned(),
+        deleting_sidebar: deleting_sidebar.clone(),
+        delete_location: workspace_entry.location.clone(),
+        removal_targets: workspace_removal_targets_for_entry(&workspace_entry, cx),
+        app_state: workspace.app_state().clone(),
+    };
 
-    let prompt = window.prompt(
-        PromptLevel::Warning,
-        "Delete workspace?",
-        Some(&format!(
-            "Delete `{}` and remove its worktree at {}?",
-            workspace_entry.name,
-            workspace_entry.display_path()
-        )),
-        &["Cancel", "Delete"],
-        cx,
-    );
-    let app_state = workspace.app_state().clone();
-
-    // Block any new opens of this workspace for the duration of the delete
-    // flow — including while the confirmation prompt is showing. Without this
-    // guard, a late open during the prompt (or while the background delete
-    // is running) would leave a stale tab behind: once the worktree files
-    // are gone the post-delete re-scan can't rediscover that instance
-    // because it matches by path via `visible_worktrees()`.
-    let delete_location = workspace_entry.location.clone();
-    register_in_flight_workspace_delete(delete_location.clone(), cx);
-
-    cx.spawn_in(window, async move |this, cx| {
-        enum DeleteWorkspaceResult {
-            Deleted { cleanup_error: Option<String> },
-            BlockedByTeardown(superzent_git::WorkspaceLifecycleFailure),
-        }
-
-        if prompt.await != Ok(1) {
-            if let Some(sidebar) = deleting_sidebar.as_ref() {
-                sidebar
-                    .update(cx, |sidebar, cx| {
-                        sidebar.mark_workspace_deleting(&workspace_entry.id, false, cx);
-                    })
-                    .ok();
-            }
-            cx.update(|_, cx| {
-                unregister_in_flight_workspace_delete(&delete_location, cx);
-            })
-            .ok();
-            return anyhow::Ok(());
-        }
-
-        let removal_targets =
-            cx.update(|_, cx| workspace_removal_targets_for_entry(&workspace_entry, cx))?;
-
-        let delete_result: anyhow::Result<DeleteWorkspaceResult> = async {
-            let workspace_to_delete = workspace_entry.clone();
-            match &project.location {
-                ProjectLocation::Local { repo_root } => {
-                    let delete_outcome = cx
-                        .background_spawn({
-                            let repo_root = repo_root.clone();
-                            async move {
-                                superzent_git::delete_workspace(
-                                    &workspace_to_delete,
-                                    &repo_root,
-                                    false,
-                                )
-                            }
-                        })
-                        .await?;
-
-                    match delete_outcome {
-                        superzent_git::WorkspaceDeleteOutcome::Deleted => {}
-                        superzent_git::WorkspaceDeleteOutcome::BlockedByTeardown(failure) => {
-                            return Ok(DeleteWorkspaceResult::BlockedByTeardown(failure));
-                        }
-                    }
-                }
-                ProjectLocation::Ssh { .. } => {
-                    let (project_workspace, _) = resolve_remote_project_workspace(
-                        &project,
-                        &store,
-                        app_state.clone(),
-                        false,
+    match &session.project.location {
+        ProjectLocation::Local { repo_root } => {
+            let delete_resolution = match superzent_git::resolve_workspace_delete_resolution(
+                &session.workspace_entry,
+                repo_root,
+            ) {
+                Ok(delete_resolution) => delete_resolution,
+                Err(error) => {
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<SuperzentSidebar>(),
+                            format!("Failed to prepare workspace delete: {error}"),
+                        ),
                         cx,
-                    )
-                    .await?;
-
-                    let repository = cx.update(|_, cx| {
-                        active_repository_for_workspace(&project_workspace, cx)
-                            .ok_or_else(|| anyhow::anyhow!("no active repository found"))
-                    })??;
-                    let target_path = PathBuf::from(
-                        workspace_to_delete
-                            .ssh_worktree_path()
-                            .ok_or_else(|| anyhow::anyhow!("missing remote worktree path"))?,
                     );
-                    let receiver = repository.update(cx, |repository, _| {
-                        repository.remove_worktree(target_path, false)
-                    });
-                    receiver.await??;
+                    clear_sidebar_deleting(cx);
+                    return;
                 }
-            }
-
-            let cleanup_error = close_workspace_in_all_windows(
-                workspace_entry.clone(),
-                fallback_workspace.clone(),
-                app_state.clone(),
-                Some(removal_targets.clone()),
+            };
+            session.register_in_flight(cx);
+            let prompt_receiver = show_delete_workspace_modal(
+                workspace,
+                session.workspace_entry.clone(),
+                delete_resolution.clone(),
+                window,
                 cx,
-            )
-            .await
-            .err()
-            .map(|error| error.to_string());
+            );
 
-            Ok(DeleteWorkspaceResult::Deleted { cleanup_error })
-        }
-        .await;
+            cx.spawn_in(window, async move |this, cx| {
+                let delete_decision = prompt_receiver
+                    .recv()
+                    .await
+                    .unwrap_or(DeleteWorkspaceModalDecision::Cancel);
+                if delete_decision == DeleteWorkspaceModalDecision::Cancel {
+                    session.finish_interaction(cx);
+                    return anyhow::Ok(());
+                }
 
-        let mut force_delete_result: Option<anyhow::Result<DeleteWorkspaceResult>> = None;
-        if let Ok(DeleteWorkspaceResult::BlockedByTeardown(failure)) = &delete_result {
-            let prompt_detail =
-                workspace_lifecycle_failure_prompt_detail(&workspace_entry, failure, None, true);
-            let retry_prompt = this.update_in(cx, |workspace, window, cx| {
-                workspace.show_toast(
-                    Toast::new(
-                        NotificationId::unique::<SuperzentSidebar>(),
-                        failure.summary(),
-                    ),
-                    cx,
-                );
-                window.prompt(
-                    PromptLevel::Warning,
-                    "Workspace teardown failed",
-                    Some(&prompt_detail),
-                    &["Cancel", "Delete Anyway"],
+                let mut delete_result = perform_workspace_delete(
+                    &session,
+                    &store,
+                    Some(&delete_resolution),
+                    delete_decision == DeleteWorkspaceModalDecision::DeleteAnyway,
                     cx,
                 )
-            })?;
+                .await;
 
-            if retry_prompt.await == Ok(1) {
-                force_delete_result = Some(
-                    async {
-                        let workspace_to_delete = workspace_entry.clone();
-                        match &project.location {
-                            ProjectLocation::Local { repo_root } => {
-                                let delete_outcome = cx
-                                    .background_spawn({
-                                        let repo_root = repo_root.clone();
-                                        async move {
-                                            superzent_git::delete_workspace(
-                                                &workspace_to_delete,
-                                                &repo_root,
-                                                true,
-                                            )
-                                        }
-                                    })
-                                    .await?;
-                                match delete_outcome {
-                                    superzent_git::WorkspaceDeleteOutcome::Deleted => {}
-                                    superzent_git::WorkspaceDeleteOutcome::BlockedByTeardown(_) => {
-                                        bail!("force delete unexpectedly retried teardown")
-                                    }
-                                }
-                            }
-                            ProjectLocation::Ssh { .. } => {
-                                bail!("force delete is only supported for local workspaces")
-                            }
-                        }
-
-                        let cleanup_error = close_workspace_in_all_windows(
-                            workspace_entry.clone(),
-                            fallback_workspace.clone(),
-                            app_state.clone(),
-                            Some(removal_targets.clone()),
+                if let Ok(DeleteWorkspaceResult::BlockedByTeardown(failure)) = &delete_result {
+                    let prompt_detail = workspace_lifecycle_failure_prompt_detail(
+                        &session.workspace_entry,
+                        failure,
+                        None,
+                        true,
+                    );
+                    let retry_prompt = this.update_in(cx, |workspace, window, cx| {
+                        workspace.show_toast(
+                            Toast::new(
+                                NotificationId::unique::<SuperzentSidebar>(),
+                                failure.summary(),
+                            ),
+                            cx,
+                        );
+                        window.prompt(
+                            PromptLevel::Warning,
+                            "Workspace teardown failed",
+                            Some(&prompt_detail),
+                            &["Cancel", "Delete Anyway"],
                             cx,
                         )
-                        .await
-                        .err()
-                        .map(|error| error.to_string());
+                    })?;
 
-                        Ok(DeleteWorkspaceResult::Deleted { cleanup_error })
+                    if retry_prompt.await == Ok(1) {
+                        delete_result = perform_workspace_delete(
+                            &session,
+                            &store,
+                            Some(&delete_resolution),
+                            true,
+                            cx,
+                        )
+                        .await;
+                        if matches!(
+                            delete_result,
+                            Ok(DeleteWorkspaceResult::BlockedByTeardown(_))
+                        ) {
+                            delete_result = Err(anyhow::anyhow!(
+                                "force delete unexpectedly retried teardown"
+                            ));
+                        }
                     }
-                    .await,
-                );
-            }
-        }
-
-        let delete_result = force_delete_result.unwrap_or(delete_result);
-
-        this.update_in(cx, |workspace, _window, cx| match delete_result {
-            Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
-                store.update(cx, |store, cx| {
-                    store.remove_workspace(&workspace_entry.id, cx);
-                });
-                if let Some(cleanup_error) = cleanup_error {
-                    log::error!(
-                        "workspace delete succeeded on disk but cleanup failed: {cleanup_error}"
-                    );
-                    workspace.show_toast(
-                        Toast::new(
-                            NotificationId::unique::<SuperzentSidebar>(),
-                            format!(
-                                "Deleted {}, but some open windows may need manual cleanup.",
-                                workspace_entry.name
-                            ),
-                        ),
-                        cx,
-                    );
-                } else {
-                    workspace.show_toast(
-                        Toast::new(
-                            NotificationId::unique::<SuperzentSidebar>(),
-                            format!("Deleted {}", workspace_entry.name),
-                        ),
-                        cx,
-                    );
                 }
-            }
-            Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
-            Err(error) => {
-                workspace.show_toast(
-                    Toast::new(
-                        NotificationId::unique::<SuperzentSidebar>(),
-                        format!("Failed to remove workspace: {error}"),
-                    ),
-                    cx,
-                );
-            }
-        })
-        .ok();
 
-        if let Some(sidebar) = deleting_sidebar.as_ref() {
-            sidebar
-                .update(cx, |sidebar, cx| {
-                    sidebar.mark_workspace_deleting(&workspace_entry.id, false, cx);
-                })
-                .ok();
+                let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
+                    Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
+                        session.finalize_deleted(&store, workspace, cleanup_error, cx);
+                    }
+                    Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
+                    Err(error) => {
+                        workspace.show_toast(
+                            Toast::new(
+                                NotificationId::unique::<SuperzentSidebar>(),
+                                format!("Failed to remove workspace: {error}"),
+                            ),
+                            cx,
+                        );
+                    }
+                });
+
+                session.finish_interaction(cx);
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
         }
+        ProjectLocation::Ssh { .. } => {
+            session.register_in_flight(cx);
+            let prompt = window.prompt(
+                PromptLevel::Warning,
+                "Delete workspace?",
+                Some(&format!(
+                    "Delete `{}` and remove its worktree at {}?",
+                    session.workspace_entry.name,
+                    session.workspace_entry.display_path()
+                )),
+                &["Cancel", "Delete"],
+                cx,
+            );
 
-        cx.update(|_, cx| {
-            unregister_in_flight_workspace_delete(&delete_location, cx);
-        })
-        .ok();
+            cx.spawn_in(window, async move |this, cx| {
+                if prompt.await != Ok(1) {
+                    session.finish_interaction(cx);
+                    return anyhow::Ok(());
+                }
 
-        anyhow::Ok(())
-    })
-    .detach_and_log_err(cx);
+                let delete_result =
+                    perform_workspace_delete(&session, &store, None, false, cx).await;
+
+                let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
+                    Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
+                        session.finalize_deleted(&store, workspace, cleanup_error, cx);
+                    }
+                    Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
+                    Err(error) => {
+                        workspace.show_toast(
+                            Toast::new(
+                                NotificationId::unique::<SuperzentSidebar>(),
+                                format!("Failed to remove workspace: {error}"),
+                            ),
+                            cx,
+                        );
+                    }
+                });
+
+                session.finish_interaction(cx);
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
+    }
 }
 
 fn run_sync_project_worktrees(
@@ -7260,9 +7624,9 @@ fn build_synced_local_workspace_entry(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
-        lifecycle_teardown_script: existing_workspace
+        teardown_script_override: existing_workspace
             .as_ref()
-            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
+            .and_then(|workspace| workspace.teardown_script_override.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -7435,9 +7799,9 @@ fn build_local_workspace_bundle(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
-        lifecycle_teardown_script: existing_workspace
+        teardown_script_override: existing_workspace
             .as_ref()
-            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
+            .and_then(|workspace| workspace.teardown_script_override.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -7585,9 +7949,9 @@ fn build_remote_workspace_bundle(
         last_attention_reason: existing_workspace
             .as_ref()
             .and_then(|workspace| workspace.last_attention_reason.clone()),
-        lifecycle_teardown_script: existing_workspace
+        teardown_script_override: existing_workspace
             .as_ref()
-            .and_then(|workspace| workspace.lifecycle_teardown_script.clone()),
+            .and_then(|workspace| workspace.teardown_script_override.clone()),
         created_at: existing_workspace
             .as_ref()
             .map(|workspace| workspace.created_at)
@@ -8170,7 +8534,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
-            lifecycle_teardown_script: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -8194,7 +8558,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
-            lifecycle_teardown_script: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -8232,7 +8596,7 @@ mod tests {
             attention_status: WorkspaceAttentionStatus::Idle,
             review_pending: false,
             last_attention_reason: None,
-            lifecycle_teardown_script: None,
+            teardown_script_override: None,
             created_at: Utc::now(),
             last_opened_at: Utc::now(),
         }
@@ -8286,6 +8650,91 @@ mod tests {
             move_changes_source_path(None, &project),
             Some(PathBuf::from("/tmp/repo"))
         );
+    }
+
+    #[test]
+    fn new_workspace_modal_bootstrap_applies_base_branch_resolution_and_defaults() {
+        let bootstrap = new_workspace_modal_bootstrap(
+            Ok(superzent_git::WorkspaceBaseBranchResolution {
+                effective_base_branch: "develop".to_string(),
+                notice: Some("Using the current base workspace branch.".to_string()),
+            }),
+            superzent_git::WorkspaceLifecycleDefaults {
+                setup_script: Some("echo setup".to_string()),
+                teardown_script: Some("echo teardown".to_string()),
+            },
+        );
+
+        assert_eq!(bootstrap.base_branch, Some("develop".to_string()));
+        assert_eq!(
+            bootstrap.base_branch_notice,
+            Some("Using the current base workspace branch.".to_string())
+        );
+        assert_eq!(bootstrap.base_branch_error, None);
+        assert_eq!(bootstrap.setup_script, Some("echo setup".to_string()));
+        assert_eq!(bootstrap.teardown_script, Some("echo teardown".to_string()));
+    }
+
+    #[test]
+    fn new_workspace_create_options_marks_only_teardown_for_repo_default_persistence() {
+        let options = new_workspace_create_options(
+            "feature/bootstrap".to_string(),
+            Some("main".to_string()),
+            Some(PathBuf::from("/tmp/repo")),
+            Some("echo setup".to_string()),
+            Some("echo teardown".to_string()),
+            true,
+            false,
+        );
+
+        assert_eq!(options.setup_script, Some("echo setup".to_string()));
+        assert_eq!(options.teardown_script, Some("echo teardown".to_string()));
+        assert!(options.save_teardown_script_as_repo_default);
+        assert_eq!(options.base_branch_override, Some("main".to_string()));
+    }
+
+    #[test]
+    fn delete_workspace_prompt_details_show_script_preview_when_teardown_will_run() {
+        let workspace = local_workspace_entry("workspace", "project", "/tmp/workspace");
+        let prompt_details = delete_workspace_prompt_details(
+            &workspace,
+            &superzent_git::WorkspaceDeleteResolution::RunTeardownScript {
+                script: "echo teardown".to_string(),
+            },
+        );
+
+        assert_eq!(prompt_details.title, "Delete workspace?");
+        assert_eq!(prompt_details.confirm_label, "Delete");
+        assert_eq!(
+            prompt_details.confirm_decision,
+            DeleteWorkspaceModalDecision::Delete
+        );
+        assert_eq!(
+            prompt_details.teardown_script,
+            Some("echo teardown".to_string())
+        );
+        assert!(prompt_details.failure_details.is_none());
+    }
+
+    #[test]
+    fn delete_workspace_prompt_details_blocked_config_path_skips_teardown() {
+        let workspace = local_workspace_entry("workspace", "project", "/tmp/workspace");
+        let prompt_details = delete_workspace_prompt_details(
+            &workspace,
+            &superzent_git::WorkspaceDeleteResolution::BlockedByConfig(lifecycle_failure(
+                superzent_git::WorkspaceLifecyclePhase::Teardown,
+            )),
+        );
+
+        assert_eq!(prompt_details.title, "Delete blocked");
+        assert_eq!(prompt_details.confirm_label, "Delete Anyway");
+        assert_eq!(
+            prompt_details.confirm_decision,
+            DeleteWorkspaceModalDecision::DeleteAnyway
+        );
+        assert!(prompt_details.teardown_script.is_none());
+        assert!(prompt_details.teardown_message.contains("skip"));
+        assert!(prompt_details.failure_details.is_some());
     }
 
     #[test]

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -2226,19 +2226,26 @@ fn local_base_workspace_path_for_create_request(
     store: &SuperzentStore,
     cx: &App,
 ) -> Option<PathBuf> {
-    single_workspace_location_snapshot(workspace_handle, cx)
-        .and_then(|location| match location {
-            WorkspaceLocation::Local { worktree_path } => Some(worktree_path),
-            WorkspaceLocation::Ssh { .. } => None,
+    let live_workspace_matches_project =
+        inferred_project_id_for_live_workspace(workspace_handle, store, cx).as_deref()
+            == Some(project.id.as_str());
+
+    store
+        .active_workspace()
+        .filter(|workspace_entry| workspace_entry.project_id == project.id)
+        .and_then(|workspace_entry| workspace_entry.local_worktree_path())
+        .map(Path::to_path_buf)
+        .or_else(|| {
+            local_workspace_path_from_location_if_project_matches(
+                single_workspace_location_snapshot(workspace_handle, cx),
+                live_workspace_matches_project,
+            )
         })
         .or_else(|| {
-            store
-                .active_workspace()
-                .filter(|workspace_entry| workspace_entry.project_id == project.id)
-                .and_then(|workspace_entry| workspace_entry.local_worktree_path())
-                .map(Path::to_path_buf)
-        })
-        .or_else(|| {
+            if !live_workspace_matches_project {
+                return None;
+            }
+
             workspace_handle
                 .read(cx)
                 .project()
@@ -2252,6 +2259,20 @@ fn local_base_workspace_path_for_create_request(
                         .map(|local| local.abs_path().to_path_buf())
                 })
         })
+}
+
+fn local_workspace_path_from_location_if_project_matches(
+    location: Option<WorkspaceLocation>,
+    project_matches_live_workspace: bool,
+) -> Option<PathBuf> {
+    if !project_matches_live_workspace {
+        return None;
+    }
+
+    match location? {
+        WorkspaceLocation::Local { worktree_path } => Some(worktree_path),
+        WorkspaceLocation::Ssh { .. } => None,
+    }
 }
 
 fn move_changes_source_path(
@@ -6165,86 +6186,89 @@ fn run_delete_workspace_entry(
             );
 
             cx.spawn_in(window, async move |this, cx| {
-                let delete_decision = prompt_receiver
-                    .recv()
-                    .await
-                    .unwrap_or(DeleteWorkspaceModalDecision::Cancel);
-                if delete_decision == DeleteWorkspaceModalDecision::Cancel {
-                    session.finish_interaction(cx);
-                    return anyhow::Ok(());
-                }
+                let task_result = async {
+                    let delete_decision = prompt_receiver
+                        .recv()
+                        .await
+                        .unwrap_or(DeleteWorkspaceModalDecision::Cancel);
+                    if delete_decision == DeleteWorkspaceModalDecision::Cancel {
+                        return anyhow::Ok(());
+                    }
 
-                let mut delete_result = perform_workspace_delete(
-                    &session,
-                    &store,
-                    Some(&delete_resolution),
-                    delete_decision == DeleteWorkspaceModalDecision::DeleteAnyway,
-                    cx,
-                )
-                .await;
+                    let mut delete_result = perform_workspace_delete(
+                        &session,
+                        &store,
+                        Some(&delete_resolution),
+                        delete_decision == DeleteWorkspaceModalDecision::DeleteAnyway,
+                        cx,
+                    )
+                    .await;
 
-                if let Ok(DeleteWorkspaceResult::BlockedByTeardown(failure)) = &delete_result {
-                    let prompt_detail = workspace_lifecycle_failure_prompt_detail(
-                        &session.workspace_entry,
-                        failure,
-                        None,
-                        true,
-                    );
-                    let retry_prompt = this.update_in(cx, |workspace, window, cx| {
-                        workspace.show_toast(
-                            Toast::new(
-                                NotificationId::unique::<SuperzentSidebar>(),
-                                failure.summary(),
-                            ),
-                            cx,
-                        );
-                        window.prompt(
-                            PromptLevel::Warning,
-                            "Workspace teardown failed",
-                            Some(&prompt_detail),
-                            &["Cancel", "Delete Anyway"],
-                            cx,
-                        )
-                    })?;
-
-                    if retry_prompt.await == Ok(1) {
-                        delete_result = perform_workspace_delete(
-                            &session,
-                            &store,
-                            Some(&delete_resolution),
+                    if let Ok(DeleteWorkspaceResult::BlockedByTeardown(failure)) = &delete_result {
+                        let prompt_detail = workspace_lifecycle_failure_prompt_detail(
+                            &session.workspace_entry,
+                            failure,
+                            None,
                             true,
-                            cx,
-                        )
-                        .await;
-                        if matches!(
-                            delete_result,
-                            Ok(DeleteWorkspaceResult::BlockedByTeardown(_))
-                        ) {
-                            delete_result = Err(anyhow::anyhow!(
-                                "force delete unexpectedly retried teardown"
-                            ));
+                        );
+                        let retry_prompt = this.update_in(cx, |workspace, window, cx| {
+                            workspace.show_toast(
+                                Toast::new(
+                                    NotificationId::unique::<SuperzentSidebar>(),
+                                    failure.summary(),
+                                ),
+                                cx,
+                            );
+                            window.prompt(
+                                PromptLevel::Warning,
+                                "Workspace teardown failed",
+                                Some(&prompt_detail),
+                                &["Cancel", "Delete Anyway"],
+                                cx,
+                            )
+                        })?;
+
+                        if retry_prompt.await == Ok(1) {
+                            delete_result = perform_workspace_delete(
+                                &session,
+                                &store,
+                                Some(&delete_resolution),
+                                true,
+                                cx,
+                            )
+                            .await;
+                            if matches!(
+                                delete_result,
+                                Ok(DeleteWorkspaceResult::BlockedByTeardown(_))
+                            ) {
+                                delete_result = Err(anyhow::anyhow!(
+                                    "force delete unexpectedly retried teardown"
+                                ));
+                            }
                         }
                     }
+
+                    let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
+                        Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
+                            session.finalize_deleted(&store, workspace, cleanup_error, cx);
+                        }
+                        Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
+                        Err(error) => {
+                            workspace.show_toast(
+                                Toast::new(
+                                    NotificationId::unique::<SuperzentSidebar>(),
+                                    format!("Failed to remove workspace: {error}"),
+                                ),
+                                cx,
+                            );
+                        }
+                    });
+
+                    anyhow::Ok(())
                 }
-
-                let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
-                    Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
-                        session.finalize_deleted(&store, workspace, cleanup_error, cx);
-                    }
-                    Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
-                    Err(error) => {
-                        workspace.show_toast(
-                            Toast::new(
-                                NotificationId::unique::<SuperzentSidebar>(),
-                                format!("Failed to remove workspace: {error}"),
-                            ),
-                            cx,
-                        );
-                    }
-                });
-
+                .await;
                 session.finish_interaction(cx);
-                anyhow::Ok(())
+                task_result
             })
             .detach_and_log_err(cx);
         }
@@ -6263,32 +6287,35 @@ fn run_delete_workspace_entry(
             );
 
             cx.spawn_in(window, async move |this, cx| {
-                if prompt.await != Ok(1) {
-                    session.finish_interaction(cx);
-                    return anyhow::Ok(());
+                let task_result = async {
+                    if prompt.await != Ok(1) {
+                        return anyhow::Ok(());
+                    }
+
+                    let delete_result =
+                        perform_workspace_delete(&session, &store, None, false, cx).await;
+
+                    let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
+                        Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
+                            session.finalize_deleted(&store, workspace, cleanup_error, cx);
+                        }
+                        Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
+                        Err(error) => {
+                            workspace.show_toast(
+                                Toast::new(
+                                    NotificationId::unique::<SuperzentSidebar>(),
+                                    format!("Failed to remove workspace: {error}"),
+                                ),
+                                cx,
+                            );
+                        }
+                    });
+
+                    anyhow::Ok(())
                 }
-
-                let delete_result =
-                    perform_workspace_delete(&session, &store, None, false, cx).await;
-
-                let _ = this.update_in(cx, |workspace, _window, cx| match delete_result {
-                    Ok(DeleteWorkspaceResult::Deleted { cleanup_error }) => {
-                        session.finalize_deleted(&store, workspace, cleanup_error, cx);
-                    }
-                    Ok(DeleteWorkspaceResult::BlockedByTeardown(_)) => {}
-                    Err(error) => {
-                        workspace.show_toast(
-                            Toast::new(
-                                NotificationId::unique::<SuperzentSidebar>(),
-                                format!("Failed to remove workspace: {error}"),
-                            ),
-                            cx,
-                        );
-                    }
-                });
-
+                .await;
                 session.finish_interaction(cx);
-                anyhow::Ok(())
+                task_result
             })
             .detach_and_log_err(cx);
         }
@@ -8649,6 +8676,33 @@ mod tests {
         assert_eq!(
             move_changes_source_path(None, &project),
             Some(PathBuf::from("/tmp/repo"))
+        );
+    }
+
+    #[test]
+    fn local_workspace_path_from_location_if_project_matches_returns_path_for_matching_local_workspace()
+     {
+        assert_eq!(
+            local_workspace_path_from_location_if_project_matches(
+                Some(WorkspaceLocation::Local {
+                    worktree_path: PathBuf::from("/tmp/project-b/worktrees/feature"),
+                }),
+                true,
+            ),
+            Some(PathBuf::from("/tmp/project-b/worktrees/feature"))
+        );
+    }
+
+    #[test]
+    fn local_workspace_path_from_location_if_project_matches_ignores_mismatched_live_workspace() {
+        assert_eq!(
+            local_workspace_path_from_location_if_project_matches(
+                Some(WorkspaceLocation::Local {
+                    worktree_path: PathBuf::from("/tmp/project-a/worktrees/feature"),
+                }),
+                false,
+            ),
+            None
         );
     }
 

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -2183,9 +2183,7 @@ async fn resolve_opened_workspace(
             .await;
     }
 
-    cx.update(|window, cx| workspace_from_window(window, cx))
-        .ok()
-        .flatten()
+    None
 }
 
 async fn create_local_workspace(

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -2944,7 +2944,7 @@ impl NewWorkspaceModal {
             setup_script_editor,
             teardown_script_editor,
             show_more_options: false,
-            save_teardown_script_as_repo_default: true,
+            save_teardown_script_as_repo_default: false,
             active_script_target: None,
             scroll_handle: ScrollHandle::new(),
             base_branch_notice: bootstrap.base_branch_notice.map(Into::into),
@@ -8713,6 +8713,21 @@ mod tests {
         assert_eq!(options.teardown_script, Some("echo teardown".to_string()));
         assert!(options.save_teardown_script_as_repo_default);
         assert_eq!(options.base_branch_override, Some("main".to_string()));
+    }
+
+    #[test]
+    fn new_workspace_create_options_keeps_repo_default_teardown_persistence_disabled_by_default() {
+        let options = new_workspace_create_options(
+            "feature/bootstrap".to_string(),
+            None,
+            Some(PathBuf::from("/tmp/repo")),
+            None,
+            None,
+            false,
+            false,
+        );
+
+        assert!(!options.save_teardown_script_as_repo_default);
     }
 
     #[test]

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -219,6 +219,12 @@ fn debug_terminal_notifications_enabled() -> bool {
         .unwrap_or(false)
 }
 
+fn debug_workspace_create_toasts_enabled() -> bool {
+    std::env::var("SUPERZENT_DEBUG_CREATE_TOASTS")
+        .map(|value| !matches!(value.as_str(), "0" | "false" | "FALSE" | "False"))
+        .unwrap_or(false)
+}
+
 impl WorkspaceAttentionController {
     fn new(cx: &mut Context<Self>) -> Self {
         let store = SuperzentStore::global(cx);
@@ -1776,6 +1782,13 @@ fn show_workspace_status_toast(
     cx: &mut App,
 ) {
     let message: SharedString = message.into();
+    if debug_workspace_create_toasts_enabled() {
+        log::info!(
+            "superzent create toast: toggling status toast on workspace_entity_id={} message={}",
+            workspace_handle.entity_id(),
+            message
+        );
+    }
     let status_toast = StatusToast::new(message, cx, move |this: StatusToast, _cx| {
         this.icon(icon).dismiss_button(true)
     });
@@ -1784,63 +1797,43 @@ fn show_workspace_status_toast(
     });
 }
 
-fn clear_workspace_setup_attention(
-    store: &mut SuperzentStore,
-    workspace_id: &str,
-    cx: &mut Context<SuperzentStore>,
-) {
-    let should_clear = store
-        .workspace(workspace_id)
-        .and_then(|workspace| workspace.last_attention_reason.as_deref())
-        == Some(WORKSPACE_SETUP_IN_PROGRESS_REASON);
-
-    if should_clear {
-        store.set_workspace_attention(
-            workspace_id,
-            WorkspaceAttentionStatus::Idle,
-            false,
-            None,
-            cx,
-        );
-    }
-}
-
-fn can_mark_workspace_setup_attention(workspace: &WorkspaceEntry) -> bool {
-    workspace.attention_status == WorkspaceAttentionStatus::Idle && !workspace.review_pending
-}
-
-fn mark_workspace_setup_attention(
-    store: &mut SuperzentStore,
-    workspace_id: &str,
-    cx: &mut Context<SuperzentStore>,
-) {
-    let should_mark = store
-        .workspace(workspace_id)
-        .is_some_and(can_mark_workspace_setup_attention);
-
-    if should_mark {
-        store.set_workspace_attention(
-            workspace_id,
-            WorkspaceAttentionStatus::Working,
-            false,
-            Some(WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string()),
-            cx,
-        );
-    }
-}
-
-fn show_current_window_status_toast(
+fn show_resolved_workspace_status_toast(
+    workspace_handle: Option<&Entity<Workspace>>,
     message: impl Into<SharedString>,
     icon: ToastIcon,
     cx: &mut AsyncWindowContext,
 ) {
+    let message: SharedString = message.into();
     if let Err(error) = cx.update(|window, cx| {
-        let Some(workspace) = workspace_from_window(window, cx) else {
+        if debug_workspace_create_toasts_enabled() {
+            log::info!(
+                "superzent create toast: resolving target message={} provided_workspace_present={}",
+                message,
+                workspace_handle.is_some()
+            );
+        }
+        let workspace = workspace_handle
+            .cloned()
+            .or_else(|| workspace_from_window(window, cx));
+        let Some(workspace) = workspace else {
+            if debug_workspace_create_toasts_enabled() {
+                log::warn!(
+                    "superzent create toast: no workspace target resolved for message={}",
+                    message
+                );
+            }
             return;
         };
-        show_workspace_status_toast(&workspace, message, icon, cx);
+        if debug_workspace_create_toasts_enabled() {
+            log::info!(
+                "superzent create toast: resolved target workspace_entity_id={} message={}",
+                workspace.entity_id(),
+                message
+            );
+        }
+        show_workspace_status_toast(&workspace, message.clone(), icon, cx);
     }) {
-        log::error!("failed to show current window status toast: {error:#}");
+        log::error!("failed to show workspace status toast: {error:#}");
     }
 }
 
@@ -2016,14 +2009,6 @@ fn delete_workspace_prompt_details(
                 failure_details: Some(failure.details()),
             }
         }
-    }
-}
-
-const WORKSPACE_SETUP_IN_PROGRESS_REASON: &str = "Setting up workspace…";
-fn workspace_setup_row_state(workspace: &WorkspaceEntry) -> Option<WorkspaceSetupRowState> {
-    match workspace.last_attention_reason.as_deref() {
-        Some(WORKSPACE_SETUP_IN_PROGRESS_REASON) => Some(WorkspaceSetupRowState::InProgress),
-        _ => None,
     }
 }
 
@@ -2319,6 +2304,7 @@ fn spawn_new_workspace_request(
     window
         .spawn(cx, async move |cx| {
             let mut move_changes_failure: Option<String> = None;
+            let mut dirty_move_choice: Option<DirtyWorkspaceCreateChoice> = None;
             let outcome = match &project.location {
                 ProjectLocation::Local { .. } => {
                     match create_local_workspace(
@@ -2351,15 +2337,16 @@ fn spawn_new_workspace_request(
                                 )
                             })?;
 
-                            let dirty_choice = match prompt.await {
+                            let dirty_choice_prompt = match prompt.await {
                                 Ok(1) => Some(DirtyWorkspaceCreateChoice::CreateOnly),
                                 Ok(2) => Some(DirtyWorkspaceCreateChoice::CreateAndMoveChanges),
                                 _ => None,
                             };
 
-                            let Some(dirty_choice) = dirty_choice else {
+                            let Some(selected_dirty_choice) = dirty_choice_prompt else {
                                 return Ok::<(), anyhow::Error>(());
                             };
+                            dirty_move_choice = Some(selected_dirty_choice);
 
                             let outcome = create_local_workspace(
                                 project.clone(),
@@ -2376,33 +2363,6 @@ fn spawn_new_workspace_request(
                                 cx,
                             )
                             .await?;
-
-                            if dirty_choice == DirtyWorkspaceCreateChoice::CreateAndMoveChanges {
-                                let source_workspace_path = move_changes_source_path(
-                                    base_workspace_path.as_deref(),
-                                    &project,
-                                );
-                                let target_worktree_path = outcome
-                                    .workspace
-                                    .local_worktree_path()
-                                    .map(Path::to_path_buf);
-
-                                if let (Some(source_workspace_path), Some(target_worktree_path)) =
-                                    (source_workspace_path, target_worktree_path)
-                                {
-                                    if let Err(error) = cx
-                                        .background_spawn(async move {
-                                            superzent_git::move_changes_to_workspace(
-                                                &source_workspace_path,
-                                                &target_worktree_path,
-                                            )
-                                        })
-                                        .await
-                                    {
-                                        move_changes_failure = Some(error.to_string());
-                                    }
-                                }
-                            }
 
                             Ok(outcome)
                         }
@@ -2445,21 +2405,53 @@ fn spawn_new_workspace_request(
                 return Ok::<(), anyhow::Error>(());
             }
 
-            let open_task = cx.update(|window, cx| {
-                open_workspace_entry(workspace_entry.clone(), app_state.clone(), window, cx)
-            })?;
-            if let Err(error) = open_task.await {
-                show_workspace_toast_async(
-                    &workspace_handle,
-                    format!("Failed to open workspace: {error}"),
-                    cx,
-                );
-                return Ok::<(), anyhow::Error>(());
-            }
-
             let current_window_handle = cx.update(|window, _| window.window_handle())?;
-            let visible_workspace =
-                resolve_opened_workspace(&workspace_entry, current_window_handle, cx).await;
+            let visible_workspace = match &workspace_entry.location {
+                WorkspaceLocation::Local { worktree_path } => {
+                    let open_task = cx.update(|window, cx| {
+                        open_local_workspace_path_and_resolve(
+                            worktree_path.clone(),
+                            app_state.clone(),
+                            window,
+                            cx,
+                        )
+                    })?;
+                    match open_task.await {
+                        Ok(workspace) => Some(workspace),
+                        Err(error) => {
+                            show_workspace_toast_async(
+                                &workspace_handle,
+                                format!("Failed to open workspace: {error}"),
+                                cx,
+                            );
+                            return Ok::<(), anyhow::Error>(());
+                        }
+                    }
+                }
+                WorkspaceLocation::Ssh { .. } => {
+                    let open_task = cx.update(|window, cx| {
+                        open_workspace_entry(workspace_entry.clone(), app_state.clone(), window, cx)
+                    })?;
+                    if let Err(error) = open_task.await {
+                        show_workspace_toast_async(
+                            &workspace_handle,
+                            format!("Failed to open workspace: {error}"),
+                            cx,
+                        );
+                        return Ok::<(), anyhow::Error>(());
+                    }
+
+                    resolve_opened_workspace(&workspace_entry, current_window_handle, cx).await
+                }
+            };
+            let opened_workspace = visible_workspace.clone();
+            if debug_workspace_create_toasts_enabled() {
+                log::info!(
+                    "superzent create toast: workspace resolved after open workspace_id={} opened_workspace_present={}",
+                    workspace_entry.id,
+                    opened_workspace.is_some()
+                );
+            }
 
             if let (Some(visible_workspace), Some(notice)) =
                 (visible_workspace.as_ref(), outcome.notice.clone())
@@ -2469,7 +2461,7 @@ fn spawn_new_workspace_request(
                 })?;
             }
 
-            let should_launch_preset = if matches!(project.location, ProjectLocation::Local { .. }) {
+            let setup_result = if matches!(project.location, ProjectLocation::Local { .. }) {
                 let project = project.clone();
                 let workspace_entry_for_setup = workspace_entry.clone();
                 let base_workspace_path = base_workspace_path.clone();
@@ -2479,11 +2471,14 @@ fn spawn_new_workspace_request(
                     .map(|script| !script.trim().is_empty())
                     .unwrap_or(false)
                 {
-                    let _ = update_store_async(&store, cx, |store, cx| {
-                        mark_workspace_setup_attention(store, &workspace_entry.id, cx);
-                    });
-                    let setup_result = cx
-                        .background_spawn(async move {
+                    show_resolved_workspace_status_toast(
+                        opened_workspace.as_ref(),
+                        "Running setup…",
+                        ToastIcon::new(IconName::ArrowCircle).color(Color::Muted),
+                        cx,
+                    );
+                    Some(
+                        cx.background_spawn(async move {
                             superzent_git::run_workspace_setup(
                                 &project,
                                 &workspace_entry_for_setup,
@@ -2491,113 +2486,48 @@ fn spawn_new_workspace_request(
                                 setup_script.as_deref(),
                             )
                         })
-                        .await;
-                    // Always resolve the currently *active* workspace at completion
-                    // time: the handle captured before setup may now point to a
-                    // hidden tab if the user navigated away, and toasts attached
-                    // to a hidden tab are never drawn. When nothing is active for
-                    // this entry we fall back to the current window so the user
-                    // still sees the result.
-                    //
-                    // The current window must be checked via `workspace_from_window`
-                    // (using the `Window` arg) because it's already on the stack
-                    // inside `cx.update`, so any `read_window`-based lookup
-                    // (including `WindowHandle::read_with`) would panic. The
-                    // iteration helper uses `WindowHandle::read` which skips the
-                    // stack-locked current window gracefully.
-                    let setup_visible_workspace = cx
-                        .update(|window, cx| {
-                            workspace_from_window(window, cx)
-                                .filter(|active| {
-                                    workspace_matches_entry(active, &workspace_entry, cx)
-                                })
-                                .or_else(|| {
-                                    currently_active_workspace_for_entry(&workspace_entry, cx)
-                                })
-                        })
-                        .ok()
-                        .flatten();
-
-                    match setup_result {
-                        Ok(()) => {
-                            let _ = update_store_async(&store, cx, |store, cx| {
-                                clear_workspace_setup_attention(store, &workspace_entry.id, cx);
-                            });
-                            if let Some(visible_workspace) = setup_visible_workspace.as_ref() {
-                                if let Err(error) = cx.update(|_, cx| {
-                                    show_workspace_status_toast(
-                                        visible_workspace,
-                                        format!("Setup finished for `{}`.", workspace_entry.name),
-                                        ToastIcon::new(IconName::Check).color(Color::Success),
-                                        cx,
-                                    );
-                                }) {
-                                    log::error!("failed to show workspace setup success toast: {error:#}");
-                                }
-                            } else {
-                                show_current_window_status_toast(
-                                    format!("Setup finished for `{}`.", workspace_entry.name),
-                                    ToastIcon::new(IconName::Check).color(Color::Success),
-                                    cx,
-                                );
-                            }
-                            true
-                        }
-                        Err(setup_failure) => {
-                            let _ = update_store_async(&store, cx, |store, cx| {
-                                clear_workspace_setup_attention(store, &workspace_entry.id, cx);
-                            });
-                            let prompt_detail = workspace_lifecycle_failure_prompt_detail(
-                                &workspace_entry,
-                                &setup_failure,
-                                outcome.notice.as_deref(),
-                                false,
-                            );
-                            let setup_prompt = cx.update(|window, cx| {
-                                // Prefer toasting the workspace where setup ran
-                                // when it's still the active tab; otherwise pop
-                                // the notice on the current window so the user
-                                // sees the failure regardless of navigation.
-                                if let Some(visible_workspace) =
-                                    setup_visible_workspace.as_ref()
-                                {
-                                    show_workspace_toast(
-                                        visible_workspace,
-                                        setup_failure.summary(),
-                                        cx,
-                                    );
-                                } else if let Some(current_workspace) =
-                                    workspace_from_window(window, cx)
-                                {
-                                    show_workspace_toast(
-                                        &current_workspace,
-                                        setup_failure.summary(),
-                                        cx,
-                                    );
-                                } else {
-                                    log::warn!(
-                                        "workspace setup failed and no window is available to show the error: {}",
-                                        setup_failure.summary()
-                                    );
-                                }
-                                window.prompt(
-                                    PromptLevel::Warning,
-                                    "Workspace created, but setup failed",
-                                    Some(&prompt_detail),
-                                    &["OK"],
-                                    cx,
-                                )
-                            })?;
-                            let _ = setup_prompt.await;
-                            false
-                        }
-                    }
+                        .await,
+                    )
                 } else {
-                    true
+                    None
                 }
             } else {
-                true
+                None
             };
+
+            if dirty_move_choice == Some(DirtyWorkspaceCreateChoice::CreateAndMoveChanges) {
+                let source_workspace_path =
+                    move_changes_source_path(base_workspace_path.as_deref(), &project);
+                let target_worktree_path = workspace_entry
+                    .local_worktree_path()
+                    .map(Path::to_path_buf);
+
+                if let (Some(source_workspace_path), Some(target_worktree_path)) =
+                    (source_workspace_path, target_worktree_path)
+                {
+                    show_resolved_workspace_status_toast(
+                        opened_workspace.as_ref(),
+                        "Moving local changes…",
+                        ToastIcon::new(IconName::ArrowCircle).color(Color::Muted),
+                        cx,
+                    );
+                    if let Err(error) = cx
+                        .background_spawn(async move {
+                            superzent_git::move_changes_to_workspace(
+                                &source_workspace_path,
+                                &target_worktree_path,
+                            )
+                        })
+                        .await
+                    {
+                        move_changes_failure = Some(error.to_string());
+                    }
+                }
+            }
+
+            let should_launch_preset = setup_result
+                .as_ref()
+                .is_none_or(|result| result.is_ok());
 
             if should_launch_preset {
                 let target_workspace = if let Some(visible_workspace) = visible_workspace.clone() {
@@ -2621,6 +2551,57 @@ fn spawn_new_workspace_request(
                     log::warn!(
                         "workspace opened, but the new workspace view could not be resolved for preset launch"
                     );
+                }
+            }
+
+            if let Some(setup_result) = setup_result {
+                match setup_result {
+                    Ok(()) => {
+                        show_resolved_workspace_status_toast(
+                            opened_workspace.as_ref(),
+                            format!("Setup finished for `{}`.", workspace_entry.name),
+                            ToastIcon::new(IconName::Check).color(Color::Success),
+                            cx,
+                        );
+                    }
+                    Err(setup_failure) => {
+                        let prompt_detail = workspace_lifecycle_failure_prompt_detail(
+                            &workspace_entry,
+                            &setup_failure,
+                            outcome.notice.as_deref(),
+                            false,
+                        );
+                        let setup_prompt = cx.update(|window, cx| {
+                            if let Some(visible_workspace) = visible_workspace.as_ref() {
+                                show_workspace_toast(
+                                    visible_workspace,
+                                    setup_failure.summary(),
+                                    cx,
+                                );
+                            } else if let Some(current_workspace) =
+                                workspace_from_window(window, cx)
+                            {
+                                show_workspace_toast(
+                                    &current_workspace,
+                                    setup_failure.summary(),
+                                    cx,
+                                );
+                            } else {
+                                log::warn!(
+                                    "workspace setup failed and no window is available to show the error: {}",
+                                    setup_failure.summary()
+                                );
+                            }
+                            window.prompt(
+                                PromptLevel::Warning,
+                                "Workspace created, but setup failed",
+                                Some(&prompt_detail),
+                                &["OK"],
+                                cx,
+                            )
+                        })?;
+                        let _ = setup_prompt.await;
+                    }
                 }
             }
 
@@ -4419,15 +4400,6 @@ impl SuperzentSidebar {
         let row_status_pill = match workspace_row_status_kind(workspace, is_open_in_current_window)
         {
             WorkspaceRowStatusKind::Hidden => None,
-            WorkspaceRowStatusKind::SetupInProgress => Some(render_workspace_setup_status_pill(
-                "Setting up…",
-                Color::Warning,
-                workspace
-                    .last_attention_reason
-                    .clone()
-                    .unwrap_or_else(|| WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string()),
-                cx,
-            )),
             WorkspaceRowStatusKind::Open => Some(render_workspace_open_pill(cx)),
             WorkspaceRowStatusKind::GitChanges => render_workspace_git_status_pill(workspace, cx),
         };
@@ -6961,6 +6933,57 @@ fn open_local_workspace_path(
     })
 }
 
+fn open_local_workspace_path_and_resolve(
+    path: PathBuf,
+    app_state: Arc<WorkspaceAppState>,
+    window: &mut gpui::Window,
+    cx: &mut App,
+) -> Task<anyhow::Result<Entity<Workspace>>> {
+    let Some(multi_workspace) = window.window_handle().downcast::<MultiWorkspace>() else {
+        let task = Workspace::new_local(vec![path], app_state, None, None, None, true, cx);
+        return cx.spawn(async move |cx| {
+            let (window_handle, _) = task.await?;
+            window_handle.update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+        });
+    };
+
+    if let Ok(multi_workspace_ref) = multi_workspace.read(cx)
+        && let Some(index) = multi_workspace_ref
+            .workspaces()
+            .iter()
+            .enumerate()
+            .find_map(|(index, workspace)| {
+                workspace_contains_local_worktree_path(workspace, &path, cx).then_some(index)
+            })
+    {
+        return cx.spawn(async move |cx| {
+            multi_workspace.update(cx, |multi_workspace, window, cx| {
+                window.activate_window();
+                multi_workspace.activate_index(index, window, cx);
+                multi_workspace.workspace().clone()
+            })
+        });
+    }
+
+    let task = Workspace::new_local(
+        vec![path],
+        app_state,
+        Some(multi_workspace),
+        None,
+        None,
+        true,
+        cx,
+    );
+    cx.spawn(async move |cx| {
+        let (window_handle, _) = task.await?;
+        window_handle.update(cx, |multi_workspace, _, _| {
+            multi_workspace.workspace().clone()
+        })
+    })
+}
+
 fn open_workspace_entry(
     workspace_entry: WorkspaceEntry,
     app_state: Arc<WorkspaceAppState>,
@@ -7267,32 +7290,6 @@ fn workspace_for_entry_in_any_window(
                 .iter()
                 .find(|workspace| workspace_matches_entry(workspace, workspace_entry, cx))
                 .cloned()
-        })
-}
-
-/// Returns the workspace entity only if it's the *currently visible* (active)
-/// tab inside some MultiWorkspace window **other than the current one**.
-/// Toasts attached to a workspace are only rendered by the bottom-right
-/// status layer when that workspace is the active tab, so callers that need
-/// to guarantee visibility must use this helper (combined with a separate
-/// current-window check) instead of `workspace_for_entry_in_any_window`,
-/// which would also match hidden tabs.
-///
-/// Uses `WindowHandle::read` (which returns `Err` for stack-locked windows)
-/// rather than `read_with` (which panics via `cx.read_window`). This means
-/// the current window is automatically skipped when called from inside
-/// `cx.update(|_, cx| ...)` — callers must check the current window
-/// separately.
-fn currently_active_workspace_for_entry(
-    workspace_entry: &WorkspaceEntry,
-    cx: &App,
-) -> Option<Entity<Workspace>> {
-    ordered_multi_workspace_windows(cx)
-        .into_iter()
-        .find_map(|handle| {
-            let multi_workspace = handle.read(cx).ok()?;
-            let active = multi_workspace.workspace().clone();
-            workspace_matches_entry(&active, workspace_entry, cx).then_some(active)
         })
 }
 
@@ -8048,12 +8045,6 @@ fn workspace_row_status_kind(
         return WorkspaceRowStatusKind::Hidden;
     }
 
-    if let Some(setup_state) = workspace_setup_row_state(workspace) {
-        return match setup_state {
-            WorkspaceSetupRowState::InProgress => WorkspaceRowStatusKind::SetupInProgress,
-        };
-    }
-
     if workspace_git_status_visual_summary(workspace).is_some() {
         WorkspaceRowStatusKind::GitChanges
     } else {
@@ -8064,14 +8055,8 @@ fn workspace_row_status_kind(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WorkspaceRowStatusKind {
     Hidden,
-    SetupInProgress,
     Open,
     GitChanges,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum WorkspaceSetupRowState {
-    InProgress,
 }
 
 fn render_workspace_open_pill(cx: &mut Context<SuperzentSidebar>) -> gpui::AnyElement {
@@ -8079,20 +8064,6 @@ fn render_workspace_open_pill(cx: &mut Context<SuperzentSidebar>) -> gpui::AnyEl
         .label_color(Color::Muted)
         .bg_color(cx.theme().colors().element_background)
         .border_color(cx.theme().colors().border_variant)
-        .into_any_element()
-}
-
-fn render_workspace_setup_status_pill(
-    label: &'static str,
-    color: Color,
-    tooltip: String,
-    cx: &mut Context<SuperzentSidebar>,
-) -> gpui::AnyElement {
-    Chip::new(label)
-        .label_color(color)
-        .bg_color(cx.theme().colors().element_background)
-        .border_color(cx.theme().colors().border_variant)
-        .tooltip(move |window, cx| ui::Tooltip::text(tooltip.clone())(window, cx))
         .into_any_element()
 }
 
@@ -9101,32 +9072,6 @@ mod tests {
             workspace_row_status_kind(&workspace, true),
             WorkspaceRowStatusKind::GitChanges
         );
-    }
-
-    #[test]
-    fn workspace_row_status_kind_shows_setup_in_progress_before_open_pill() {
-        let mut workspace = workspace_entry(WorkspaceKind::Primary);
-        workspace.attention_status = WorkspaceAttentionStatus::Working;
-        workspace.last_attention_reason = Some(WORKSPACE_SETUP_IN_PROGRESS_REASON.to_string());
-
-        assert_eq!(
-            workspace_row_status_kind(&workspace, true),
-            WorkspaceRowStatusKind::SetupInProgress
-        );
-    }
-
-    #[test]
-    fn can_mark_workspace_setup_attention_only_when_idle_without_review_pending() {
-        let workspace = workspace_entry(WorkspaceKind::Primary);
-        assert!(can_mark_workspace_setup_attention(&workspace));
-
-        let mut permission_workspace = workspace_entry(WorkspaceKind::Primary);
-        permission_workspace.attention_status = WorkspaceAttentionStatus::Permission;
-        assert!(!can_mark_workspace_setup_attention(&permission_workspace));
-
-        let mut review_workspace = workspace_entry(WorkspaceKind::Primary);
-        review_workspace.review_pending = true;
-        assert!(!can_mark_workspace_setup_attention(&review_workspace));
     }
 
     #[test]

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -7702,9 +7702,6 @@ fn build_local_workspace_bundle(
     let WorkspaceLocation::Local { worktree_path } = &workspace_location else {
         return None;
     };
-    if !worktree_path.exists() {
-        return None;
-    }
 
     let project_handle = workspace.read(cx).project();
     let project = project_handle.read(cx);

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -66,7 +66,7 @@ use std::{
 use sum_tree::{Bias, Dimensions, Edit, KeyedItem, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
 use util::{
-    ResultExt, debug_panic, maybe,
+    ResultExt, maybe,
     paths::{PathMatcher, PathStyle, SanitizedPath, home_dir},
     rel_path::RelPath,
 };
@@ -5115,10 +5115,12 @@ impl BackgroundScanner {
             match existing_repository_entry {
                 None => {
                     let Ok(relative) = dot_git_dir.strip_prefix(state.snapshot.abs_path()) else {
-                        debug_panic!(
-                            "update_git_repositories called with .git directory outside the worktree root"
+                        log::warn!(
+                            "ignoring git directory outside the worktree root during repository refresh: {} (worktree root: {})",
+                            dot_git_dir.display(),
+                            state.snapshot.abs_path().display()
                         );
-                        return Vec::new();
+                        continue;
                     };
                     affected_repo_roots.push(dot_git_dir.parent().unwrap().into());
                     state

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -6997,6 +6997,7 @@ mod tests {
                             attention_status: WorkspaceAttentionStatus::Idle,
                             review_pending: false,
                             last_attention_reason: None,
+                            teardown_script_override: None,
                             created_at: opened_at,
                             last_opened_at: opened_at,
                         },

--- a/docs/brainstorms/2026-04-06-managed-workspace-lifecycle-config-requirements.md
+++ b/docs/brainstorms/2026-04-06-managed-workspace-lifecycle-config-requirements.md
@@ -1,0 +1,85 @@
+---
+date: 2026-04-06
+topic: managed-workspace-lifecycle-config
+---
+
+# Managed Workspace Lifecycle Config
+
+## Problem Frame
+
+`superzent` already creates and deletes managed local workspaces through a dedicated flow, but repo-specific lifecycle behavior is still implicit and incomplete. Teams want a committed way to run setup and cleanup steps for each managed workspace, and they also want predictable control over which branch new worktrees are based on.
+
+Without an explicit repo-level lifecycle contract, common tasks like copying env files, starting or stopping local services, and choosing a stable base branch are handled ad hoc. The current behavior is also inconsistent: teardown logic exists in a hidden form, setup is not first-class, and managed workspace creation still relies on implicit branch selection instead of an explicit policy.
+
+## Requirements
+
+**Config Surface**
+
+- R1. For v1, `superzent` must read managed workspace lifecycle config only from the repo-root `.superzent/config.json`.
+- R2. `.superzent/config.json` must support three top-level user-facing fields: `setup`, `teardown`, and `base_branch`.
+- R3. `setup` and `teardown` must be arrays of shell commands executed in order.
+- R4. If `.superzent/config.json` is absent, managed workspace creation and deletion must still work with no lifecycle commands.
+- R5. v1 must not add `.superzent/config.local.json`, home-directory overrides, or any other config precedence layer.
+- R6. Copying or deleting repo files as part of workspace lifecycle must be expressed through `setup` or `teardown` commands rather than a separate first-class `copy` config field.
+
+**Lifecycle Execution**
+
+- R7. `setup` commands must run only when a managed local workspace is created, after the worktree directory exists.
+- R8. `teardown` commands must run only when a managed local workspace is deleted.
+- R9. Opening, focusing, closing, or re-opening an existing workspace in the current window must not trigger `setup` or `teardown`.
+- R10. Lifecycle commands must run sequentially with the managed worktree as the working directory.
+- R11. Lifecycle commands must receive a stable environment contract containing `SUPERZENT_ROOT_PATH`, `SUPERZENT_WORKTREE_PATH`, and `SUPERZENT_WORKSPACE_NAME`.
+- R12. If `setup` fails, `superzent` must keep the new worktree and workspace, surface the failure and logs, and leave the workspace available for manual recovery.
+- R13. If `teardown` fails, `superzent` must block deletion, surface the failure and logs, and offer an explicit force-delete path that skips the failing teardown on retry.
+- R14. v1 lifecycle execution applies only to managed local workspaces and must not attempt to run repo lifecycle automation for SSH or other remote workspaces.
+
+**Base Branch Selection**
+
+- R15. Managed workspace creation must allow a one-off base branch override at create time.
+- R16. When no one-off override is provided, managed workspace creation must use `.superzent/config.json` `base_branch` if it is configured.
+- R17. When neither a one-off override nor a configured `base_branch` is available, managed workspace creation must fall back to the base workspace's current branch.
+- R18. If the configured `base_branch` is missing or no longer exists, `superzent` must fall back to the base workspace's current branch when available, otherwise the repository default branch, and tell the user the configured branch could not be used.
+- R19. Before a managed workspace is created, the create flow must make the effective base branch clear to the user.
+
+## Success Criteria
+
+- A repo can commit `.superzent/config.json` and use it to standardize managed workspace setup, cleanup, and default base branch behavior.
+- Creating a managed local workspace runs `setup` once, uses the expected effective base branch, and does not re-run setup when the workspace is later re-opened.
+- A failed `setup` leaves behind a usable workspace with visible logs so the user can fix the problem in place.
+- A failed `teardown` does not silently remove the workspace; the user must explicitly force deletion to continue.
+- Teams can express env-file copy, local service startup, cleanup, and similar lifecycle behavior through scripts instead of one-off manual steps.
+
+## Scope Boundaries
+
+- This change applies to managed local workspace creation and deletion flows, not to simple open/close behavior inside the current window.
+- This change does not add lifecycle automation for SSH or other remote workspaces in v1.
+- This change does not add repo-local or user-local config override layers beyond repo-root `.superzent/config.json`.
+- This change does not introduce a first-class `copy` field in the public config surface.
+- This change does not require the generic Git worktree picker and every other worktree creation entry point to honor the new config in v1.
+
+## Key Decisions
+
+- Create/delete semantics only: lifecycle automation should map to actual resource creation and removal, not transient window open/close actions.
+- Repo-root config only in v1: the first shipped version should avoid config merge and precedence rules.
+- Scripts instead of declarative copy rules: one mechanism is easier to teach and extend than both shell hooks and a separate copy DSL.
+- Base branch resolution order is `create-time override -> configured base_branch -> base workspace current branch -> repository default branch`.
+- Setup failures are recoverable, while teardown failures are protective: creation should continue with visibility, but deletion should stop unless the user explicitly forces it.
+
+## Dependencies / Assumptions
+
+- Managed local workspace creation and deletion already flow through `crates/superzent_git`, which is the natural integration point for v1 lifecycle behavior.
+- The repository default branch can be resolved at managed workspace creation time for local repos.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R6][Technical] What is the lowest-risk way to remove or phase out the hidden `copy` handling that already exists in `crates/superzent_git`?
+- [Affects R12][Technical] What is the best existing UI surface for showing setup failure logs and recovery actions during managed workspace creation?
+- [Affects R13][Technical] What is the best existing UI surface for showing teardown failure logs and the force-delete action during managed workspace deletion?
+- [Affects R19][Needs research] Which managed workspace creation UI should own the base-branch override so the effective branch is visible before creation without widening scope into unrelated worktree flows?
+- [Affects R15][Technical] Should the generic Git worktree picker adopt the same base-branch policy in a later follow-up, or remain separate from managed workspace config?
+
+## Next Steps
+
+-> /prompts:ce-plan for structured implementation planning

--- a/docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
+++ b/docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
@@ -1,0 +1,79 @@
+---
+date: 2026-04-10
+topic: managed-workspace-lifecycle-compaction
+---
+
+# Managed Workspace Lifecycle Compaction
+
+## Problem Frame
+
+The recently added managed workspace lifecycle feature preserves important user-facing behavior, but the internal implementation has become larger and more coupled than it needs to be. The goal of this follow-up is to keep the current user contract intact while making the code more compact, more accurate about sources of truth, and easier to evolve without touching multiple unrelated layers for one behavior change.
+
+## Requirements
+
+**Source Of Truth**
+
+- R1. Repo-level lifecycle defaults must come from repo-root `.superzent/config.json` and remain the default source of truth for `base_branch`, `setup`, and `teardown`.
+- R2. A workspace-local override is allowed only for `teardown`, and only when the user provided a non-saved teardown value during workspace creation.
+- R3. A workspace-local teardown override must persist across app restarts so later delete behavior matches what the user chose at create time.
+
+**Create Contract**
+
+- R4. `setup` remains a create-time-only action and must not become a persisted per-workspace behavior.
+- R5. The create modal must continue to allow both `setup` and `teardown` input.
+- R5a. The current save-toggle semantics must be made explicit; if a single save control remains, it must apply only to repo-default teardown persistence rather than implicitly persisting `setup`.
+- R6. The create flow should not depend on re-entering the current workspace state during modal construction or other similarly fragile UI initialization paths.
+
+**Delete Contract**
+
+- R7. The delete confirmation must always show the actual final teardown script that will run, or clearly indicate that no teardown script will run.
+- R8. When the teardown script is long or multiline, the confirmation should present it in a scrollable code block rather than truncating or hiding it.
+- R9. If repo config is malformed or unreadable, normal delete should be blocked, but `Delete Anyway` must remain available as an explicit recovery path.
+- R9a. When unreadable config blocks normal delete, the recovery flow must explicitly state that `Delete Anyway` skips teardown rather than retrying an unknown script.
+
+**Compaction Goals**
+
+- R10. Internal simplification must preserve the current managed local workspace feature set rather than removing behavior for the sake of smaller code.
+- R11. Repo defaults should not be duplicated into unrelated workspace persistence or sync paths unless that duplication is necessary to preserve the explicit workspace-local teardown override contract.
+- R12. Delete flow state should become easier to reason about by reducing split ownership across global state, result plumbing, and post-delete cleanup decisions.
+
+## Success Criteria
+
+- A reader can identify one default source of truth for lifecycle behavior and one narrow exception for persisted teardown overrides.
+- The create and delete user experience remains functionally equivalent for current managed local workspace behavior.
+- The implementation has fewer cross-layer data propagation paths and fewer hidden state transitions than the current version.
+- The refined design gives planning a clear target for simplification without inventing new user-facing behavior.
+
+## Scope Boundaries
+
+- Do not remove support for repo-root `.superzent/config.json`.
+- Do not remove `setup` or `teardown` inputs from the create modal.
+- Do not add a post-create UI for editing workspace-local teardown overrides.
+- Do not change remote workspace behavior in this pass.
+- Do not broaden this effort into agent-native parity work or a generalized job/logging system.
+
+## Key Decisions
+
+- Repo config remains the default contract: it is the baseline lifecycle source of truth rather than something inferred from workspace metadata.
+- `setup` is intentionally one-shot: it applies during creation only and should not linger as workspace-local behavior.
+- `teardown` is the only allowed persisted workspace-local override because users may reasonably expect delete-time cleanup to honor what they chose at create time.
+- Delete confirmation should always show the final script that will run, but it does not need to explain whether it came from repo config or a workspace-local override.
+- If config is broken, delete should stay conservative by default while still offering an explicit `Delete Anyway` escape hatch.
+- If the create modal keeps one save checkbox, that control should persist repo-default teardown only; `setup` remains one-shot even when the checkbox is selected.
+
+## Dependencies / Assumptions
+
+- The current managed workspace lifecycle feature and docs remain the behavior baseline for this refactor.
+- The simplification effort is allowed to change internal ownership boundaries as long as the user contract above stays intact.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R11][Technical] What is the smallest persistence shape that preserves workspace-local teardown overrides without copying repo defaults through every workspace sync path?
+- [Affects R12][Technical] What is the simplest delete-flow structure that keeps explicit recovery behavior while reducing state split across UI helpers?
+- [Affects R6][Technical] Which create-time values should always be precomputed before modal construction to avoid re-entrant UI state access?
+
+## Next Steps
+
+-> /ce:plan for structured implementation planning

--- a/docs/plans/2026-04-06-001-feat-managed-workspace-lifecycle-config-plan.md
+++ b/docs/plans/2026-04-06-001-feat-managed-workspace-lifecycle-config-plan.md
@@ -1,0 +1,374 @@
+---
+title: feat: Add managed workspace lifecycle config
+type: feat
+status: completed
+date: 2026-04-06
+origin: docs/brainstorms/2026-04-06-managed-workspace-lifecycle-config-requirements.md
+---
+
+# feat: Add managed workspace lifecycle config
+
+## Overview
+
+Add a repo-committed `.superzent/config.json` contract for managed local workspace lifecycle automation and default base-branch policy. The implementation should make `setup` and `teardown` first-class for managed local workspace create/delete flows, replace the hidden `copy` behavior with script-driven setup, and let the create flow surface and override the effective base branch without widening scope into remote workspaces or every generic worktree entry point (see origin: `docs/brainstorms/2026-04-06-managed-workspace-lifecycle-config-requirements.md`).
+
+## Problem Frame
+
+Today `superzent` already routes managed local workspace creation and deletion through `crates/superzent_git`, but the lifecycle contract is partial and internally inconsistent. The code still chooses a new worktree base from the current branch, still carries hidden `copy` behavior inspired by `superset`, and only exposes teardown hooks indirectly. The product intent is to turn this into an explicit `superzent` contract: repo-root config only, scripts only, create/delete semantics only, local managed workspaces only, and a predictable base-branch resolution order that users can see before creating a workspace.
+
+## Requirements Trace
+
+- R1-R5. Define the v1 config surface as repo-root `.superzent/config.json` with only `setup`, `teardown`, and `base_branch`, and no config layering.
+- R6. Remove `copy` as a first-class lifecycle concept and make setup scripts the supported way to copy or prepare files.
+- R7-R14. Run lifecycle commands only for managed local workspace create/delete, sequentially, with a stable environment contract; keep setup failures recoverable and teardown failures blocking unless force-deleted.
+- R15-R19. Add a one-off base-branch override, default to configured `base_branch`, otherwise fall back to the base workspace current branch, and make the effective choice visible in the create flow.
+
+## Scope Boundaries
+
+- Do not add lifecycle automation for SSH or other remote workspaces in this phase.
+- Do not add `.superzent/config.local.json`, home-directory overrides, or merge rules.
+- Do not broaden the feature to the generic `git_ui` worktree picker or every worktree creation entry point in v1.
+- Do not keep `copy` as a supported public config field.
+- Do not turn this plan into a general-purpose task runner or background-job system; the scope is limited to synchronous create/delete lifecycle commands.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/superzent_git/src/lib.rs`
+  - `create_workspace` and `delete_workspace` already own managed local workspace lifecycle for the product surface that matters here.
+  - `CreateWorkspaceOptions` currently only carries `branch_name`.
+  - `load_superzent_config`, `prepare_workspace_contents`, and `run_repo_hooks` show that `.superzent/config.json`, hidden `copy`, and teardown hooks already exist in partial form.
+  - `run_shell_command` already executes shell commands in zsh with environment injection, but it currently exports `SUPERSET_*` variable names rather than a `SUPERZENT_*` contract.
+  - The inline tests in this file are already the primary regression harness for managed workspace creation and deletion behavior.
+- `crates/superzent_ui/src/lib.rs`
+  - `spawn_new_workspace_request` is the current local/remote branching seam for managed workspace creation.
+  - `NewWorkspaceModal` currently only collects a branch name, so it is the narrowest place to add base-branch preview and override for the managed local flow.
+  - `run_delete_workspace_entry` currently has a simple confirm/delete prompt and no structured teardown-failure recovery path.
+  - The current `warning` flow already shows post-create notices via toast after the workspace is opened, which is the natural seam for non-fatal setup failures.
+- `crates/git/src/repository.rs`
+  - `default_branch` already implements robust repository-default resolution (`upstream/HEAD`, `origin/HEAD`, `init.defaultBranch`, then `master`), which is better aligned with the new requirements than the current `superzent_git` "use the current branch" behavior.
+- `docs/src/getting-started.md`, `README.md`, and `docs/src/SUMMARY.md`
+  - These are the current user-facing docs surfaces for explaining core `superzent` workflows and are the right places to document repo lifecycle config.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`
+  - Cross-crate lifecycle failures in `superzent` often look like UI bugs but actually fail upstream. The plan should keep lifecycle outcomes structured and observable from the earliest failing stage instead of only surfacing a final generic toast.
+- `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`
+  - Product regressions came from coupling multiple concerns under one broad switch. This feature should keep config parsing, lifecycle execution, and UI presentation as separate contracts instead of blending them into one opaque workspace-creation path.
+
+### External References
+
+- None. Local patterns are strong enough, and the work is primarily about tightening `superzent`'s own product contract rather than adopting external framework behavior.
+
+## Key Technical Decisions
+
+- Scope the v1 implementation to the existing managed local workspace flow in `crates/superzent_git` and `crates/superzent_ui`.
+  - Rationale: this is the product seam already used for managed local workspace creation/deletion, and widening into `git_ui` or SSH paths would multiply scope without helping the first shipped behavior.
+- Resolve the effective base branch in `superzent_git` as `override -> configured base_branch -> base workspace current branch -> repository default branch`.
+  - Rationale: the workspace shell should branch from what the user is actively basing work on by default, while still preserving explicit repo policy and a final repository-default fallback.
+- Remove hidden copy preparation from the create flow and rely on scripts plus normal git-tracked worktree contents.
+  - Rationale: `.superzent` files that are committed already appear in the worktree after `git worktree add`, so manual copy behavior is redundant, non-obvious, and conflicts with the goal of making scripts the only supported lifecycle mechanism.
+- Model setup failure as successful worktree creation with attached lifecycle failure details, not as a top-level create error.
+  - Rationale: users need the created workspace left intact so they can inspect or repair the environment in place.
+- Model teardown failure as a structured failure that the UI can inspect and then bypass on an explicit force-delete retry.
+  - Rationale: the current plain `anyhow` surface is not expressive enough to support logs plus a deliberate "Delete Anyway" path.
+- Export `SUPERZENT_*` as the documented environment contract, while also exporting the legacy `SUPERSET_*` names during the transition.
+  - Rationale: the current hidden hook path already uses `SUPERSET_*`; dual export avoids silently breaking existing internal adopters while making `SUPERZENT_*` the supported contract going forward.
+- Keep setup-failure and teardown-failure logs in a small `superzent_ui`-owned lifecycle failure surface instead of inventing a global logs subsystem.
+  - Rationale: both failure modes originate in one product feature, and the repo does not already show a better generic log-viewing abstraction for this path.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Which create flow should own the base-branch override and preview?
+  - Resolution: `NewWorkspaceModal` in `crates/superzent_ui/src/lib.rs` for managed local workspaces only. Remote create remains unchanged in v1.
+- Should the generic Git worktree picker adopt the same config and base-branch policy in this phase?
+  - Resolution: no. Keep the first implementation scoped to managed local workspace flows and treat generic worktree parity as a follow-up.
+- How should base-branch resolution behave when `base_branch` is absent or stale?
+  - Resolution: use the base workspace current branch before falling back to repository-default semantics, then warn when a configured branch cannot be resolved.
+- What should replace the hidden `copy` behavior?
+  - Resolution: remove the manual copy preparation path and require repo setup steps to live in `setup` scripts or in files already tracked into the worktree.
+
+### Deferred to Implementation
+
+- Whether `superzent_git` should depend directly on the `git` crate for default-branch resolution or copy the current fallback logic into a local helper.
+  - Why deferred: both choices are valid at plan time; the implementer can pick the smaller dependency and code-movement cost once editing begins.
+- Whether the smallest log-viewing surface is a reusable lifecycle modal or a dedicated failure prompt followed by a read-only modal.
+  - Why deferred: the plan fixes the product behavior and ownership boundary, but the precise widget shape is easier to finalize against the current `superzent_ui` helpers during implementation.
+- Whether the force-delete retry should reuse the original confirmation path or branch into a dedicated teardown-failure prompt object.
+  - Why deferred: the semantic contract is fixed, but the cleanest prompt composition depends on the final structured delete error shape.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
+
+| Stage                      | Owner                             | Planned contract                                                                                                                                        |
+| -------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Repo config parse          | `crates/superzent_git/src/lib.rs` | Read repo-root `.superzent/config.json`; support `setup`, `teardown`, `base_branch`; no public `copy` path                                              |
+| Base branch resolution     | `crates/superzent_git/src/lib.rs` | Resolve `override -> configured base_branch -> base workspace current branch -> repo default`; return both effective branch and source/fallback warning |
+| Managed create UI          | `crates/superzent_ui/src/lib.rs`  | Collect branch name, optional local-only base-branch override, and show the effective base branch before create                                         |
+| Setup execution            | `crates/superzent_git/src/lib.rs` | Run sequential commands in the new worktree; capture stdout/stderr and keep the workspace on failure                                                    |
+| Create result presentation | `crates/superzent_ui/src/lib.rs`  | Upsert and open the workspace even when setup fails, then surface a concise failure summary with log access                                             |
+| Teardown execution         | `crates/superzent_git/src/lib.rs` | Run sequential commands before deletion; return structured failure details instead of flattening everything to one string                               |
+| Delete result presentation | `crates/superzent_ui/src/lib.rs`  | On teardown failure, keep the workspace, show logs, and allow an explicit force-delete retry that skips teardown                                        |
+
+Lifecycle outcome matrix:
+
+| Operation | Command phase result                       | Expected product behavior                                                                                  |
+| --------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Create    | No config or all setup commands succeed    | Workspace is created, opened, and behaves like today's managed local flow                                  |
+| Create    | Setup command fails                        | Worktree stays on disk, workspace is still registered/opened, user sees failure summary and logs           |
+| Delete    | No config or all teardown commands succeed | Worktree is removed and workspace entry is deleted                                                         |
+| Delete    | Teardown command fails                     | Worktree and workspace stay intact, user sees failure summary and logs, force-delete is offered explicitly |
+
+## Implementation Units
+
+- [x] **Unit 1: Normalize the managed workspace config and base-branch contract**
+
+**Goal:** Replace the hidden partial config behavior with the v1 public config contract and compute the effective base branch from the right sources.
+
+**Requirements:** R1, R2, R4, R5, R6, R15, R16, R17, R18
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_git/Cargo.toml`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+
+- Replace the current config struct with a v1-focused contract containing `setup`, `teardown`, and `base_branch`.
+- Remove `prepare_workspace_contents` and the hidden `copy` path from managed workspace creation, relying on the checked-out worktree contents plus scripts instead.
+- Extend the create input to carry an optional one-off base-branch override.
+- Add a helper that resolves the effective base branch and, when relevant, a fallback warning/source marker that the UI can display.
+- Stop basing new managed worktrees on `current_branch()`; use repo-default semantics when there is no explicit or configured override.
+
+**Execution note:** Start with failing `superzent_git` tests for "configured base branch beats current branch" and "stale configured base branch falls back to repo default" before changing the helper logic.
+
+**Patterns to follow:**
+
+- `create_workspace` and `CreateWorkspaceOptions` in `crates/superzent_git/src/lib.rs`
+- `default_branch` semantics in `crates/git/src/repository.rs`
+- Existing inline test style in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: when `.superzent/config.json` sets `base_branch` to an existing branch, a new managed workspace is created from that branch even if the repo is currently checked out elsewhere.
+- Happy path: a one-off create-time override wins over the configured `base_branch`.
+- Edge case: when `base_branch` is absent, the create flow uses the repository default branch instead of the current branch.
+- Edge case: when `base_branch` points at a missing branch, the helper falls back to the repository default branch and returns a warning source that can be surfaced to the UI.
+- Error path: invalid `.superzent/config.json` shape causes an explicit create failure before any lifecycle command runs.
+- Integration: committed `.superzent` files remain available in the new worktree through normal git checkout without the old manual copy path.
+
+**Verification:**
+
+- Managed workspace creation no longer depends on the current checked-out branch.
+- The create flow has one authoritative config contract and no hidden copy semantics.
+
+- [x] **Unit 2: Add structured lifecycle command execution and failure outcomes**
+
+**Goal:** Make setup and teardown first-class command phases with captured output, stable environment variables, and result shapes that match the product requirements.
+
+**Requirements:** R3, R7, R8, R10, R11, R12, R13, R14
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+
+- Introduce a structured lifecycle execution helper that captures phase, command, stdout, stderr, and a concise summary instead of flattening everything into one opaque `anyhow` string.
+- Run `setup` after the worktree exists and before returning the final create outcome.
+- Keep the created worktree intact on setup failure and return a success outcome that includes lifecycle failure details the UI can inspect.
+- Run `teardown` before `git worktree remove`; on failure, return a structured delete failure without removing the worktree unless the caller retries in force-delete mode.
+- Export the documented `SUPERZENT_ROOT_PATH`, `SUPERZENT_WORKTREE_PATH`, and `SUPERZENT_WORKSPACE_NAME` variables, while also exporting legacy `SUPERSET_ROOT_PATH` and `SUPERSET_WORKSPACE_NAME` during the transition.
+
+**Execution note:** Start with failing lifecycle tests for setup-failure retention and teardown-failure blocking before reshaping the return types.
+
+**Patterns to follow:**
+
+- `run_shell_command` in `crates/superzent_git/src/lib.rs`
+- Existing `WorkspaceCreateOutcome.warning` path in `crates/superzent_git/src/lib.rs`
+- Existing stale-path deletion fallbacks in `delete_workspace` in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: multiple setup commands run sequentially in the new worktree and each command sees the expected environment variables.
+- Happy path: multiple teardown commands run sequentially before `git worktree remove`.
+- Edge case: a setup command failure leaves the new worktree on disk and returns structured failure output rather than deleting the worktree.
+- Edge case: a teardown command failure leaves the worktree on disk and returns a structured failure that identifies the teardown phase.
+- Error path: a force-delete retry skips teardown and still removes the worktree when teardown had previously failed.
+- Integration: both `SUPERZENT_*` and legacy `SUPERSET_*` variables are visible to lifecycle commands during the transition window.
+
+**Verification:**
+
+- Lifecycle command failures are inspectable as structured outcomes.
+- Setup failure no longer collapses into "workspace creation failed" semantics.
+- Teardown failure no longer forces the UI to choose between silent deletion and a generic error toast.
+
+- [x] **Unit 3: Add local create-flow base-branch preview and setup-failure presentation**
+
+**Goal:** Make the managed local create flow show the effective base branch before creation and preserve/open the workspace when setup fails.
+
+**Requirements:** R12, R15, R16, R17, R18, R19
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Extend `NewWorkspaceModal` so local managed workspace creation can carry an optional base-branch override and show the resolved effective base branch plus any fallback warning before the user confirms.
+- Keep the remote create path unchanged for v1 rather than pretending the new local config applies there.
+- Thread the optional override through `spawn_new_workspace_request` into `superzent_git::create_workspace`.
+- When setup fails but creation succeeds, keep the existing open-and-toast success path, but upgrade the notice from a plain warning string to a structured setup-failure summary with access to full logs.
+- Reuse the current post-open toast seam for concise notices so the create flow stays lightweight when setup succeeds.
+
+**Execution note:** Implement helper-level tests for base-branch preview state before wiring the modal interactions.
+
+**Patterns to follow:**
+
+- `NewWorkspaceModal` and `spawn_new_workspace_request` in `crates/superzent_ui/src/lib.rs`
+- Current `warning` toast handling after workspace open in `crates/superzent_ui/src/lib.rs`
+- Existing local-vs-remote branch in `spawn_new_workspace_request`
+
+**Test scenarios:**
+
+- Happy path: for a local project with configured `base_branch`, the modal shows the effective base branch before create and passes it through when the user does not override it.
+- Happy path: entering a one-off override changes the effective base branch shown to the user and is passed into the create request.
+- Edge case: when the configured `base_branch` is stale, the create UI shows the fallback effective branch plus a warning before the user confirms.
+- Edge case: remote projects continue to use the existing branch-name-only create path and do not incorrectly show local lifecycle config UI.
+- Error path: setup failure still results in the workspace being upserted and opened, followed by a visible failure summary rather than a top-level create abort.
+- Integration: the branch preview state and the create request stay in sync when the user edits the override field multiple times before confirming.
+- Integration: re-opening an already-created workspace through the normal workspace-open path does not invoke setup again, proving lifecycle execution remains confined to managed create/delete seams.
+
+**Verification:**
+
+- Users can tell which base branch will be used before creating a managed local workspace.
+- Setup failure no longer prevents the new workspace from opening.
+
+- [x] **Unit 4: Add teardown-failure logs and force-delete recovery in the delete flow**
+
+**Goal:** Turn teardown failure into an explicit recovery path rather than a terminal generic error toast.
+
+**Requirements:** R8, R13, R14
+
+**Dependencies:** Unit 2
+
+**Files:**
+
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+
+- Keep the current delete confirmation prompt for the initial destructive action.
+- When local managed deletion fails specifically in teardown, surface the structured failure details in a dedicated lifecycle-failure recovery surface that offers log viewing and an explicit force-delete retry.
+- Ensure force-delete retries call back into `superzent_git::delete_workspace` with teardown skipped, then continue through the current workspace/store cleanup path.
+- Preserve current success behavior and remote deletion behavior outside the new local teardown-failure branch.
+- Reset sidebar "deleting" state on all exit paths, including cancel-after-failure.
+
+**Execution note:** Start with failing UI-level tests for "teardown failure leaves workspace intact" and "force delete removes it on retry".
+
+**Patterns to follow:**
+
+- `run_delete_workspace_entry` in `crates/superzent_ui/src/lib.rs`
+- Existing delete confirmation prompt and sidebar deleting-state handling in `crates/superzent_ui/src/lib.rs`
+- Existing `delete_workspace` stale-path cleanup tests in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: successful delete still removes the worktree, closes the workspace in all windows, and removes the store entry.
+- Edge case: teardown failure leaves the worktree and workspace entry intact and resets the UI deleting state.
+- Happy path: selecting force delete after teardown failure retries without teardown and completes the delete.
+- Edge case: cancelling after teardown failure leaves the workspace available and does not leak a stuck deleting indicator.
+- Error path: a second failure during force delete is still surfaced as a delete failure without partially removing the store entry.
+- Integration: remote workspace deletion remains on the existing path and is unaffected by the local teardown-recovery UI.
+
+**Verification:**
+
+- Users cannot accidentally lose teardown failures behind a generic toast.
+- Force delete is explicit, local to teardown failure, and does not change the normal delete path.
+
+- [x] **Unit 5: Document the repo lifecycle contract**
+
+**Goal:** Teach the new `.superzent/config.json` behavior in the main `superzent` docs so teams can adopt it without reading implementation details.
+
+**Requirements:** R1, R2, R3, R11, R12, R13
+
+**Dependencies:** Unit 1, Unit 2, Unit 3, Unit 4
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/src/getting-started.md`
+- Modify: `docs/src/SUMMARY.md`
+- Create: `docs/src/managed-workspace-lifecycle.md`
+
+**Approach:**
+
+- Add a dedicated docs page that explains the config file location, supported keys, create/delete-only semantics, local-only scope, environment variables, setup-failure behavior, and teardown-failure force-delete behavior.
+- Link that page from the getting-started flow and the docs summary so it is discoverable from the core workspace/worktree onboarding path.
+- Keep examples aligned with the product contract: repo-root `.superzent/config.json`, tracked setup scripts, and `base_branch` plus one-off override.
+
+**Patterns to follow:**
+
+- User-facing workflow explanations in `docs/src/getting-started.md`
+- Navigation style in `docs/src/SUMMARY.md`
+- Top-level docs linking style in `README.md`
+
+**Test scenarios:**
+
+- Test expectation: none -- documentation-only unit.
+
+**Verification:**
+
+- A user can discover and understand the managed workspace lifecycle contract from the repo docs without reading source code or hidden historical behavior.
+
+## System-Wide Impact
+
+- **Interaction graph:** `NewWorkspaceModal` -> `spawn_new_workspace_request` -> `superzent_git::create_workspace` -> config parse -> base-branch resolution -> setup execution -> store upsert/open; and `run_delete_workspace_entry` -> `superzent_git::delete_workspace` -> teardown execution -> either failure recovery or workspace/store removal.
+- **Error propagation:** setup and teardown failures should propagate as structured lifecycle outcomes to `superzent_ui`; only the UI should flatten them into user-facing summaries or recovery prompts.
+- **State lifecycle risks:** create-time partial side effects are now intentional; the plan must preserve the worktree and avoid accidental cleanup on setup failure. Delete-time partial side effects must not remove the store entry until teardown succeeds or the user explicitly force deletes.
+- **API surface parity:** the new config contract and environment variables are repo-facing surfaces, so accidental divergence between docs and implementation would create silent workflow breakage. The generic `git_ui` worktree picker is an explicit non-goal in this phase and should remain behaviorally unchanged.
+- **Integration coverage:** the highest-value cross-layer scenarios are "configured base branch preview matches the eventual create request", "setup failure still opens the workspace", and "teardown failure plus force delete keeps store and filesystem state coherent".
+- **Unchanged invariants:** remote workspace creation/deletion semantics remain unchanged; non-managed and primary workspaces remain undeletable; generic git worktree flows outside managed local creation keep their existing behavior.
+
+## Risks & Dependencies
+
+| Risk                                                                                                   | Mitigation                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Existing internal repos may already depend on hidden `SUPERSET_*` env names or `copy` behavior         | Dual-export env names during the transition, document `SUPERZENT_*` as canonical, and remove `copy` only where tests prove tracked-file/script workflows cover the supported path |
+| Base-branch preview in the create modal can drift from the branch actually used by `superzent_git`     | Use one shared resolution helper or shared result shape between UI preview and create execution rather than re-implementing fallback logic twice                                  |
+| Setup-failure retention can leave partially initialized local resources that users mistake for success | Surface concise failure messaging immediately on open and provide log access rather than hiding the failure inside background logs                                                |
+| Teardown force-delete could remove a workspace even though cleanup commands never ran                  | Keep force delete as an explicit second-step recovery action only after a visible teardown failure, not as part of the normal delete path                                         |
+| Adding `git` crate dependency to `superzent_git` could be heavier than expected                        | Evaluate reuse-vs-copy during implementation and choose the smaller, testable option without changing the planned semantics                                                       |
+
+## Documentation / Operational Notes
+
+- The docs should call out that lifecycle config is repo-root only in v1 and that remote workspaces are intentionally out of scope.
+- Examples should prefer tracked scripts like `./.superzent/setup.sh` rather than inline long shell commands.
+- The PR description should note that `SUPERZENT_*` is the supported env contract and whether legacy `SUPERSET_*` compatibility is still present.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-06-managed-workspace-lifecycle-config-requirements.md`
+- Related code: `crates/superzent_git/src/lib.rs`
+- Related code: `crates/superzent_ui/src/lib.rs`
+- Related code: `crates/git/src/repository.rs`
+- Related docs: `docs/src/getting-started.md`
+- Related docs: `README.md`
+- Institutional learning: `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`
+- Institutional learning: `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`

--- a/docs/plans/2026-04-09-001-fix-managed-workspace-lifecycle-review-findings-plan.md
+++ b/docs/plans/2026-04-09-001-fix-managed-workspace-lifecycle-review-findings-plan.md
@@ -1,0 +1,183 @@
+---
+title: fix: Address managed workspace lifecycle review findings
+type: fix
+status: active
+date: 2026-04-09
+origin: docs/plans/2026-04-06-001-feat-managed-workspace-lifecycle-config-plan.md
+---
+
+# fix: Address managed workspace lifecycle review findings
+
+## Overview
+
+Fix the managed workspace lifecycle regressions found during review of the recent lifecycle-config feature. The follow-up should preserve the shipped v1 scope while correcting the create/delete behaviors that currently use the wrong base workspace context, can strand deleted workspaces in the store, or mutate repo config before create succeeds.
+
+## Problem Frame
+
+The first implementation landed the main lifecycle feature, but review surfaced a second pass of behavioral bugs rather than missing product scope. The create flow still derives some decisions from the project root instead of the active base workspace, persisted lifecycle defaults are written too early, and the delete flow can leave a broken workspace entry behind or fail closed on malformed lifecycle config. These are correctness and recovery issues inside the current feature, not reasons to widen the feature into remote workspaces, a generalized job system, or an agent-native redesign.
+
+## Requirements Trace
+
+- R1. Managed local workspace creation must use the active base workspace path, not only the project root, for dirty-worktree checks, base-branch fallback, and move-changes handoff.
+- R2. One-off create settings that also request persistence must not rewrite `.superzent/config.json` until create has passed validation and the new worktree exists.
+- R3. Managed local workspace deletion must stay recoverable when lifecycle config loading fails; malformed or deprecated config must not block the user from force-deleting.
+- R4. After a managed workspace is deleted on disk, the app must remove the matching store entry even if best-effort tab/window cleanup hits an error.
+- R5. The follow-up must add regression coverage for the corrected create/delete behaviors in `crates/superzent_git/src/lib.rs` and any targeted UI tests that are feasible in the touched area.
+
+## Scope Boundaries
+
+- Do not add lifecycle automation for SSH or other remote workspaces.
+- Do not redesign the whole lifecycle system around background jobs, progress views, or a separate log subsystem.
+- Do not use this pass to address subjective maintainability suggestions unless the code changes naturally simplify while fixing the concrete bugs.
+- Do not broaden the work into agent-native parity beyond noting residual gaps in review.
+
+## Context & Research
+
+### Relevant Code
+
+- `crates/superzent_git/src/lib.rs`
+  - `create_workspace_internal` currently uses `project.local_repo_root()` for dirty checks and base-branch fallback even when the UI already resolved a more specific base workspace path.
+  - `prepare_superzent_config_for_create` currently writes `.superzent/config.json` before branch validation and `git worktree add`.
+  - `delete_workspace` currently hard-fails if `load_superzent_config` fails in the non-force path.
+- `crates/superzent_ui/src/lib.rs`
+  - `spawn_new_workspace_request` already resolves `base_workspace_path`, but the downstream git layer does not consistently honor it.
+  - `run_delete_workspace_entry` deletes on disk before store cleanup and currently treats any later UI cleanup failure as a full delete failure.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`
+  - Keep upstream lifecycle stages observable and recoverable rather than only surfacing the final UI symptom.
+- `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`
+  - Keep repo defaults, runtime state, and per-invocation overrides as separate concerns rather than blending them into one helper or cached state source.
+
+## Key Decisions
+
+- Treat the active base workspace path as the authoritative local context for create-time dirty checks, base-branch fallback, and move-changes behavior.
+  - Rationale: the recent feature explicitly introduced “base workspace current branch” semantics, so using the project root when a different worktree is active violates the intended contract.
+- Keep delete recoverability by converting lifecycle-config load failures into a force-delete-capable failure path instead of silently skipping teardown.
+  - Rationale: deletion should remain conservative by default, but malformed config should not trap the user with no recovery option.
+- Make config persistence transactional with create.
+  - Rationale: failed creates should not leave repo-level lifecycle defaults partially updated.
+- Prefer “delete succeeded on disk, cleanup degraded in UI” semantics over leaving a stale workspace entry in the store.
+  - Rationale: once the worktree is gone, the store must converge to disk reality even if some window cleanup needs best-effort recovery.
+
+## Implementation Units
+
+- [ ] **Unit 1: Honor the active base workspace across create-time git decisions**
+
+**Goal:** Make managed local create behavior use the resolved base workspace path instead of the project root wherever the feature contract depends on the user’s current workspace context.
+
+**Requirements:** R1
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+
+- Thread the effective source workspace path through the create flow for dirty checks and base-branch fallback logic.
+- Update any move-changes handoff to stash from the active base workspace path rather than the project’s canonical repo root.
+- Preserve linked-worktree repo-root discovery for worktree placement while separating it from “current workspace” behavior.
+
+**Execution note:** Start with regression tests for “active secondary worktree branch wins over primary repo branch” and “move changes uses active workspace source” before changing the helpers.
+
+**Patterns to follow:**
+
+- `spawn_new_workspace_request` in `crates/superzent_ui/src/lib.rs`
+- `create_workspace_from_linked_worktree_uses_primary_repo_root` in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: creating from a secondary worktree uses that worktree’s current branch as the fallback base branch.
+- Happy path: create-and-move-changes moves staged, unstaged, and untracked changes from the active source workspace rather than the project root.
+- Edge case: linked-worktree creation still places new worktrees under the primary repo’s `.superzent-worktrees` directory.
+
+**Verification:**
+
+- Base-branch fallback matches the active base workspace, not the repo root.
+- Move-changes behavior follows the workspace the user launched create from.
+
+- [ ] **Unit 2: Make persisted lifecycle defaults transactional with create**
+
+**Goal:** Prevent `.superzent/config.json` from being rewritten until create has passed validation and the new worktree exists.
+
+**Requirements:** R2, R5
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+
+- Split config preparation into an in-memory phase and a persistence phase.
+- Run branch validation and `git worktree add` before writing repo defaults.
+- If persistence fails after the worktree is created, clean up the just-created worktree before returning an error so the operation remains all-or-nothing.
+
+**Execution note:** Keep this test-first; the main risk is partial mutation on failure.
+
+**Patterns to follow:**
+
+- Existing create/delete cleanup helpers in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: persisted setup/teardown defaults are written on successful create.
+- Error path: invalid branch input or failed base-branch resolution does not mutate `.superzent/config.json`.
+- Error path: persistence failure after worktree creation removes the newly created worktree and returns an error.
+
+**Verification:**
+
+- Failed create attempts leave repo lifecycle config unchanged.
+- Successful persisted creates still write the expected config contents.
+
+- [ ] **Unit 3: Keep local delete recoverable and converge store state after on-disk deletion**
+
+**Goal:** Preserve force-delete recovery for lifecycle-config failures and ensure successful on-disk deletion cannot leave a ghost workspace entry in the store.
+
+**Requirements:** R3, R4, R5
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Convert lifecycle-config load failures in the non-force delete path into a structured failure that the UI can present through the existing force-delete prompt.
+- Restructure the UI delete flow so store removal is keyed to whether deletion on disk succeeded, not to whether every later tab/window cleanup step succeeded.
+- Keep cleanup errors visible to the user as degraded follow-up behavior rather than pretending the delete fully failed.
+
+**Execution note:** Characterize the current delete ordering first, then change the control flow with focused tests.
+
+**Patterns to follow:**
+
+- `delete_workspace_blocks_on_teardown_failure_until_force_delete` in `crates/superzent_git/src/lib.rs`
+- `run_delete_workspace_entry` in `crates/superzent_ui/src/lib.rs`
+
+**Test scenarios:**
+
+- Error path: malformed `.superzent/config.json` still results in a force-delete-capable failure path instead of an unrecoverable error.
+- Happy path: successful delete removes the store entry even when window cleanup reports an error after deletion.
+- Edge case: teardown failure still keeps the worktree until the user explicitly retries with force delete.
+
+**Verification:**
+
+- Users can recover from malformed lifecycle config by force deleting.
+- Deleted workspaces no longer remain in the store after the backing path is gone.
+
+## Dependencies & Sequencing
+
+1. Unit 1 first, because it corrects the base workspace semantics the other fixes build on.
+2. Unit 2 next, because create-time transactionality is isolated to the git layer and should be stabilized before the final review pass.
+3. Unit 3 last, because it depends on understanding the corrected lifecycle failure surfaces from the earlier units.
+
+## Verification Strategy
+
+- Run targeted crate tests for `superzent_git`.
+- Run any focused `superzent_ui` tests covering delete-flow helpers if available.
+- Re-run review after implementation with this plan attached so requirement completeness is checked against the follow-up scope.

--- a/docs/plans/2026-04-10-001-refactor-managed-workspace-lifecycle-compaction-plan.md
+++ b/docs/plans/2026-04-10-001-refactor-managed-workspace-lifecycle-compaction-plan.md
@@ -1,0 +1,249 @@
+---
+title: refactor: Compact managed workspace lifecycle internals
+type: refactor
+status: completed
+date: 2026-04-10
+origin: docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
+---
+
+# refactor: Compact managed workspace lifecycle internals
+
+## Overview
+
+Keep the current managed workspace lifecycle feature set, but reduce the internal coupling between repo config, workspace persistence, modal bootstrap, and delete recovery. The target state is one default lifecycle source of truth (`.superzent/config.json`) plus one narrow persisted exception (workspace-local teardown override), with create and delete flows shaped around that contract instead of letting helper state leak across layers.
+
+## Problem Frame
+
+The current implementation works, but it got there by threading lifecycle state through several unrelated surfaces: repo config, modal inputs, workspace persistence, sync builders, and delete cleanup helpers. The user-facing behavior is mostly right, but the code now pays a carrying cost each time lifecycle behavior changes. This refactor keeps the current feature contract while shrinking the number of places that need to know lifecycle details.
+
+## Requirements Trace
+
+- R1-R3. Keep repo-root `.superzent/config.json` as the default source of truth while preserving a persisted workspace-local teardown override.
+- R4-R6. Keep `setup` create-time-only, preserve both modal inputs, and avoid fragile re-entrant modal initialization paths.
+- R7-R9a. Always show the final teardown script or lack thereof in delete confirmation, use a scrollable code block, and make unreadable config a blocked-but-recoverable delete state.
+- R10-R12. Reduce lifecycle duplication and make delete ownership easier to reason about without trimming current feature scope.
+
+## Scope Boundaries
+
+- Do not remove `.superzent/config.json` support or the existing create modal inputs.
+- Do not add an edit UI for persisted workspace-local teardown overrides.
+- Do not change remote workspace behavior.
+- Do not use this refactor to add timeout/cancellation behavior for lifecycle commands; that remains separate follow-up work.
+- Do not broaden this into agent-native parity or a generalized logging subsystem.
+
+## Context & Research
+
+### Relevant Code
+
+- `crates/superzent_git/src/lib.rs`
+  - Owns repo-config loading, create-time setup, delete-time teardown, and the workspace-local teardown persistence hook.
+  - Already exposes `resolve_workspace_base_branch_from_workspace`, `WorkspaceLifecycleFailure`, and the create/delete primitives the UI can build on.
+- `crates/superzent_model/src/lib.rs`
+  - `WorkspaceEntry` currently stores `lifecycle_teardown_script`, which is semantically broader than the actual user contract.
+- `crates/superzent_ui/src/lib.rs`
+  - `NewWorkspaceModal` owns setup/teardown input and the single “save these script commands” checkbox.
+  - `open_new_workspace_modal` now precomputes `initial_base_workspace_path`, which is the pattern to extend for compact create bootstrap.
+  - `run_delete_workspace_entry` currently combines delete prompting, in-flight registration, forced recovery, window cleanup, and store cleanup.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`
+  - Early-stage pipeline failures should be surfaced from their true source rather than only from the final UI symptom. This supports resolving delete behavior up front before prompting.
+
+## Key Technical Decisions
+
+- Keep repo config as the baseline lifecycle contract and narrow workspace persistence to an explicit teardown override field only.
+  - Rationale: the user agreed that persisted teardown overrides are the one exception that should survive restarts; everything else should derive from repo defaults or create-time input.
+- Treat `setup` as one-shot even when the modal still offers both text areas.
+  - Rationale: compactness comes from removing hidden post-create behavior, not from removing current input affordances.
+- Reinterpret the current save checkbox as teardown-default persistence only.
+  - Rationale: this preserves a compact single-control UI while aligning with the agreed contract that `setup` is never persisted.
+- Resolve delete behavior before opening the destructive confirmation.
+  - Rationale: the delete prompt must always be able to show the exact final teardown script or clearly explain that no script will run.
+- Use a dedicated delete-resolution helper or small session helper rather than scattering state across global flags, result enums, and post-hoc cleanup checks.
+  - Rationale: the current pain is not lack of behavior but ownership split.
+
+## Implementation Units
+
+- [x] **Unit 1: Narrow lifecycle persistence to a teardown override contract**
+
+**Goal:** Replace the generic persisted lifecycle script field with a narrowly named teardown-override concept and stop copying repo defaults into workspace metadata.
+
+**Requirements:** R1, R2, R3, R11
+
+**Files:**
+
+- Modify: `crates/superzent_model/src/lib.rs`
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Rename `lifecycle_teardown_script` to a field that clearly means persisted workspace-local teardown override.
+- Persist that field only when the user supplied a non-saved teardown value at create time.
+- Make delete resolution follow `workspace override -> repo config -> no teardown`.
+- Keep legacy-state conversion and workspace bundle sync, but only for the narrow override field rather than a generic lifecycle script concept.
+
+**Execution note:** Start with characterization tests for “persisted teardown override survives restart/sync paths” before renaming the field through the model and UI.
+
+**Patterns to follow:**
+
+- Existing `WorkspaceEntry` persistence in `crates/superzent_model/src/lib.rs`
+- Current create/delete lifecycle tests in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+
+- Happy path: a non-saved teardown value is stored as a workspace-local override and used after restart.
+- Happy path: when no override exists, delete falls back to repo config teardown.
+- Edge case: repo defaults are not mirrored into workspace persistence when the user did not create a workspace-specific override.
+
+**Verification:**
+
+- Workspace metadata contains only the narrow persisted override contract.
+- Repo defaults no longer need to be propagated through unrelated sync code.
+
+- [x] **Unit 2: Compact the create modal bootstrap and make save-toggle semantics explicit**
+
+**Goal:** Keep the current create modal inputs while moving fragile initialization and ambiguous persistence semantics out of the constructor path.
+
+**Requirements:** R4, R5, R5a, R6, R10
+
+**Files:**
+
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Modify: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Precompute all create-time values needed to bootstrap the modal rather than letting the constructor reach back into live workspace state.
+- Introduce a small helper or draft type that makes the save-toggle meaning explicit: it persists repo-default teardown only and never persists `setup`.
+- Update the checkbox copy to match its real behavior.
+- Keep base-branch preview and both script inputs, but make constructor inputs purely data, not live entity lookups.
+
+**Execution note:** Implement helper-level tests first for the checkbox semantics and modal bootstrap inputs so the UI refactor stays small and verifiable.
+
+**Patterns to follow:**
+
+- `open_new_workspace_modal` precomputation in `crates/superzent_ui/src/lib.rs`
+- `resolve_workspace_base_branch_from_workspace` usage in the modal bootstrap path
+
+**Test scenarios:**
+
+- Happy path: modal still shows both setup and teardown inputs and preloads repo defaults correctly.
+- Happy path: selecting the save toggle persists repo-default teardown but does not persist `setup`.
+- Edge case: opening the modal from a local workspace does not re-enter workspace state during modal construction.
+
+**Verification:**
+
+- The modal no longer depends on fragile entity re-entry.
+- A reader can tell from the UI copy and code path that `setup` is one-shot and save applies to repo-default teardown only.
+
+- [x] **Unit 3: Reshape delete resolution around the final teardown preview**
+
+**Goal:** Make delete prompting and recovery flow derive from one explicit delete-resolution step that always knows the final teardown script or blocked state.
+
+**Requirements:** R7, R8, R9, R9a, R12
+
+**Files:**
+
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Introduce a delete-resolution helper that returns one of:
+  - run this exact teardown script
+  - no teardown script will run
+  - normal delete is blocked because config could not be read
+- Use that helper before the main delete confirmation so the confirmation can always render the final teardown preview in a scrollable code block.
+- When config is unreadable, render a blocked recovery state whose `Delete Anyway` path explicitly skips teardown and proceeds to force delete.
+- Reuse the existing `WorkspaceLifecycleFailure` surface where useful, but stop making the prompt body infer behavior from later failure handling.
+
+**Execution note:** Characterize the current force-delete flow before restructuring prompts so the final recovery path stays behaviorally equivalent.
+
+**Patterns to follow:**
+
+- Existing teardown failure recovery in `run_delete_workspace_entry`
+- Existing `workspace_lifecycle_failure_prompt_detail` helper
+
+**Test scenarios:**
+
+- Happy path: delete confirmation shows the final repo-config teardown script in a scrollable block before delete.
+- Happy path: delete confirmation shows the workspace-local override script when one exists.
+- Edge case: when no teardown exists, the confirmation explicitly says so instead of rendering an empty script block.
+- Error path: unreadable config blocks normal delete and offers `Delete Anyway`, which skips teardown.
+
+**Verification:**
+
+- Delete confirmation always explains the final teardown behavior up front.
+- The unreadable-config path is explicit rather than implicit.
+
+- [x] **Unit 4: Collapse delete-flow ownership after on-disk deletion**
+
+**Goal:** Keep the explicit delete recovery behavior while reducing ownership split across global delete state, result plumbing, and post-delete cleanup.
+
+**Requirements:** R10, R12
+
+**Dependencies:** Unit 3
+
+**Files:**
+
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+
+- Consolidate the delete session lifecycle into one helper object or one tightly scoped orchestration helper that owns registration, prompt branching, cleanup, and store removal.
+- Keep the in-flight open guard if still necessary, but make its setup/teardown happen in one place.
+- Preserve the current rule that store state must converge to disk reality once deletion succeeded on disk, even if later UI cleanup degrades.
+
+**Execution note:** This is the only unit that should touch the delete-session orchestration shape; avoid mixing it with repo-config semantics once Unit 3 has stabilized the prompt contract.
+
+**Patterns to follow:**
+
+- Current `InFlightWorkspaceDeletes` protection in `crates/superzent_ui/src/lib.rs`
+- Existing best-effort cleanup behavior after delete succeeds on disk
+
+**Test scenarios:**
+
+- Happy path: successful delete removes the store entry and closes windows through the consolidated helper path.
+- Edge case: cleanup errors after on-disk deletion still remove the store entry and show a degraded cleanup message.
+- Edge case: cancel paths and blocked paths still unregister any in-flight delete guard correctly.
+
+**Verification:**
+
+- Delete ownership is concentrated enough that new branches do not need to remember three separate cleanup responsibilities.
+
+## Dependencies & Sequencing
+
+1. Unit 1 first, because the persistence contract defines what the rest of the system is actually allowed to store.
+2. Unit 2 next, because create semantics should be aligned with the new persistence contract before delete is reshaped.
+3. Unit 3 then sets the explicit final-teardown preview and unreadable-config recovery contract.
+4. Unit 4 last, because it is mostly orchestration cleanup once the delete contract is already stable.
+
+## Risks & Mitigations
+
+| Risk                                                                                  | Mitigation                                                                                                   |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Narrowing persistence could accidentally drop restart behavior for teardown overrides | Start with characterization coverage for persisted override restoration before renaming or collapsing fields |
+| Reinterpreting the save checkbox could confuse users if copy changes are too subtle   | Update the label explicitly and add helper-level tests for its semantics                                     |
+| Delete confirmation could become too large with multiline scripts                     | Use a scrollable code block and explicit “no teardown” messaging instead of raw text concatenation           |
+| Delete compaction could regress the in-flight open guard                              | Keep the guard behavior until equivalent protection exists in the consolidated helper                        |
+
+## Verification Strategy
+
+- Run targeted crate tests for `superzent_git`.
+- Run focused `superzent_ui` tests for modal bootstrap helpers and delete helper behavior.
+- Re-run `ce:review` against the refactor diff to check whether the source-of-truth and delete-flow complexity findings have been reduced.
+
+## Sources & References
+
+- Origin requirements: `docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md`
+- Related plan: `docs/plans/2026-04-09-001-fix-managed-workspace-lifecycle-review-findings-plan.md`
+- Current feature baseline: `docs/plans/2026-04-06-001-feat-managed-workspace-lifecycle-config-plan.md`
+- Institutional learning: `docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md`

--- a/docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md
+++ b/docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md
@@ -15,7 +15,14 @@ symptoms:
   - Lifecycle defaults and workspace persistence were coupled across model, git, and UI layers
   - The create modal save toggle implied broader persistence than the actual one-shot setup contract
   - Delete confirmation could not reliably present the final teardown behavior up front
-tags: [managed-workspace-lifecycle, teardown-override, source-of-truth, delete-preview, workspace-persistence]
+tags:
+  [
+    managed-workspace-lifecycle,
+    teardown-override,
+    source-of-truth,
+    delete-preview,
+    workspace-persistence,
+  ]
 ---
 
 # Managed workspace lifecycle should keep repo config as the default and persist only teardown overrides

--- a/docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md
+++ b/docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md
@@ -1,0 +1,112 @@
+---
+title: Managed workspace lifecycle should keep repo config as the default and persist only teardown overrides
+date: 2026-04-10
+category: best-practices
+module: managed workspace lifecycle
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - Refactoring or extending managed local workspace create and delete behavior
+  - Changing how repo-root `.superzent/config.json` lifecycle defaults interact with workspace persistence
+  - Adding or reshaping delete confirmations that must preview the exact teardown behavior
+  - Narrowing persisted state so repo defaults do not get copied through unrelated sync paths
+symptoms:
+  - Lifecycle defaults and workspace persistence were coupled across model, git, and UI layers
+  - The create modal save toggle implied broader persistence than the actual one-shot setup contract
+  - Delete confirmation could not reliably present the final teardown behavior up front
+tags: [managed-workspace-lifecycle, teardown-override, source-of-truth, delete-preview, workspace-persistence]
+---
+
+# Managed workspace lifecycle should keep repo config as the default and persist only teardown overrides
+
+## Context
+
+Managed workspace lifecycle behavior had drifted into a multi-source implementation. Repo config, modal inputs, workspace persistence, sync builders, and delete helpers all carried lifecycle meaning at once. That made small behavior changes expensive because each change needed updates across unrelated layers.
+
+The fix was to make the contract narrower and more honest: repo-root `.superzent/config.json` stays the default source of truth, and workspace state is allowed to persist only one explicit exception, a teardown override chosen at workspace creation time.
+
+## Guidance
+
+Keep repo defaults and workspace-local exceptions separate.
+
+- Treat repo-root `.superzent/config.json` as the default source of truth for `base_branch`, `setup`, and `teardown`.
+- Treat `setup` as create-time-only input and one-shot execution, not ongoing workspace state.
+- Persist only `teardown`, and only when the user entered a non-saved teardown script that differs from the repo default.
+- Precompute modal bootstrap data before constructing the modal so the UI consumes plain data instead of re-entering live workspace state.
+- Resolve delete behavior before opening the destructive confirmation, then execute deletion against that same resolved plan so the preview and the real delete path cannot drift.
+
+## Why This Matters
+
+This pattern removes persistence ambiguity and makes delete preview deterministic. Workspace sync no longer carries repo defaults through unrelated paths, the save toggle no longer implies that `setup` persists, and the delete prompt no longer guesses at behavior from a later config read or failure branch.
+
+## When to Apply
+
+- When repo-scoped defaults coexist with one-off per-instance input
+- When create-time setup should never become persisted workspace behavior
+- When only one delete-time choice must survive restart
+- When a destructive confirmation must preview the exact action that will run, even if config is unreadable
+
+## Examples
+
+Store a workspace-local teardown override only when it is both unsaved and meaningfully different from the repo default:
+
+```rust
+fn workspace_teardown_script_override_for_create(
+    config: &SuperzentConfig,
+    teardown_script: Option<&str>,
+    save_teardown_script_as_repo_default: bool,
+) -> Option<String> {
+    if save_teardown_script_as_repo_default {
+        return None;
+    }
+
+    let teardown_script = normalize_command(teardown_script);
+    let repo_default_teardown_script = commands_to_script(&config.teardown);
+
+    if teardown_script == repo_default_teardown_script {
+        None
+    } else {
+        teardown_script
+    }
+}
+```
+
+Resolve delete behavior once, preview it, then execute against that same plan:
+
+```rust
+pub enum WorkspaceDeleteResolution {
+    RunTeardownScript { script: String },
+    SkipTeardown,
+    BlockedByConfig(WorkspaceLifecycleFailure),
+}
+```
+
+```rust
+let delete_resolution =
+    resolve_workspace_delete_resolution(&session.workspace_entry, repo_root)?;
+let prompt_receiver = show_delete_workspace_modal(
+    workspace,
+    session.workspace_entry.clone(),
+    delete_resolution.clone(),
+    window,
+    cx,
+);
+let delete_result = perform_workspace_delete(
+    &session,
+    &store,
+    Some(&delete_resolution),
+    force,
+    cx,
+)
+.await;
+```
+
+In the blocked-config branch, the prompt must explicitly say that normal delete is blocked and that `Delete Anyway` skips teardown, rather than retrying an unknown script.
+
+## Related
+
+- [managed-terminal-popup-notifications-2026-04-04.md](/Users/junpark/codingcoding/.superzent-worktrees/superzent/worktree-setup/docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md) — similar pattern: fix the earliest lifecycle/config stage instead of patching the final UI symptom
+- [default-build-next-edit-surface-restoration-2026-04-05.md](/Users/junpark/codingcoding/.superzent-worktrees/superzent/worktree-setup/docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md) — another example of narrowing sources of truth and removing helper-level coupling
+- Related requirements: `docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md`
+- Related plan: `docs/plans/2026-04-10-001-refactor-managed-workspace-lifecycle-compaction-plan.md`

--- a/docs/solutions/integration-issues/managed-zsh-terminals-can-lose-codex-and-claude-wrapper-resolution-after-shell-startup-2026-04-07.md
+++ b/docs/solutions/integration-issues/managed-zsh-terminals-can-lose-codex-and-claude-wrapper-resolution-after-shell-startup-2026-04-07.md
@@ -1,6 +1,7 @@
 ---
 title: Managed zsh terminals can lose Codex and Claude wrapper resolution after shell startup
 date: 2026-04-07
+last_updated: 2026-04-10
 category: integration-issues
 module: managed terminal wrappers
 problem_type: integration_issue
@@ -9,6 +10,7 @@ symptoms:
   - In Superzent-launched zsh terminals, `codex` and `claude` could resolve to user-installed binaries after shell startup instead of the Superzent wrapper
   - Wrapper precedence became unreliable after user dotfiles ran, so managed agent terminals could lose hook coverage
   - Claude sessions could drop user, project, or local settings because the wrapper replaced the settings file instead of merging hooks into the existing config
+  - Shell startup could fail immediately with `job table full or recursion limit exceeded` from generated `.zshenv`, `.zprofile`, `.zshrc`, or `.zlogin` files under `agent-hooks/shell/zsh`
 root_cause: logic_error
 resolution_type: code_fix
 severity: high
@@ -44,6 +46,8 @@ Superzent was prepending its wrapper directory into the managed terminal environ
 - Prepending `PATH` once in the injected terminal environment was not enough. zsh can still source `.zprofile`, `.zshrc`, and `.zlogin` afterwards, and user dotfiles can prepend other directories again.
 - Writing a dedicated `claude-settings.json` file and passing it to `--settings` made Superzent own the full settings payload instead of treating hooks as additive configuration.
 - Temporarily overriding shell functions in the live terminal session was avoided because that path had already proven brittle in earlier managed-terminal debugging.
+- Treating `ZDOTDIR` as an implicit source of truth during re-entry was not safe once Superzent had already pointed it at its own generated override directory. That made it possible to resolve the bootstrap directory as the “original” dotdir again.
+- Restoring `ZDOTDIR` around `source` calls was necessary but not sufficient; without a per-file reentry guard, the generated startup files could still recurse.
 
 ## Solution
 
@@ -57,6 +61,9 @@ Superzent now bootstraps zsh through a dedicated override `ZDOTDIR` under `agent
 - restores the original `ZDOTDIR` while sourcing the user's `.zshenv`, `.zprofile`, `.zshrc`, and `.zlogin`
 - prepends `SUPERZENT_AGENT_HOOK_BIN_DIR` before sourcing `.zprofile`
 - re-prepends the wrapper path after `.zshrc` and `.zlogin`
+- resolves the original dotdir more defensively by rejecting the Superzent override directory as a candidate
+- removes the process-global `ZDOTDIR` fallback from original-dotdir resolution
+- adds reentry guards to generated `.zshenv`, `.zprofile`, `.zshrc`, and `.zlogin` so repeated startup sourcing exits immediately instead of recursing
 
 `crates/superzent_agent/src/runtime.rs` now:
 
@@ -64,9 +71,13 @@ Superzent now bootstraps zsh through a dedicated override `ZDOTDIR` under `agent
 - builds the Claude hook configuration as inline JSON
 - passes that JSON directly to `claude --settings '<json>'` so the hooks are added at launch time instead of replacing user/project/local settings with a generated file
 
+The later hardening of this bootstrap path now prefers `SUPERZENT_ORIGINAL_ZDOTDIR`, rejects the override directory as a candidate for the original dotdir, and adds reentry guards to each generated startup file.
+
 ## Why This Works
 
 The zsh override gives Superzent a deterministic place to participate in shell startup instead of hoping one early `PATH` prepend survives every user dotfile mutation. Restoring the original `ZDOTDIR` only for the `source` step preserves the user's normal shell semantics while still letting Superzent reassert wrapper precedence afterwards.
+
+The later recursion fix closes the remaining hole in that design by making original-dotdir resolution explicit and making the generated startup files safe to re-enter.
 
 On the Claude side, using inline `--settings` JSON makes the hook configuration additive. Superzent still injects its hooks, but the rest of Claude's user/project/local settings model stays intact because the wrapper is no longer swapping in a standalone generated settings file.
 
@@ -78,11 +89,17 @@ On the Claude side, using inline `--settings` JSON makes the hook configuration 
   - `which claude`
   - run `zsh` again and repeat the checks
 - Prefer startup bootstrap over one-time `PATH` mutation when zsh dotfiles can still run afterwards.
+- When bootstrapping through an override `ZDOTDIR`, never use the override directory itself as a fallback candidate for the original dotdir.
+- Prefer an explicit `SUPERZENT_ORIGINAL_ZDOTDIR` handoff over reading process-global `ZDOTDIR` from the parent process.
+- Any generated shell startup file that can `source` user startup files should include a reentry guard.
+- Keep a shell-level smoke test for startup regressions: `zsh -lic 'echo SUPERZENT_ZSH_START_OK'`.
 - If a wrapper needs to augment Claude behavior, treat `--settings` as an additive overlay rather than replacing the user's settings file.
 - Keep tests around the bootstrap order and settings payload shape. The current coverage checks:
   - original `ZDOTDIR` is restored while sourcing user dotfiles
   - `.zprofile` prepends the wrapper path before user startup runs
   - `.zshrc` and `.zlogin` re-prepend the wrapper path after user startup runs
+  - original-dotdir resolution prefers `SUPERZENT_ORIGINAL_ZDOTDIR` and rejects the override directory
+  - generated startup files contain explicit reentry guards
   - the inline Claude settings payload parses as valid JSON and still contains the expected hook structure
 
 ## Related Issues

--- a/docs/solutions/ui-bugs/managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md
+++ b/docs/solutions/ui-bugs/managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md
@@ -1,0 +1,102 @@
+---
+title: Managed workspace create progress toasts can fail to appear after local open
+date: 2026-04-12
+category: ui-bugs
+module: managed workspace create flow
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - During managed local workspace creation, progress status toasts such as `Running setup…`, `Moving local changes…`, and the final setup success toast could fail to appear even when the work visibly took time
+  - The workspace could open and setup could run, but the user got no visible in-context progress feedback
+  - Debug logs could report `opened_workspace_present=false` after open, leaving the create flow without a reliable toast target
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags:
+  [
+    managed-workspace,
+    create-flow,
+    status-toast,
+    workspace-resolution,
+    ui-feedback,
+  ]
+---
+
+# Managed workspace create progress toasts can fail to appear after local open
+
+## Problem
+
+The managed local workspace create flow opened the workspace successfully, but progress status toasts were often not visible because the code tried to rediscover the newly opened workspace later from `workspace_entry`. When that second lookup missed, the status toast had no reliable `Entity<Workspace>` target, so transient progress UI never rendered where the user could see it.
+
+## Symptoms
+
+- `Running setup…`, `Moving local changes…`, and `Setup finished...` could fail to appear even when workspace setup visibly took time.
+- Debug logs showed the flow could not reliably resolve the opened workspace after the open step.
+
+## What Didn't Work
+
+- Re-resolving the new workspace later with `resolve_opened_workspace(&workspace_entry, ...)` was too indirect for the local path.
+- The flow already knew when it opened a brand-new local workspace, but it threw away the returned UI identity and later tried to infer it from matching logic.
+- The older persistent “setup in progress” sidebar state was the wrong abstraction. It stored long-lived UI state for a short-lived create/setup step and still did not guarantee visible progress feedback.
+
+## Solution
+
+Add a local-only helper that opens the worktree and immediately returns the live `Entity<Workspace>` instead of `()`. For local paths, that helper either reuses an already-open workspace or returns the newly opened one directly from the open result.
+
+Use that returned handle in the managed create flow and pin progress status toasts to it:
+
+```rust
+let visible_workspace = match &workspace_entry.location {
+    WorkspaceLocation::Local { worktree_path } => {
+        let open_task = cx.update(|window, cx| {
+            open_local_workspace_path_and_resolve(
+                worktree_path.clone(),
+                app_state.clone(),
+                window,
+                cx,
+            )
+        })?;
+        match open_task.await {
+            Ok(workspace) => Some(workspace),
+            Err(error) => {
+                show_workspace_toast_async(
+                    &workspace_handle,
+                    format!("Failed to open workspace: {error}"),
+                    cx,
+                );
+                return Ok::<(), anyhow::Error>(());
+            }
+        }
+    }
+    WorkspaceLocation::Ssh { .. } => {
+        open_workspace_entry(workspace_entry.clone(), app_state.clone(), window, cx).await?;
+        resolve_opened_workspace(&workspace_entry, current_window_handle, cx).await
+    }
+};
+let opened_workspace = visible_workspace.clone();
+
+show_resolved_workspace_status_toast(
+    opened_workspace.as_ref(),
+    "Running setup…",
+    ToastIcon::new(IconName::ArrowCircle).color(Color::Muted),
+    cx,
+);
+```
+
+The same opened workspace handle is reused for `Moving local changes…` and the final setup success toast.
+
+## Why This Works
+
+`StatusToast` is workspace-scoped UI. It must be toggled on the actual `Entity<Workspace>` that is rendering the status layer. The local open path already knows exactly which workspace was created or re-activated, so carrying that handle forward removes the fragile second lookup.
+
+## Prevention
+
+- When a flow opens a workspace and immediately needs workspace-scoped UI, prefer an open API that returns `Entity<Workspace>` instead of reopening or re-resolving later from `WorkspaceEntry`.
+- Use `resolve_opened_workspace` as a fallback for paths like SSH where the open primitive cannot directly hand back the live workspace, not as the default for local opens.
+- Keep create/setup progress non-persistent unless users need resumable state; transient status belongs in toasts, not store-backed row state.
+- Add an integration test around the managed local create flow that asserts the opened workspace handle is available immediately after open and is the same handle used for progress toasts.
+
+## Related Issues
+
+- Related solution: [managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md](/Users/junpark/codingcoding/.superzent-worktrees/superzent/worktree-setup/docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md)
+- Related solution: [managed-terminal-popup-notifications-2026-04-04.md](/Users/junpark/codingcoding/.superzent-worktrees/superzent/worktree-setup/docs/solutions/integration-issues/managed-terminal-popup-notifications-2026-04-04.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,7 @@
 # Welcome
 
 - [Getting Started](./getting-started.md)
+- [Managed Workspace Lifecycle](./managed-workspace-lifecycle.md)
 - [Installation](./installation.md)
   - [Update](./update.md)
   - [Uninstall](./uninstall.md)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -13,6 +13,8 @@ description: Get started with superzent, the local-first workspace shell for cod
 
 The main window is built around multiple local workspaces. Use the welcome page or sidebar controls to open an existing repository, then create or switch worktrees from there.
 
+If your repo needs per-workspace setup or cleanup, add a repo-root `.superzent/config.json`. See [Managed Workspace Lifecycle](./managed-workspace-lifecycle.md).
+
 ### 2. Learn the core shortcuts
 
 | Action                      | macOS          |
@@ -40,6 +42,7 @@ Good first settings:
 - startup workspace behavior
 - keybindings
 - project-specific tasks
+- repo-level managed workspace setup and teardown
 
 See [Running & Testing](./running-testing.md), [Terminal](./terminal.md), and [All Settings](./reference/all-settings.md).
 

--- a/docs/src/managed-workspace-lifecycle.md
+++ b/docs/src/managed-workspace-lifecycle.md
@@ -1,0 +1,96 @@
+---
+title: Managed Workspace Lifecycle
+description: Configure setup, teardown, and default base branches for managed local workspaces.
+---
+
+# Managed Workspace Lifecycle
+
+Managed local workspaces can run repo-defined setup and teardown commands through a repo-root `.superzent/config.json`.
+
+This is useful for tasks like:
+
+- copying or generating local env files
+- starting or stopping local services
+- choosing a default base branch for new managed workspaces
+
+## Config File
+
+Create `.superzent/config.json` in the repository root:
+
+```json
+{
+  "base_branch": "main",
+  "setup": ["./.superzent/setup.sh"],
+  "teardown": ["./.superzent/teardown.sh"]
+}
+```
+
+Supported keys:
+
+- `base_branch`: default base branch for new managed local workspaces
+- `setup`: commands run after a managed local workspace is created
+- `teardown`: commands run before a managed local workspace is deleted
+
+## How It Works
+
+`superzent` runs these commands only for managed local workspace create/delete flows.
+
+- Create workspace: create git worktree, then run `setup`
+- Delete workspace: run `teardown`, then remove the git worktree
+
+Opening, closing, or re-opening an existing workspace does not run `setup` or `teardown`.
+
+## Base Branch Selection
+
+When you create a managed local workspace, `superzent` resolves the base branch in this order:
+
+1. One-off base branch override from the create flow
+2. `.superzent/config.json` `base_branch`
+3. Base workspace's current branch
+4. Repository default branch
+
+If the configured `base_branch` does not exist, `superzent` falls back to the base workspace's current branch when available. If the base workspace has no current branch, it falls back to the repository default branch and warns before creation continues.
+
+## Environment Variables
+
+Lifecycle commands run in the new or existing worktree directory and receive:
+
+- `SUPERZENT_ROOT_PATH`
+- `SUPERZENT_WORKTREE_PATH`
+- `SUPERZENT_WORKSPACE_NAME`
+
+For compatibility during the transition, `SUPERSET_ROOT_PATH` and `SUPERSET_WORKSPACE_NAME` are also exported.
+
+## Failure Behavior
+
+### Setup failure
+
+If `setup` fails:
+
+- the worktree is kept
+- the workspace is still added and opened
+- `superzent` shows the failure and command output so you can fix the workspace in place
+
+### Teardown failure
+
+If `teardown` fails:
+
+- deletion stops
+- the workspace and worktree are kept
+- `superzent` shows the failure and command output
+- you can explicitly choose `Delete Anyway` to retry deletion without running teardown again
+
+## Scope
+
+Current v1 scope:
+
+- repo-root `.superzent/config.json` only
+- managed local workspaces only
+- create/delete lifecycle only
+
+Not included in this phase:
+
+- remote workspace lifecycle automation
+- `.superzent/config.local.json`
+- home-directory override layers
+- generic git worktree flows outside the managed workspace shell


### PR DESCRIPTION
Introduce repo-root lifecycle config for managed local workspaces, including setup and teardown commands, base-branch selection, and the corresponding create/delete UI and documentation.

This also folds in the follow-up fixes for active base workspace semantics, transactional config persistence, force-delete recovery, and the modal crash path so the shipped flow matches the intended behavior.

Closes #ISSUE

Before marking this PR ready for review, make sure that you have:
- [ ] Added tests or clear manual verification notes
- [ ] Done a self-review for regressions, security, and release-facing behavior
- [ ] Updated docs or templates if the change affects installation, updates, release flow, or OSS contribution workflow
- [ ] Checked the current guidance in [CONTRIBUTING.md](https://github.com/currybab/superzent/blob/main/CONTRIBUTING.md)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
