### PR TITLE
title_bar: Restore macOS double-click-to-zoom on custom header

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -431,7 +431,11 @@ impl TitleBar {
                             }),
                     ),
             )
-            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .on_mouse_down(MouseButton::Left, |event, _, cx| {
+                if event.click_count < 2 {
+                    cx.stop_propagation();
+                }
+            })
             .into_any_element()
     }
 


### PR DESCRIPTION
## Summary

On macOS, double-clicking the window title bar is expected to perform the user's `AppleActionOnDoubleClick` system action (Zoom / Minimize / Do Nothing). The plumbing for this already exists in `PlatformTitleBar` via `window.titlebar_double_click()`, but the Superzent custom header at `crates/title_bar/src/title_bar.rs` installed an unconditional `on_mouse_down` handler that called `stop_propagation()` on every left click. That swallowed the second mouse-down before the parent could synthesize a double-click, so `on_click(click_count == 2)` never fired and the native zoom behavior was lost over the custom header area.

The fix lets double-clicks bubble up to the parent while keeping the original intent (a single click on the header shouldn't arm a window drag).

## Test plan

- [ ] Double-click empty area of the header → window zooms (or performs the configured `AppleActionOnDoubleClick` action)
- [ ] Single-click + drag on the header → still starts a window move
- [ ] Single-click on header buttons (sidebar toggles) → still triggers their action and doesn't start a drag
- [ ] `defaults write -g AppleActionOnDoubleClick Minimize` + relaunch → double-click miniaturizes instead of zooming
- [ ] Linux: no regression (same `on_click` path is reused for `window.zoom_window()`)

Release Notes:

- Fixed double-click on the macOS title bar not zooming/minimizing the window per the system `AppleActionOnDoubleClick` preference