### PR TITLE
Restore field-level lifecycle default saves

### DIFF
--- a/crates/superzent_git/src/lib.rs
+++ b/crates/superzent_git/src/lib.rs
@@ -32,10 +32,22 @@ pub struct WorkspaceBaseBranchResolution {
     pub notice: Option<String>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct WorkspaceLifecycleDefaults {
     pub setup_script: Option<String>,
     pub teardown_script: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceLifecycleDefaultSaveSelections {
+    pub setup_script: bool,
+    pub teardown_script: bool,
+}
+
+impl WorkspaceLifecycleDefaultSaveSelections {
+    fn any(self) -> bool {
+        self.setup_script || self.teardown_script
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,7 +133,7 @@ pub struct CreateWorkspaceOptions {
     pub base_workspace_path: Option<PathBuf>,
     pub setup_script: Option<String>,
     pub teardown_script: Option<String>,
-    pub save_teardown_script_as_repo_default: bool,
+    pub save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections,
     pub allow_dirty: bool,
 }
 
@@ -245,8 +257,9 @@ fn create_workspace_internal(
     let configured_teardown_script = normalize_command(options.teardown_script.as_deref());
     let config = prepare_superzent_config_for_create(
         &repo_root,
+        configured_setup_script.clone(),
         configured_teardown_script.clone(),
-        options.save_teardown_script_as_repo_default,
+        options.save_lifecycle_defaults,
     )?;
     let base_branch_resolution = resolve_workspace_base_branch_for_repo(
         &repo_root,
@@ -278,7 +291,7 @@ fn create_workspace_internal(
             &base_branch_resolution.effective_base_branch,
         ],
     )?;
-    if options.save_teardown_script_as_repo_default {
+    if options.save_lifecycle_defaults.any() {
         if let Err(error) = write_superzent_config(&repo_root, &config) {
             cleanup_created_worktree(&repo_root, &worktree_path, &branch_name);
             return Err(error);
@@ -312,7 +325,7 @@ fn create_workspace_internal(
     let teardown_script_override = workspace_teardown_script_override_for_create(
         &config,
         configured_teardown_script.as_deref(),
-        options.save_teardown_script_as_repo_default,
+        options.save_lifecycle_defaults.teardown_script,
     );
 
     Ok(WorkspaceCreateOutcome {
@@ -996,11 +1009,18 @@ fn run_lifecycle_commands(
 
 fn prepare_superzent_config_for_create(
     repo_root: &Path,
+    setup_script: Option<String>,
     teardown_script: Option<String>,
-    save_teardown_script_as_repo_default: bool,
+    save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections,
 ) -> Result<SuperzentConfig> {
     let mut config = load_superzent_config(repo_root)?;
-    if save_teardown_script_as_repo_default {
+    if save_lifecycle_defaults.setup_script {
+        config.setup = setup_script
+            .as_deref()
+            .map(split_commands)
+            .unwrap_or_default();
+    }
+    if save_lifecycle_defaults.teardown_script {
         config.teardown = teardown_script
             .as_deref()
             .map(split_commands)
@@ -1164,7 +1184,7 @@ mod tests {
             base_workspace_path: None,
             setup_script: None,
             teardown_script: None,
-            save_teardown_script_as_repo_default: false,
+            save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
             allow_dirty: false,
         }
     }
@@ -1233,7 +1253,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: true,
             },
         )
@@ -1280,7 +1300,7 @@ mod tests {
                 base_workspace_path: Some(secondary_worktree_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -1304,19 +1324,37 @@ mod tests {
     }
 
     #[test]
-    fn prepare_superzent_config_for_create_updates_only_repo_default_teardown() {
+    fn prepare_superzent_config_for_create_updates_only_selected_repo_defaults() {
         let repo = init_repo();
         fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
         fs::write(
             repo.repo_path.join(".superzent").join("config.json"),
-            r#"{"setup":["echo keep setup"]}"#,
+            r#"{"setup":["echo keep setup"],"teardown":["echo keep teardown"]}"#,
         )
         .unwrap();
 
         let config = prepare_superzent_config_for_create(
             &repo.repo_path,
+            Some("echo new setup".to_string()),
             Some("cargo clean\ncargo test".to_string()),
-            true,
+            WorkspaceLifecycleDefaultSaveSelections {
+                setup_script: true,
+                teardown_script: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(config.setup, vec!["echo new setup".to_string()]);
+        assert_eq!(config.teardown, vec!["echo keep teardown".to_string()]);
+
+        let config = prepare_superzent_config_for_create(
+            &repo.repo_path,
+            Some("echo ignored setup".to_string()),
+            Some("cargo clean\ncargo test".to_string()),
+            WorkspaceLifecycleDefaultSaveSelections {
+                setup_script: false,
+                teardown_script: true,
+            },
         )
         .unwrap();
 
@@ -1328,7 +1366,52 @@ mod tests {
     }
 
     #[test]
-    fn create_workspace_saves_repo_default_teardown_without_persisting_setup_script() {
+    fn create_workspace_saves_selected_repo_default_setup() {
+        let repo = init_repo();
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/persisted-setup".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: Some("echo setup one\necho setup two".to_string()),
+                teardown_script: Some("echo teardown once".to_string()),
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: true,
+                    teardown_script: false,
+                },
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        let config = load_superzent_config(&repo.repo_path).unwrap();
+        assert_eq!(
+            config.setup,
+            vec!["echo setup one".to_string(), "echo setup two".to_string()]
+        );
+        assert!(config.teardown.is_empty());
+        assert_eq!(
+            workspace_lifecycle_defaults(&registration.project)
+                .unwrap()
+                .setup_script,
+            Some("echo setup one\necho setup two".to_string())
+        );
+        assert_eq!(
+            outcome.workspace.teardown_script_override,
+            Some("echo teardown once".to_string())
+        );
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "persisted-setup workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_saves_selected_repo_default_teardown_without_persisting_setup_script() {
         let repo = init_repo();
         let registration = register_project(&repo.repo_path, "codex").unwrap();
         let outcome = create_workspace(
@@ -1340,7 +1423,10 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup one\necho setup two".to_string()),
                 teardown_script: Some("echo teardown".to_string()),
-                save_teardown_script_as_repo_default: true,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: false,
+                    teardown_script: true,
+                },
                 allow_dirty: false,
             },
         )
@@ -1354,6 +1440,51 @@ mod tests {
         assert_deleted(
             delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
             "persisted-scripts workspace should be deleted",
+        );
+    }
+
+    #[test]
+    fn create_workspace_can_clear_repo_default_lifecycle_fields() {
+        let repo = init_repo();
+        fs::create_dir_all(repo.repo_path.join(".superzent")).unwrap();
+        fs::write(
+            repo.repo_path.join(".superzent").join("config.json"),
+            r#"{"setup":["echo keep setup"],"teardown":["echo keep teardown"]}"#,
+        )
+        .unwrap();
+        commit_all_changes(&repo.repo_path, "add lifecycle defaults");
+
+        let registration = register_project(&repo.repo_path, "codex").unwrap();
+        let outcome = create_workspace(
+            &registration.project,
+            "codex",
+            CreateWorkspaceOptions {
+                branch_name: "feature/clear-defaults".to_string(),
+                base_branch_override: None,
+                base_workspace_path: Some(repo.repo_path.clone()),
+                setup_script: None,
+                teardown_script: None,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: true,
+                    teardown_script: true,
+                },
+                allow_dirty: false,
+            },
+        )
+        .unwrap();
+
+        let config = load_superzent_config(&repo.repo_path).unwrap();
+        assert!(config.setup.is_empty());
+        assert!(config.teardown.is_empty());
+        assert_eq!(
+            workspace_lifecycle_defaults(&registration.project).unwrap(),
+            WorkspaceLifecycleDefaults::default()
+        );
+        assert_eq!(outcome.workspace.teardown_script_override, None);
+
+        assert_deleted(
+            delete_workspace(&outcome.workspace, repo.repo_path.as_path(), true).unwrap(),
+            "clear-defaults workspace should be deleted",
         );
     }
 
@@ -1378,7 +1509,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: None,
                 teardown_script: Some("echo repo default".to_string()),
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -1416,7 +1547,7 @@ mod tests {
                     "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"
                         .to_string(),
                 ),
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -1452,7 +1583,10 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup".to_string()),
                 teardown_script: Some("echo teardown".to_string()),
-                save_teardown_script_as_repo_default: true,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: true,
+                    teardown_script: true,
+                },
                 allow_dirty: false,
             },
         )
@@ -1486,7 +1620,10 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("echo setup".to_string()),
                 teardown_script: None,
-                save_teardown_script_as_repo_default: true,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: true,
+                    teardown_script: false,
+                },
                 allow_dirty: false,
             },
         )
@@ -1508,7 +1645,7 @@ mod tests {
     }
 
     #[test]
-    fn move_changes_to_workspace_moves_tracked_and_untracked_changes() {
+    fn move_changes_to_workspace_moves_tracked_and_untracked_changes_with_saved_defaults() {
         let repo = init_repo();
         fs::write(repo.repo_path.join("tracked.txt"), "tracked\n").unwrap();
         fs::write(repo.repo_path.join("untracked.txt"), "untracked\n").unwrap();
@@ -1522,13 +1659,24 @@ mod tests {
                 branch_name: "feature/move-changes".to_string(),
                 base_branch_override: None,
                 base_workspace_path: Some(repo.repo_path.clone()),
-                setup_script: None,
+                setup_script: Some("echo saved setup".to_string()),
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections {
+                    setup_script: true,
+                    teardown_script: false,
+                },
                 allow_dirty: true,
             },
         )
         .unwrap();
+
+        assert_eq!(
+            workspace_lifecycle_defaults(&registration.project)
+                .unwrap()
+                .setup_script,
+            Some("echo saved setup".to_string())
+        );
+        assert!(repo.repo_path.join("untracked.txt").exists());
 
         let worktree_path = outcome
             .workspace
@@ -1629,7 +1777,7 @@ mod tests {
                 base_workspace_path: Some(secondary_worktree_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -1873,7 +2021,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -1907,7 +2055,7 @@ mod tests {
                 base_workspace_path: None,
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -2000,7 +2148,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: None,
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )
@@ -2076,7 +2224,7 @@ mod tests {
                 base_workspace_path: Some(repo.repo_path.clone()),
                 setup_script: Some("cp \"$SUPERZENT_BASE_PATH\"/.env .env".to_string()),
                 teardown_script: None,
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: true,
             },
         )
@@ -2202,7 +2350,7 @@ mod tests {
                     "printf workspace-override > \"$SUPERZENT_ROOT_PATH\"/teardown-log.txt"
                         .to_string(),
                 ),
-                save_teardown_script_as_repo_default: false,
+                save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections::default(),
                 allow_dirty: false,
             },
         )

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -1874,7 +1874,7 @@ fn new_workspace_create_options(
     base_workspace_path: Option<PathBuf>,
     setup_script: Option<String>,
     teardown_script: Option<String>,
-    save_teardown_script_as_repo_default: bool,
+    save_lifecycle_defaults: superzent_git::WorkspaceLifecycleDefaultSaveSelections,
     allow_dirty: bool,
 ) -> superzent_git::CreateWorkspaceOptions {
     superzent_git::CreateWorkspaceOptions {
@@ -1883,9 +1883,16 @@ fn new_workspace_create_options(
         base_workspace_path,
         setup_script,
         teardown_script,
-        save_teardown_script_as_repo_default,
+        save_lifecycle_defaults,
         allow_dirty,
     }
+}
+
+fn allow_dirty_workspace_create_options(
+    mut create_options: superzent_git::CreateWorkspaceOptions,
+) -> superzent_git::CreateWorkspaceOptions {
+    create_options.allow_dirty = true;
+    create_options
 }
 
 fn new_workspace_modal_bootstrap(
@@ -2292,7 +2299,7 @@ fn spawn_new_workspace_request(
     base_branch_override: Option<String>,
     setup_script: Option<String>,
     teardown_script: Option<String>,
-    save_teardown_script_as_repo_default: bool,
+    save_lifecycle_defaults: superzent_git::WorkspaceLifecycleDefaultSaveSelections,
     window: &mut Window,
     cx: &mut App,
 ) {
@@ -2308,18 +2315,19 @@ fn spawn_new_workspace_request(
             let mut dirty_move_choice: Option<DirtyWorkspaceCreateChoice> = None;
             let outcome = match &project.location {
                 ProjectLocation::Local { .. } => {
+                    let create_options = new_workspace_create_options(
+                        branch_name.clone(),
+                        base_branch_override.clone(),
+                        base_workspace_path.clone(),
+                        setup_script.clone(),
+                        teardown_script.clone(),
+                        save_lifecycle_defaults,
+                        false,
+                    );
                     match create_local_workspace(
                         project.clone(),
                         preset_id.clone(),
-                        new_workspace_create_options(
-                            branch_name.clone(),
-                            base_branch_override.clone(),
-                            base_workspace_path.clone(),
-                            setup_script.clone(),
-                            teardown_script.clone(),
-                            save_teardown_script_as_repo_default,
-                            false,
-                        ),
+                        create_options.clone(),
                         cx,
                     )
                     .await
@@ -2352,15 +2360,7 @@ fn spawn_new_workspace_request(
                             let outcome = create_local_workspace(
                                 project.clone(),
                                 preset_id.clone(),
-                                new_workspace_create_options(
-                                    branch_name.clone(),
-                                    base_branch_override.clone(),
-                                    base_workspace_path.clone(),
-                                    setup_script.clone(),
-                                    teardown_script.clone(),
-                                    save_teardown_script_as_repo_default,
-                                    true,
-                                ),
+                                allow_dirty_workspace_create_options(create_options),
                                 cx,
                             )
                             .await?;
@@ -2797,7 +2797,7 @@ struct NewWorkspaceModal {
     setup_script_editor: Entity<Editor>,
     teardown_script_editor: Entity<Editor>,
     show_more_options: bool,
-    save_teardown_script_as_repo_default: bool,
+    save_lifecycle_defaults: superzent_git::WorkspaceLifecycleDefaultSaveSelections,
     active_script_target: Option<ScriptEditorTarget>,
     scroll_handle: ScrollHandle,
     base_branch_notice: Option<SharedString>,
@@ -2945,7 +2945,8 @@ impl NewWorkspaceModal {
             setup_script_editor,
             teardown_script_editor,
             show_more_options: false,
-            save_teardown_script_as_repo_default: false,
+            save_lifecycle_defaults:
+                superzent_git::WorkspaceLifecycleDefaultSaveSelections::default(),
             active_script_target: None,
             scroll_handle: ScrollHandle::new(),
             base_branch_notice: bootstrap.base_branch_notice.map(Into::into),
@@ -3075,7 +3076,7 @@ impl NewWorkspaceModal {
             self.base_branch(cx),
             self.setup_script(cx),
             self.teardown_script(cx),
-            self.save_teardown_script_as_repo_default,
+            self.save_lifecycle_defaults,
             window,
             cx,
         );
@@ -3182,12 +3183,29 @@ impl Render for NewWorkspaceModal {
                                                                     )
                                                                     .child(
                                                                         Label::new(
-                                                                            "Runs once after creation for this workspace. Changes here are never saved as repo defaults.",
+                                                                            "Runs once after creation for this workspace.",
                                                                         )
                                                                         .size(LabelSize::Small)
                                                                         .color(Color::Muted),
                                                                     )
-                                                                    .child(self.setup_script_editor.clone()),
+                                                                    .child(self.setup_script_editor.clone())
+                                                                    .child(
+                                                                        Checkbox::new(
+                                                                            "superzent-new-workspace-save-setup-default",
+                                                                            self.save_lifecycle_defaults.setup_script.into(),
+                                                                        )
+                                                                        .label("Save as repo default")
+                                                                        .fill()
+                                                                        .elevation(ElevationIndex::Surface)
+                                                                        .label_size(LabelSize::Small)
+                                                                        .on_click(cx.listener(
+                                                                            |this, selection, _, cx| {
+                                                                                this.save_lifecycle_defaults.setup_script =
+                                                                                    *selection == ToggleState::Selected;
+                                                                                cx.notify();
+                                                                            },
+                                                                        )),
+                                                                    ),
                                                             )
                                                             .child(
                                                                 v_flex()
@@ -3196,7 +3214,31 @@ impl Render for NewWorkspaceModal {
                                                                         Label::new("Teardown Script")
                                                                             .size(LabelSize::Small),
                                                                     )
-                                                                    .child(self.teardown_script_editor.clone()),
+                                                                    .child(
+                                                                        Label::new(
+                                                                            "Runs before deletion for this workspace.",
+                                                                        )
+                                                                        .size(LabelSize::Small)
+                                                                        .color(Color::Muted),
+                                                                    )
+                                                                    .child(self.teardown_script_editor.clone())
+                                                                    .child(
+                                                                        Checkbox::new(
+                                                                            "superzent-new-workspace-save-teardown-default",
+                                                                            self.save_lifecycle_defaults.teardown_script.into(),
+                                                                        )
+                                                                        .label("Save as repo default")
+                                                                        .fill()
+                                                                        .elevation(ElevationIndex::Surface)
+                                                                        .label_size(LabelSize::Small)
+                                                                        .on_click(cx.listener(
+                                                                            |this, selection, _, cx| {
+                                                                                this.save_lifecycle_defaults.teardown_script =
+                                                                                    *selection == ToggleState::Selected;
+                                                                                cx.notify();
+                                                                            },
+                                                                        )),
+                                                                    ),
                                                             )
                                                             .child(
                                                                 v_flex()
@@ -3222,25 +3264,6 @@ impl Render for NewWorkspaceModal {
                                                                                 cx,
                                                                             )),
                                                                     ),
-                                                            )
-                                                            .child(
-                                                                Checkbox::new(
-                                                                    "superzent-new-workspace-save-lifecycle",
-                                                                    self.save_teardown_script_as_repo_default.into(),
-                                                                )
-                                                                .label(
-                                                                    "Save teardown script as the default for this repository",
-                                                                )
-                                                                .fill()
-                                                                .elevation(ElevationIndex::Surface)
-                                                                .label_size(LabelSize::Small)
-                                                                .on_click(cx.listener(
-                                                                    |this, selection, _, cx| {
-                                                                        this.save_teardown_script_as_repo_default =
-                                                                            *selection == ToggleState::Selected;
-                                                                        cx.notify();
-                                                                    },
-                                                                )),
                                                             ),
                                                     )
                                                 }),
@@ -8701,36 +8724,77 @@ mod tests {
     }
 
     #[test]
-    fn new_workspace_create_options_marks_only_teardown_for_repo_default_persistence() {
+    fn new_workspace_create_options_tracks_field_level_repo_default_saves() {
         let options = new_workspace_create_options(
             "feature/bootstrap".to_string(),
             Some("main".to_string()),
             Some(PathBuf::from("/tmp/repo")),
             Some("echo setup".to_string()),
             Some("echo teardown".to_string()),
-            true,
+            superzent_git::WorkspaceLifecycleDefaultSaveSelections {
+                setup_script: true,
+                teardown_script: false,
+            },
             false,
         );
 
         assert_eq!(options.setup_script, Some("echo setup".to_string()));
         assert_eq!(options.teardown_script, Some("echo teardown".to_string()));
-        assert!(options.save_teardown_script_as_repo_default);
+        assert_eq!(
+            options.save_lifecycle_defaults,
+            superzent_git::WorkspaceLifecycleDefaultSaveSelections {
+                setup_script: true,
+                teardown_script: false,
+            }
+        );
         assert_eq!(options.base_branch_override, Some("main".to_string()));
     }
 
     #[test]
-    fn new_workspace_create_options_keeps_repo_default_teardown_persistence_disabled_by_default() {
+    fn new_workspace_create_options_keeps_repo_default_saves_disabled_by_default() {
         let options = new_workspace_create_options(
             "feature/bootstrap".to_string(),
             None,
             Some(PathBuf::from("/tmp/repo")),
             None,
             None,
-            false,
+            superzent_git::WorkspaceLifecycleDefaultSaveSelections::default(),
             false,
         );
 
-        assert!(!options.save_teardown_script_as_repo_default);
+        assert_eq!(
+            options.save_lifecycle_defaults,
+            superzent_git::WorkspaceLifecycleDefaultSaveSelections::default()
+        );
+    }
+
+    #[test]
+    fn allow_dirty_workspace_create_options_preserves_save_selections_and_scripts() {
+        let options = new_workspace_create_options(
+            "feature/bootstrap".to_string(),
+            Some("main".to_string()),
+            Some(PathBuf::from("/tmp/repo")),
+            Some("echo setup".to_string()),
+            Some("echo teardown".to_string()),
+            superzent_git::WorkspaceLifecycleDefaultSaveSelections {
+                setup_script: true,
+                teardown_script: true,
+            },
+            false,
+        );
+
+        let retried = allow_dirty_workspace_create_options(options.clone());
+
+        assert!(retried.allow_dirty);
+        assert_eq!(retried.branch_name, options.branch_name);
+        assert_eq!(retried.base_branch_override, options.base_branch_override);
+        assert_eq!(retried.base_workspace_path, options.base_workspace_path);
+        assert_eq!(retried.setup_script, options.setup_script);
+        assert_eq!(retried.teardown_script, options.teardown_script);
+        assert_eq!(
+            retried.save_lifecycle_defaults,
+            options.save_lifecycle_defaults
+        );
     }
 
     #[test]

--- a/docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
+++ b/docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
@@ -7,7 +7,7 @@ topic: managed-workspace-lifecycle-compaction
 
 ## Problem Frame
 
-The recently added managed workspace lifecycle feature preserves important user-facing behavior, but the internal implementation has become larger and more coupled than it needs to be. The goal of this follow-up is to keep the current user contract intact while making the code more compact, more accurate about sources of truth, and easier to evolve without touching multiple unrelated layers for one behavior change.
+The recently added managed workspace lifecycle feature preserves important user-facing behavior, but the internal implementation has become larger and more coupled than it needs to be. The compaction follow-up should still reduce that carrying cost, but the narrowed save semantics introduced a user-facing gap: teams can no longer promote a one-off `setup` script into the repo default from the create flow even though `.superzent/config.json` still treats `setup` as a repo-level default concept. The goal of this revision is to keep the simpler persistence model while restoring explicit repo-default `setup` saving in a way that is easier to understand and less error-prone than a shared lifecycle save toggle.
 
 ## Requirements
 
@@ -21,7 +21,12 @@ The recently added managed workspace lifecycle feature preserves important user-
 
 - R4. `setup` remains a create-time-only action and must not become a persisted per-workspace behavior.
 - R5. The create modal must continue to allow both `setup` and `teardown` input.
-- R5a. The current save-toggle semantics must be made explicit; if a single save control remains, it must apply only to repo-default teardown persistence rather than implicitly persisting `setup`.
+- R5a. The create modal must allow repo-default `setup` and repo-default `teardown` to be saved independently during workspace creation.
+- R5b. Each save control must live with its corresponding script field rather than behind one combined lifecycle save toggle.
+- R5c. Saving one script as a repo default must not implicitly save, clear, or otherwise change the other script's repo default.
+- R5d. If the user clears a script field and explicitly saves that field as the repo default, the existing repo default for that field must be removed from `.superzent/config.json`.
+- R5e. Repo-default `setup` or `teardown` changes requested during create must be persisted only after workspace creation succeeds; failed creates must not leave partial repo-default changes behind.
+- R5f. Saved repo-default `setup` and `teardown` values must prefill their matching create-modal fields on later workspace creations.
 - R6. The create flow should not depend on re-entering the current workspace state during modal construction or other similarly fragile UI initialization paths.
 
 **Delete Contract**
@@ -33,21 +38,24 @@ The recently added managed workspace lifecycle feature preserves important user-
 
 **Compaction Goals**
 
-- R10. Internal simplification must preserve the current managed local workspace feature set rather than removing behavior for the sake of smaller code.
-- R11. Repo defaults should not be duplicated into unrelated workspace persistence or sync paths unless that duplication is necessary to preserve the explicit workspace-local teardown override contract.
+- R10. Internal simplification must preserve the current managed local workspace feature set, including repo-default `setup` authoring from the create flow, rather than removing behavior for the sake of smaller code.
+- R11. Repo defaults should remain in repo-root `.superzent/config.json` and should not be duplicated into unrelated workspace persistence or sync paths unless that duplication is necessary to preserve the explicit workspace-local teardown override contract.
 - R12. Delete flow state should become easier to reason about by reducing split ownership across global state, result plumbing, and post-delete cleanup decisions.
 
 ## Success Criteria
 
 - A reader can identify one default source of truth for lifecycle behavior and one narrow exception for persisted teardown overrides.
-- The create and delete user experience remains functionally equivalent for current managed local workspace behavior.
+- A user can save repo-default `setup` and repo-default `teardown` independently from the create modal without guessing what another field will do.
+- A user can explicitly remove an existing repo-default `setup` or `teardown` from the create modal by saving an empty value for that field.
+- Failed creates do not mutate repo lifecycle defaults.
 - The implementation has fewer cross-layer data propagation paths and fewer hidden state transitions than the current version.
-- The refined design gives planning a clear target for simplification without inventing new user-facing behavior.
+- The refined design gives planning a clear target for simplification without widening scope beyond the clarified field-level save behavior.
 
 ## Scope Boundaries
 
 - Do not remove support for repo-root `.superzent/config.json`.
 - Do not remove `setup` or `teardown` inputs from the create modal.
+- Do not persist `setup` as workspace-local behavior or re-run it when an existing workspace is opened again.
 - Do not add a post-create UI for editing workspace-local teardown overrides.
 - Do not change remote workspace behavior in this pass.
 - Do not broaden this effort into agent-native parity work or a generalized job/logging system.
@@ -55,24 +63,32 @@ The recently added managed workspace lifecycle feature preserves important user-
 ## Key Decisions
 
 - Repo config remains the default contract: it is the baseline lifecycle source of truth rather than something inferred from workspace metadata.
-- `setup` is intentionally one-shot: it applies during creation only and should not linger as workspace-local behavior.
+- `setup` is intentionally one-shot per workspace: it applies during creation only and should not linger as workspace-local behavior, but it should still be saveable as a repo default for future creations.
 - `teardown` is the only allowed persisted workspace-local override because users may reasonably expect delete-time cleanup to honor what they chose at create time.
+- Save intent must be field-specific and colocated with each script input; a shared lifecycle save toggle is simpler visually but too ambiguous operationally.
+- Explicitly saving an empty script means removing that repo default rather than leaving stale config behind.
+- Repo-default writes should remain transactional with successful workspace creation.
 - Delete confirmation should always show the final script that will run, but it does not need to explain whether it came from repo config or a workspace-local override.
 - If config is broken, delete should stay conservative by default while still offering an explicit `Delete Anyway` escape hatch.
-- If the create modal keeps one save checkbox, that control should persist repo-default teardown only; `setup` remains one-shot even when the checkbox is selected.
+
+## Alternatives Considered
+
+- A single save toggle for both lifecycle fields was rejected. It is more compact, but it makes it too easy to accidentally persist a temporary `setup` edit while trying to save only `teardown`, and it obscures which field will actually be changed in `.superzent/config.json`.
 
 ## Dependencies / Assumptions
 
-- The current managed workspace lifecycle feature and docs remain the behavior baseline for this refactor.
+- The current managed workspace lifecycle feature and docs remain the behavior baseline for this refactor except where this document explicitly restores repo-default `setup` saving.
+- Repo-root `.superzent/config.json` remains the only default lifecycle config source and already supports both `setup` and `teardown`.
 - The simplification effort is allowed to change internal ownership boundaries as long as the user contract above stays intact.
 
 ## Outstanding Questions
 
 ### Deferred to Planning
 
-- [Affects R11][Technical] What is the smallest persistence shape that preserves workspace-local teardown overrides without copying repo defaults through every workspace sync path?
+- [Affects R11][Technical] What is the smallest persistence shape that keeps repo defaults only in `.superzent/config.json` while still preserving workspace-local teardown overrides where required?
+- [Affects R5e][Technical] What is the simplest transactional create flow that can stage independent `setup` and `teardown` repo-default writes in memory and apply them only after create succeeds?
 - [Affects R12][Technical] What is the simplest delete-flow structure that keeps explicit recovery behavior while reducing state split across UI helpers?
-- [Affects R6][Technical] Which create-time values should always be precomputed before modal construction to avoid re-entrant UI state access?
+- [Affects R6][Technical] Which create-time values should always be precomputed before modal construction so field-level save state and default-prefill logic avoid re-entrant UI state access?
 
 ## Next Steps
 

--- a/docs/plans/2026-04-13-001-fix-managed-workspace-field-level-default-saves-plan.md
+++ b/docs/plans/2026-04-13-001-fix-managed-workspace-field-level-default-saves-plan.md
@@ -1,0 +1,252 @@
+---
+title: fix: Restore field-level managed workspace default saves
+type: fix
+status: active
+date: 2026-04-13
+origin: docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md
+---
+
+# fix: Restore field-level managed workspace default saves
+
+## Overview
+
+Restore repo-default `setup` saving in the managed workspace create flow without undoing the lifecycle compaction work. The follow-up should keep repo-root `.superzent/config.json` as the only lifecycle default source, keep workspace-local persistence teardown-only, and replace the current shared save behavior with field-level save controls attached to the `setup` and `teardown` editors.
+
+## Problem Frame
+
+The 2026-04-10 lifecycle compaction pass simplified persistence by narrowing save behavior to teardown defaults and teardown overrides. That reduced ambiguity, but it also removed a useful authoring path: promoting a one-off `setup` script into the repo default from the create modal. The current code now hardcodes a teardown-only save contract across modal copy, request plumbing, helper tests, and config staging in `crates/superzent_ui/src/lib.rs` and `crates/superzent_git/src/lib.rs`.
+
+This follow-up is a behavior fix inside the new compaction contract, not a rollback of it. Repo defaults should still live only in `.superzent/config.json`, `setup` should still remain one-shot per created workspace, and workspace-local persistence should still be teardown-only. The missing behavior is field-level repo-default authoring from the create flow, plus an unambiguous way to clear an existing repo default intentionally.
+
+## Requirements Trace
+
+- R1. Keep repo-root `.superzent/config.json` as the default source of truth for `base_branch`, `setup`, and `teardown`.
+- R2-R4. Preserve the narrowed runtime contract: workspace-local persistence stays teardown-only, teardown overrides still survive restart, and `setup` stays create-time-only behavior.
+- R5-R5f. Add independent repo-default save controls for `setup` and `teardown`, colocate each control with its field, make empty-plus-save clear that field's repo default, keep writes transactional with create success, and prefill later create modals from saved defaults.
+- R6. Keep modal bootstrap data precomputed before view construction.
+- R7-R9a. Preserve the delete contract from the compaction work; this follow-up must not reopen delete resolution or recovery behavior.
+- R10-R12. Preserve the compaction outcome by restoring `setup` default authoring without reintroducing multi-source lifecycle state.
+
+## Scope Boundaries
+
+- Do not add workspace-local persistence for `setup`.
+- Do not re-open delete-flow behavior, delete copy, or unreadable-config recovery beyond preserving the existing contract.
+- Do not change SSH or other remote workspace create behavior.
+- Do not add a new "disable repo default for this create only" mode; this follow-up only changes repo-default authoring and clearing when the matching save control is explicitly selected.
+- Do not introduce a second lifecycle config file or any precedence layer beyond repo-root `.superzent/config.json`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/superzent_ui/src/lib.rs`
+  - `NewWorkspaceModalBootstrap` already precomputes base-branch and lifecycle default text before modal construction.
+  - `NewWorkspaceModal` currently owns two editors but only one save flag, `save_teardown_script_as_repo_default`.
+  - `new_workspace_create_options` and `spawn_new_workspace_request` duplicate the teardown-only save contract across the normal create path and the dirty-workspace retry path.
+  - Existing unit tests near the bottom of the file already cover bootstrap defaults and create-option helper semantics.
+- `crates/superzent_git/src/lib.rs`
+  - `CreateWorkspaceOptions` currently models save intent as a single teardown-only boolean.
+  - `prepare_superzent_config_for_create` stages only teardown changes before create.
+  - `create_workspace_internal` already has the right transactional seam: it stages config in memory, creates the worktree, writes config, and cleans up the worktree if the write fails.
+  - `workspace_teardown_script_override_for_create` already enforces the repo-default-vs-workspace-override split and should remain the only persisted exception.
+  - `workspace_lifecycle_defaults` already reads repo defaults back out for modal prefill.
+- `docs/plans/2026-04-10-001-refactor-managed-workspace-lifecycle-compaction-plan.md`
+  - The completed compaction plan is the baseline to preserve, not something to overwrite.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md`
+  - Repo config should remain the default lifecycle source of truth and workspace persistence should stay teardown-only.
+  - Modal bootstrap should consume plain precomputed data rather than re-entering live workspace state.
+  - Delete behavior should remain resolved once and executed against that same plan; this follow-up should not disturb that separation.
+
+### External References
+
+- None. The local codebase and recent lifecycle docs provide sufficient guidance for this follow-up.
+
+## Key Technical Decisions
+
+- Replace the shared lifecycle save contract with field-level save intent in the create request.
+  - Rationale: the missing behavior is not another persistence layer; it is the ability to save `setup` and `teardown` independently without ambiguity.
+- Keep repo-default writes staged in memory and persisted once, after worktree creation succeeds.
+  - Rationale: the existing transactional seam in `create_workspace_internal` already matches R5e and should be extended rather than reworked.
+- Continue resolving workspace-local teardown overrides against the staged repo default, not the pre-edit repo default.
+  - Rationale: if the user saves a new teardown default during create, the same value must not also be persisted as a workspace-local override.
+- Treat explicit empty-plus-save as "clear this repo default," but leave unsaved blank fields outside the scope of this follow-up.
+  - Rationale: R5d is explicit about clearing repo defaults only when the save control is selected; adding a separate one-off disable mode would widen product behavior beyond the brainstorm.
+- Keep modal bootstrap as pure data and make the dirty-workspace retry path reuse the same save intent.
+  - Rationale: the biggest practical regression risk is losing one field's save selection or text when the create flow retries after the dirty-workspace prompt.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How should the source-of-truth contract stay compact? Keep repo defaults only in `.superzent/config.json` and keep workspace-local persistence teardown-only.
+- How should create stay transactional? Stage setup/teardown repo-default changes in memory, write them after `git worktree add`, and reuse the existing cleanup-on-write-failure path.
+- How should the UI avoid save ambiguity? Place one save control beside each script editor instead of sharing one lifecycle toggle.
+
+### Deferred to Implementation
+
+- Should the request contract be represented as two booleans or a small `RepoDefaultSaveSelections` helper struct once the touched call sites are in view?
+- Should the dirty-workspace retry path be deduplicated by storing one reusable create-request value or by keeping the current helper call pattern and extending it?
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+| Field state at confirm time | Matching save control | Staged `.superzent/config.json` effect | Current create behavior | Persisted workspace effect |
+|---|---|---|---|---|
+| Non-empty `setup` text | Off | Leave repo-default `setup` unchanged | Use the one-off `setup` text for this create | None |
+| Non-empty `setup` text | On | Replace repo-default `setup` with that text | Use the same text for this create | None |
+| Empty `setup` text | On | Clear repo-default `setup` | Run no `setup` for this create | None |
+| Non-empty `teardown` text | Off | Leave repo-default `teardown` unchanged | Keep current create result | Persist a teardown override only if it differs from the staged repo default |
+| Non-empty `teardown` text | On | Replace repo-default `teardown` with that text | Keep current create result | No teardown override for the same value |
+| Empty `teardown` text | On | Clear repo-default `teardown` | Keep current create result | No teardown override |
+
+## Implementation Units
+
+- [ ] **Unit 1: Thread field-level save intent through the create request contract**
+
+**Goal:** Replace the shared teardown-only save flag with independent `setup` and `teardown` save intent throughout the UI request path, including the dirty-workspace retry branch.
+
+**Requirements:** R5, R5a, R5b, R5c, R5f, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Modify: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+- Extend `NewWorkspaceModal` state and `new_workspace_create_options` so save intent is modeled per field instead of through `save_teardown_script_as_repo_default`.
+- Update `spawn_new_workspace_request` to thread the new save contract through both the initial create attempt and the retry path after the dirty-workspace prompt.
+- Keep modal bootstrap precomputed and data-only; do not reintroduce live workspace lookups during modal construction.
+
+**Patterns to follow:**
+- `build_new_workspace_modal_bootstrap` in `crates/superzent_ui/src/lib.rs`
+- Existing helper tests around `new_workspace_create_options` in `crates/superzent_ui/src/lib.rs`
+- `CreateWorkspaceOptions` usage in `crates/superzent_git/src/lib.rs`
+
+**Test scenarios:**
+- Happy path: helper-level create options preserve independent `setup` and `teardown` save selections.
+- Happy path: opening the modal still preloads repo-default `setup` and `teardown` text without re-entering workspace state.
+- Edge case: the dirty-workspace retry path preserves both script texts and both save selections on the second create attempt.
+- Edge case: remote workspace creation still bypasses the local lifecycle save path.
+
+**Verification:**
+- The create request contract can express "save setup only," "save teardown only," "save both," and "save neither."
+- No local create path silently drops one field's save intent during retry.
+
+- [ ] **Unit 2: Stage setup and teardown repo-default writes independently in `superzent_git`**
+
+**Goal:** Extend config staging so `setup` and `teardown` repo defaults can be saved or cleared independently while keeping config writes transactional with create success.
+
+**Requirements:** R1, R4, R5a, R5c, R5d, R5e, R10, R11
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+
+**Approach:**
+- Expand `prepare_superzent_config_for_create` from a teardown-only helper into a field-aware staging step that updates only the repo-default fields whose save controls were selected.
+- Preserve untouched repo-default fields exactly as they were loaded from `.superzent/config.json`.
+- Interpret explicit empty-plus-save as an empty command list for that field so serialization removes the field from config.
+- Reuse the existing "write after worktree add, then clean up on write failure" flow rather than adding another persistence step.
+
+**Execution note:** Implement this characterization-first. The main risk is accidental mutation of untouched repo-default fields.
+
+**Patterns to follow:**
+- `prepare_superzent_config_for_create` and `write_superzent_config` in `crates/superzent_git/src/lib.rs`
+- Existing transactional create tests such as `create_workspace_cleans_up_worktree_when_persisted_config_write_fails`
+
+**Test scenarios:**
+- Happy path: saving only `setup` updates `config.setup` and preserves the previous repo-default `teardown`.
+- Happy path: saving only `teardown` updates `config.teardown` and preserves the previous repo-default `setup`.
+- Happy path: saving both fields updates both in one config write.
+- Edge case: saving an empty `setup` clears repo-default `setup` from `.superzent/config.json`.
+- Edge case: saving an empty `teardown` clears repo-default `teardown` from `.superzent/config.json`.
+- Error path: base-branch resolution or validation failure leaves `.superzent/config.json` unchanged.
+- Error path: config write failure after worktree creation removes the new worktree and leaves `.superzent/config.json` unchanged.
+
+**Verification:**
+- Repo-default writes touch only the selected fields.
+- Failed creates leave both the config file and the worktree graph unchanged.
+
+- [ ] **Unit 3: Keep runtime execution, override persistence, and modal prefill aligned with staged defaults**
+
+**Goal:** Ensure create-time script execution, teardown override persistence, and later modal prefill all consume the same staged repo-default contract after field-level saves are introduced.
+
+**Requirements:** R2, R3, R4, R5c, R5d, R5e, R5f, R10, R11
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/superzent_git/src/lib.rs`
+- Modify: `crates/superzent_ui/src/lib.rs`
+- Test: `crates/superzent_git/src/lib.rs`
+- Test: `crates/superzent_ui/src/lib.rs`
+
+**Approach:**
+- Resolve setup execution from the same staged config/input contract used for repo-default writes so "save setup default" and "run setup for this create" stay in sync.
+- Keep teardown override persistence grounded in the staged repo default so saving a new teardown default does not also persist a redundant workspace-local override.
+- Update modal copy and layout to place the save controls beside the matching editors, including copy that makes "save as repo default" and "clear when empty and saved" behavior legible.
+- Keep `workspace_lifecycle_defaults` as the only modal-prefill source so later create modals reflect whatever repo defaults were actually persisted.
+
+**Patterns to follow:**
+- `workspace_lifecycle_defaults` in `crates/superzent_git/src/lib.rs`
+- `workspace_teardown_script_override_for_create` in `crates/superzent_git/src/lib.rs`
+- Existing modal render structure and editor subscriptions in `crates/superzent_ui/src/lib.rs`
+
+**Test scenarios:**
+- Happy path: creating with a saved `setup` default writes the config and preloads the same `setup` text when the create modal is opened again later.
+- Happy path: creating with a saved `teardown` default does not persist a workspace-local teardown override for the same value.
+- Happy path: creating with an unsaved one-off teardown still persists a teardown override when it differs from the staged repo default.
+- Edge case: saving an empty `setup` clears later modal prefill for `setup`.
+- Edge case: saving an empty `teardown` clears later modal prefill for `teardown`.
+- Integration: after the dirty-workspace prompt path, the final persisted config and later modal prefill still match the user's selected save controls.
+
+**Verification:**
+- Repo-default prefill, create-time execution, and teardown override persistence all reflect the same staged contract.
+- The UI copy makes the field-level save behavior understandable without relying on old teardown-only assumptions.
+
+## Dependencies & Sequencing
+
+1. Unit 1 first, because the field-level save contract has to exist before the git layer can stage the right config.
+2. Unit 2 next, because transactional config staging is the behavioral core of the fix.
+3. Unit 3 last, because it validates that execution behavior, override persistence, and UI prefill all stay aligned with the new contract.
+
+## System-Wide Impact
+
+- **Interaction graph:** `build_new_workspace_modal_bootstrap` -> `NewWorkspaceModal::confirm` -> `spawn_new_workspace_request` -> `create_local_workspace` -> `superzent_git::create_workspace_without_setup` -> later `workspace_lifecycle_defaults` prefill on the next modal open.
+- **Error propagation:** Config serialization or write failures should continue to surface as create failures; the new save controls must not swallow or downgrade those errors.
+- **State lifecycle risks:** The highest-risk branch is the dirty-workspace retry flow because it reconstructs create options after an intermediate prompt. The second risk is comparing teardown overrides against the wrong repo-default snapshot.
+- **API surface parity:** Remote workspace create remains unchanged. Delete resolution, delete preview, and workspace-local teardown precedence remain unchanged.
+- **Integration coverage:** The strongest integration proof is a create-save-reopen cycle and a dirty-prompt-retry-create-save-reopen cycle, because those prove the full path from modal state to config write to future prefill.
+- **Unchanged invariants:** Workspace-local persistence remains teardown-only, repo defaults still load only from repo-root `.superzent/config.json`, and delete behavior remains governed by the existing compaction contract.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Field-level save intent could be applied on the first create attempt but dropped on the dirty-workspace retry path | Cover both create attempts with helper-level tests before changing the UI plumbing |
+| Config staging could accidentally overwrite the untouched repo-default field | Add explicit single-field save tests before broadening `prepare_superzent_config_for_create` |
+| Teardown override logic could compare against the pre-edit repo default instead of the staged one | Add regression coverage for "save teardown default and create in one action" before changing the override helper |
+| UI copy could imply a new one-off disable mode that the behavior does not implement | Keep copy scoped to "save as repo default" and "empty plus save clears the default" rather than promising per-create disable semantics |
+
+## Documentation / Operational Notes
+
+- No standalone docs update is required for this follow-up.
+- The in-product copy inside `NewWorkspaceModal` should explain the field-level repo-default save behavior clearly enough that the old teardown-only assumption no longer appears in code or UI text.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-10-managed-workspace-lifecycle-compaction-requirements.md`
+- Related plan: `docs/plans/2026-04-10-001-refactor-managed-workspace-lifecycle-compaction-plan.md`
+- Related plan: `docs/plans/2026-04-09-001-fix-managed-workspace-lifecycle-review-findings-plan.md`
+- Institutional learning: `docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md`
+- Related code: `crates/superzent_ui/src/lib.rs`
+- Related code: `crates/superzent_git/src/lib.rs`

--- a/docs/plans/2026-04-13-001-fix-managed-workspace-field-level-default-saves-plan.md
+++ b/docs/plans/2026-04-13-001-fix-managed-workspace-field-level-default-saves-plan.md
@@ -92,16 +92,16 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 
 ## High-Level Technical Design
 
-> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce._
 
-| Field state at confirm time | Matching save control | Staged `.superzent/config.json` effect | Current create behavior | Persisted workspace effect |
-|---|---|---|---|---|
-| Non-empty `setup` text | Off | Leave repo-default `setup` unchanged | Use the one-off `setup` text for this create | None |
-| Non-empty `setup` text | On | Replace repo-default `setup` with that text | Use the same text for this create | None |
-| Empty `setup` text | On | Clear repo-default `setup` | Run no `setup` for this create | None |
-| Non-empty `teardown` text | Off | Leave repo-default `teardown` unchanged | Keep current create result | Persist a teardown override only if it differs from the staged repo default |
-| Non-empty `teardown` text | On | Replace repo-default `teardown` with that text | Keep current create result | No teardown override for the same value |
-| Empty `teardown` text | On | Clear repo-default `teardown` | Keep current create result | No teardown override |
+| Field state at confirm time | Matching save control | Staged `.superzent/config.json` effect         | Current create behavior                      | Persisted workspace effect                                                  |
+| --------------------------- | --------------------- | ---------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
+| Non-empty `setup` text      | Off                   | Leave repo-default `setup` unchanged           | Use the one-off `setup` text for this create | None                                                                        |
+| Non-empty `setup` text      | On                    | Replace repo-default `setup` with that text    | Use the same text for this create            | None                                                                        |
+| Empty `setup` text          | On                    | Clear repo-default `setup`                     | Run no `setup` for this create               | None                                                                        |
+| Non-empty `teardown` text   | Off                   | Leave repo-default `teardown` unchanged        | Keep current create result                   | Persist a teardown override only if it differs from the staged repo default |
+| Non-empty `teardown` text   | On                    | Replace repo-default `teardown` with that text | Keep current create result                   | No teardown override for the same value                                     |
+| Empty `teardown` text       | On                    | Clear repo-default `teardown`                  | Keep current create result                   | No teardown override                                                        |
 
 ## Implementation Units
 
@@ -114,28 +114,33 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 **Dependencies:** None
 
 **Files:**
+
 - Modify: `crates/superzent_ui/src/lib.rs`
 - Modify: `crates/superzent_git/src/lib.rs`
 - Test: `crates/superzent_ui/src/lib.rs`
 - Test: `crates/superzent_git/src/lib.rs`
 
 **Approach:**
+
 - Extend `NewWorkspaceModal` state and `new_workspace_create_options` so save intent is modeled per field instead of through `save_teardown_script_as_repo_default`.
 - Update `spawn_new_workspace_request` to thread the new save contract through both the initial create attempt and the retry path after the dirty-workspace prompt.
 - Keep modal bootstrap precomputed and data-only; do not reintroduce live workspace lookups during modal construction.
 
 **Patterns to follow:**
+
 - `build_new_workspace_modal_bootstrap` in `crates/superzent_ui/src/lib.rs`
 - Existing helper tests around `new_workspace_create_options` in `crates/superzent_ui/src/lib.rs`
 - `CreateWorkspaceOptions` usage in `crates/superzent_git/src/lib.rs`
 
 **Test scenarios:**
+
 - Happy path: helper-level create options preserve independent `setup` and `teardown` save selections.
 - Happy path: opening the modal still preloads repo-default `setup` and `teardown` text without re-entering workspace state.
 - Edge case: the dirty-workspace retry path preserves both script texts and both save selections on the second create attempt.
 - Edge case: remote workspace creation still bypasses the local lifecycle save path.
 
 **Verification:**
+
 - The create request contract can express "save setup only," "save teardown only," "save both," and "save neither."
 - No local create path silently drops one field's save intent during retry.
 
@@ -148,10 +153,12 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 **Dependencies:** Unit 1
 
 **Files:**
+
 - Modify: `crates/superzent_git/src/lib.rs`
 - Test: `crates/superzent_git/src/lib.rs`
 
 **Approach:**
+
 - Expand `prepare_superzent_config_for_create` from a teardown-only helper into a field-aware staging step that updates only the repo-default fields whose save controls were selected.
 - Preserve untouched repo-default fields exactly as they were loaded from `.superzent/config.json`.
 - Interpret explicit empty-plus-save as an empty command list for that field so serialization removes the field from config.
@@ -160,10 +167,12 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 **Execution note:** Implement this characterization-first. The main risk is accidental mutation of untouched repo-default fields.
 
 **Patterns to follow:**
+
 - `prepare_superzent_config_for_create` and `write_superzent_config` in `crates/superzent_git/src/lib.rs`
 - Existing transactional create tests such as `create_workspace_cleans_up_worktree_when_persisted_config_write_fails`
 
 **Test scenarios:**
+
 - Happy path: saving only `setup` updates `config.setup` and preserves the previous repo-default `teardown`.
 - Happy path: saving only `teardown` updates `config.teardown` and preserves the previous repo-default `setup`.
 - Happy path: saving both fields updates both in one config write.
@@ -173,6 +182,7 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 - Error path: config write failure after worktree creation removes the new worktree and leaves `.superzent/config.json` unchanged.
 
 **Verification:**
+
 - Repo-default writes touch only the selected fields.
 - Failed creates leave both the config file and the worktree graph unchanged.
 
@@ -185,23 +195,27 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 **Dependencies:** Unit 2
 
 **Files:**
+
 - Modify: `crates/superzent_git/src/lib.rs`
 - Modify: `crates/superzent_ui/src/lib.rs`
 - Test: `crates/superzent_git/src/lib.rs`
 - Test: `crates/superzent_ui/src/lib.rs`
 
 **Approach:**
+
 - Resolve setup execution from the same staged config/input contract used for repo-default writes so "save setup default" and "run setup for this create" stay in sync.
 - Keep teardown override persistence grounded in the staged repo default so saving a new teardown default does not also persist a redundant workspace-local override.
 - Update modal copy and layout to place the save controls beside the matching editors, including copy that makes "save as repo default" and "clear when empty and saved" behavior legible.
 - Keep `workspace_lifecycle_defaults` as the only modal-prefill source so later create modals reflect whatever repo defaults were actually persisted.
 
 **Patterns to follow:**
+
 - `workspace_lifecycle_defaults` in `crates/superzent_git/src/lib.rs`
 - `workspace_teardown_script_override_for_create` in `crates/superzent_git/src/lib.rs`
 - Existing modal render structure and editor subscriptions in `crates/superzent_ui/src/lib.rs`
 
 **Test scenarios:**
+
 - Happy path: creating with a saved `setup` default writes the config and preloads the same `setup` text when the create modal is opened again later.
 - Happy path: creating with a saved `teardown` default does not persist a workspace-local teardown override for the same value.
 - Happy path: creating with an unsaved one-off teardown still persists a teardown override when it differs from the staged repo default.
@@ -210,6 +224,7 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 - Integration: after the dirty-workspace prompt path, the final persisted config and later modal prefill still match the user's selected save controls.
 
 **Verification:**
+
 - Repo-default prefill, create-time execution, and teardown override persistence all reflect the same staged contract.
 - The UI copy makes the field-level save behavior understandable without relying on old teardown-only assumptions.
 
@@ -230,12 +245,12 @@ This follow-up is a behavior fix inside the new compaction contract, not a rollb
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
-| Field-level save intent could be applied on the first create attempt but dropped on the dirty-workspace retry path | Cover both create attempts with helper-level tests before changing the UI plumbing |
-| Config staging could accidentally overwrite the untouched repo-default field | Add explicit single-field save tests before broadening `prepare_superzent_config_for_create` |
-| Teardown override logic could compare against the pre-edit repo default instead of the staged one | Add regression coverage for "save teardown default and create in one action" before changing the override helper |
-| UI copy could imply a new one-off disable mode that the behavior does not implement | Keep copy scoped to "save as repo default" and "empty plus save clears the default" rather than promising per-create disable semantics |
+| Risk                                                                                                               | Mitigation                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Field-level save intent could be applied on the first create attempt but dropped on the dirty-workspace retry path | Cover both create attempts with helper-level tests before changing the UI plumbing                                                     |
+| Config staging could accidentally overwrite the untouched repo-default field                                       | Add explicit single-field save tests before broadening `prepare_superzent_config_for_create`                                           |
+| Teardown override logic could compare against the pre-edit repo default instead of the staged one                  | Add regression coverage for "save teardown default and create in one action" before changing the override helper                       |
+| UI copy could imply a new one-off disable mode that the behavior does not implement                                | Keep copy scoped to "save as repo default" and "empty plus save clears the default" rather than promising per-create disable semantics |
 
 ## Documentation / Operational Notes
 

--- a/docs/solutions/logic-errors/restore-field-level-managed-workspace-default-saves-2026-04-13.md
+++ b/docs/solutions/logic-errors/restore-field-level-managed-workspace-default-saves-2026-04-13.md
@@ -1,0 +1,179 @@
+---
+title: Restore field-level managed workspace default saves
+date: 2026-04-13
+category: logic-errors
+module: managed workspace create flow
+problem_type: logic_error
+component: tooling
+symptoms:
+  - The create modal only allowed saving teardown as a repo default, so setup could no longer be promoted from the create flow
+  - Setup and teardown repo-default changes were no longer handled independently during workspace creation
+  - Dirty-workspace retry paths needed to preserve lifecycle script text and save selections across the second create attempt
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  [
+    managed-workspace,
+    create-flow,
+    repo-defaults,
+    lifecycle,
+    setup,
+    teardown,
+    dirty-workspace,
+  ]
+---
+
+# Restore field-level managed workspace default saves
+
+## Problem
+
+The managed workspace create flow regressed into teardown-only save semantics during lifecycle compaction. Users could still enter both `setup` and `teardown` scripts in the modal, but only teardown had a repo-default persistence path, so a one-off `setup` script could not be promoted back into `.superzent/config.json`.
+
+## Symptoms
+
+- A `setup` script could run for the current create flow but would not prefill future creates as a repo default.
+- Clearing and saving one lifecycle field could not be expressed independently from the other field.
+- The dirty-workspace retry path had to preserve lifecycle script text and save selections across the second create attempt.
+
+## What Didn't Work
+
+- Keeping the post-compaction create request as a teardown-only save contract. That preserved the narrowed teardown-override model, but it also removed legitimate repo-default `setup` authoring from the create flow. (session history)
+- Treating one save toggle as enough for both lifecycle fields. Earlier review and brainstorm passes already surfaced that the create-modal save semantics were underdefined when `setup` and `teardown` shared one control. (session history)
+- Rebuilding retry-time create state from scratch after the dirty-workspace prompt. That made it too easy to lose lifecycle script text or save selections on the second attempt. (session history)
+
+## Solution
+
+Introduce a field-level repo-default save contract and carry that same contract through config staging, retry flows, and modal UI.
+
+In `crates/superzent_git/src/lib.rs`, replace the teardown-only boolean with an explicit per-field selection type:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceLifecycleDefaultSaveSelections {
+    pub setup_script: bool,
+    pub teardown_script: bool,
+}
+```
+
+Use that selection set when staging `.superzent/config.json`, so only the selected fields are rewritten and empty selected values clear that field:
+
+```rust
+fn prepare_superzent_config_for_create(
+    repo_root: &Path,
+    setup_script: Option<String>,
+    teardown_script: Option<String>,
+    save_lifecycle_defaults: WorkspaceLifecycleDefaultSaveSelections,
+) -> Result<SuperzentConfig> {
+    let mut config = load_superzent_config(repo_root)?;
+    if save_lifecycle_defaults.setup_script {
+        config.setup = setup_script
+            .as_deref()
+            .map(split_commands)
+            .unwrap_or_default();
+    }
+    if save_lifecycle_defaults.teardown_script {
+        config.teardown = teardown_script
+            .as_deref()
+            .map(split_commands)
+            .unwrap_or_default();
+    }
+    Ok(config)
+}
+```
+
+Keep config writes transactional with worktree creation instead of writing defaults early:
+
+```rust
+let config = prepare_superzent_config_for_create(
+    &repo_root,
+    configured_setup_script.clone(),
+    configured_teardown_script.clone(),
+    options.save_lifecycle_defaults,
+)?;
+
+run_git(&repo_root, &["worktree", "add", "-b", &branch_name, ...])?;
+
+if options.save_lifecycle_defaults.any() {
+    if let Err(error) = write_superzent_config(&repo_root, &config) {
+        cleanup_created_worktree(&repo_root, &worktree_path, &branch_name);
+        return Err(error);
+    }
+}
+```
+
+In `crates/superzent_ui/src/lib.rs`, keep one `CreateWorkspaceOptions` value alive across the dirty-workspace retry path and only flip `allow_dirty` for the second attempt:
+
+```rust
+fn allow_dirty_workspace_create_options(
+    mut create_options: superzent_git::CreateWorkspaceOptions,
+) -> superzent_git::CreateWorkspaceOptions {
+    create_options.allow_dirty = true;
+    create_options
+}
+```
+
+```rust
+let create_options = new_workspace_create_options(
+    branch_name.clone(),
+    base_branch_override.clone(),
+    base_workspace_path.clone(),
+    setup_script.clone(),
+    teardown_script.clone(),
+    save_lifecycle_defaults,
+    false,
+);
+
+match create_local_workspace(project.clone(), preset_id.clone(), create_options.clone(), cx).await {
+    Ok(outcome) => Ok(outcome),
+    Err(error) if is_dirty_workspace_create_error(&error) => {
+        create_local_workspace(
+            project.clone(),
+            preset_id.clone(),
+            allow_dirty_workspace_create_options(create_options),
+            cx,
+        )
+        .await
+    }
+    Err(error) => Err(error),
+}
+```
+
+Also move the save controls next to the matching modal fields so `setup` and `teardown` can be saved independently:
+
+```rust
+Checkbox::new(
+    "superzent-new-workspace-save-setup-default",
+    self.save_lifecycle_defaults.setup_script.into(),
+)
+.label("Save as repo default")
+```
+
+```rust
+Checkbox::new(
+    "superzent-new-workspace-save-teardown-default",
+    self.save_lifecycle_defaults.teardown_script.into(),
+)
+.label("Save as repo default")
+```
+
+## Why This Works
+
+This restores the missing behavior without undoing the compaction contract.
+
+- Repo defaults still live only in repo-root `.superzent/config.json`.
+- `setup` remains a one-shot create-time action because nothing about the workspace model starts persisting setup state.
+- `teardown` remains the only workspace-local override because `workspace_teardown_script_override_for_create` still decides override persistence only for teardown, and only when teardown was not saved as the repo default.
+- Config writes remain transactional because they happen after `git worktree add`, with cleanup on write failure.
+- Dirty-workspace retries stop losing state because the retry path reuses the same `CreateWorkspaceOptions` instead of re-deriving the lifecycle selection state.
+
+## Prevention
+
+- When two create-time fields have different persistence rules, model save intent per field instead of hiding both behind one shared toggle.
+- Keep one regression suite around the high-risk paths: setup-only save, teardown-only save, empty-plus-save clearing, and dirty-workspace/untracked retries that must preserve lifecycle selections.
+
+## Related Issues
+
+- [managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md](../best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md) — the broader lifecycle source-of-truth and teardown-override contract this fix preserves
+- [managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md](../ui-bugs/managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md) — adjacent managed-workspace create-flow UI issue
+- GitHub issue search was skipped because `gh issue list` could not reach `api.github.com` from this environment


### PR DESCRIPTION
## Summary

Managed workspace creation can once again save `setup` and `teardown` defaults independently. This keeps repo config as the lifecycle source of truth, preserves teardown-only workspace persistence, and keeps dirty-workspace retry flows from dropping lifecycle save selections.

## What Changed

- Replaced the teardown-only save flag with field-level lifecycle default selections in `superzent_git` and `superzent_ui`
- Updated config staging so `setup` and `teardown` defaults can be saved or cleared independently while keeping create transactional
- Reused the same create options across allow-dirty retries so lifecycle scripts and save selections survive the second attempt
- Added targeted regression coverage and documented the change in brainstorm, plan, and solution docs

## Tests

- `cargo test -p superzent_git create_workspace_saves_selected_repo_default_setup`
- `cargo test -p superzent_git create_workspace_can_clear_repo_default_lifecycle_fields`
- `cargo test -p superzent_git create_workspace_saves_selected_repo_default_teardown_without_persisting_setup_script`
- `cargo test -p superzent_git move_changes_to_workspace_moves_tracked_and_untracked_changes_with_saved_defaults`
- `cargo test -p superzent_ui new_workspace_create_options_tracks_field_level_repo_default_saves`
- `cargo test -p superzent_ui allow_dirty_workspace_create_options_preserves_save_selections_and_scripts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.4-000000?logoColor=white)

Release Notes:

- Fixed managed workspace creation so setup and teardown defaults can be saved independently without losing selections during dirty-workspace retries.