### PR TITLE
refactor: clean up lifecycle env vars and add descriptions to variable

### DIFF
--- a/crates/superzent_git/src/lib.rs
+++ b/crates/superzent_git/src/lib.rs
@@ -1076,13 +1076,7 @@ fn run_shell_command(
         .envs(
             base_workspace_path
                 .map(|base_workspace_path| {
-                    [
-                        ("SUPERZENT_BASE_PATH", base_workspace_path.as_os_str()),
-                        (
-                            "SUPERZENT_SOURCE_WORKSPACE_PATH",
-                            base_workspace_path.as_os_str(),
-                        ),
-                    ]
+                    [("SUPERZENT_BASE_PATH", base_workspace_path.as_os_str())]
                 })
                 .into_iter()
                 .flatten(),

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -3014,6 +3014,7 @@ impl NewWorkspaceModal {
         &self,
         id: &'static str,
         variable: &'static str,
+        description: &'static str,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         h_flex()
@@ -3031,6 +3032,11 @@ impl NewWorkspaceModal {
                 CopyButton::new(format!("{id}-copy"), variable)
                     .tooltip_label("Copy variable")
                     .icon_size(IconSize::XSmall),
+            )
+            .child(
+                Label::new(description)
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
             )
     }
 
@@ -3201,22 +3207,18 @@ impl Render for NewWorkspaceModal {
                                                                             .color(Color::Muted),
                                                                     )
                                                                     .child(
-                                                                        h_flex()
-                                                                            .gap_2()
-                                                                            .flex_wrap()
+                                                                        v_flex()
+                                                                            .gap_1()
                                                                             .child(self.render_variable_helper(
                                                                                 "superzent-base-path",
                                                                                 "$SUPERZENT_BASE_PATH",
+                                                                                "Path to the source workspace",
                                                                                 cx,
                                                                             ))
                                                                             .child(self.render_variable_helper(
                                                                                 "superzent-worktree-path",
                                                                                 "$SUPERZENT_WORKTREE_PATH",
-                                                                                cx,
-                                                                            ))
-                                                                            .child(self.render_variable_helper(
-                                                                                "superzent-root-path",
-                                                                                "$SUPERZENT_ROOT_PATH",
+                                                                                "Path to the new worktree",
                                                                                 cx,
                                                                             )),
                                                                     ),


### PR DESCRIPTION
helpers

Remove unused SUPERZENT_SOURCE_WORKSPACE_PATH (duplicate of SUPERZENT_BASE_PATH) and remove SUPERZENT_ROOT_PATH button from the new-workspace modal since it is rarely needed in setup scripts.

Add short descriptions next to each variable helper button so users understand what the variables resolve to.

Closes #ISSUE

Before marking this PR ready for review, make sure that you have:
- [ ] Added tests or clear manual verification notes
- [ ] Done a self-review for regressions, security, and release-facing behavior
- [ ] Updated docs or templates if the change affects installation, updates, release flow, or OSS contribution workflow
- [ ] Checked the current guidance in [CONTRIBUTING.md](https://github.com/currybab/superzent/blob/main/CONTRIBUTING.md)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
