### PR TITLE
Fix release notes button to open in browser

### DIFF
--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -284,20 +284,17 @@ pub fn notify_if_app_was_updated(cx: &mut App) {
                         NotificationId::unique::<UpdateNotification>(),
                         cx,
                         move |cx| {
-                            let workspace_handle = cx.entity().downgrade();
                             cx.new(|cx| {
                                 MessageNotification::new(
                                     format!("Updated to {app_name} {}", version),
                                     cx,
                                 )
                                 .primary_message("View Release Notes")
-                                .primary_on_click(move |window, cx| {
-                                    if let Some(workspace) = workspace_handle.upgrade() {
-                                        workspace.update(cx, |workspace, cx| {
-                                            crate::view_release_notes_locally(
-                                                workspace, window, cx,
-                                            );
-                                        })
+                                // Superzent doesn't serve the /api/release_notes endpoint,
+                                // so open the releases page in the browser directly.
+                                .primary_on_click(move |_window, cx| {
+                                    if let Some(url) = release_notes_url(cx) {
+                                        cx.open_url(&url);
                                     }
                                     cx.emit(DismissEvent);
                                 })


### PR DESCRIPTION
The "View Release Notes" button in the post-update notification tried to fetch from `/api/release_notes/v2/...` and render in-app. Superzent doesn't serve that endpoint, so clicking always failed silently. Now it opens the releases page (`releases.nangman.ai`) directly in the browser.

Release Notes:

- Fixed "View Release Notes" button in update notification to open in browser instead of failing silently

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)