### PR TITLE
feat: display ~ instead of home directory in workspace sidebar path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16916,6 +16916,7 @@ dependencies = [
  "paths",
  "serde",
  "serde_json",
+ "util",
  "uuid",
 ]
 

--- a/crates/superzent_model/Cargo.toml
+++ b/crates/superzent_model/Cargo.toml
@@ -19,4 +19,5 @@ log.workspace = true
 paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+util.workspace = true
 uuid.workspace = true

--- a/crates/superzent_model/src/lib.rs
+++ b/crates/superzent_model/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use util::paths::PathExt as _;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -290,7 +291,9 @@ impl ProjectEntry {
 
     pub fn display_root(&self) -> String {
         match &self.location {
-            ProjectLocation::Local { repo_root } => repo_root.display().to_string(),
+            ProjectLocation::Local { repo_root } => {
+                repo_root.compact().to_string_lossy().to_string()
+            }
             ProjectLocation::Ssh {
                 connection,
                 repo_root,


### PR DESCRIPTION
Replace the full home directory prefix with ~ in the project path shown below the project title in the workspace sidebar.

Closes #ISSUE

Before marking this PR ready for review, make sure that you have:
- [ ] Added tests or clear manual verification notes
- [ ] Done a self-review for regressions, security, and release-facing behavior
- [ ] Updated docs or templates if the change affects installation, updates, release flow, or OSS contribution workflow
- [ ] Checked the current guidance in [CONTRIBUTING.md](https://github.com/currybab/superzent/blob/main/CONTRIBUTING.md)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
