### PR TITLE
superzent_ui: Add Reveal in Finder and Copy Path to workspace menu

### DIFF
--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -20,10 +20,10 @@ use editor::{Editor, EditorEvent, actions::SelectAll};
 use git::repository::validate_worktree_directory;
 use git_ui::git_panel::GitPanel;
 use gpui::{
-    Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, DismissEvent, Entity,
-    EntityId, EventEmitter, FocusHandle, Focusable, MouseButton, MouseDownEvent, PathPromptOptions,
-    Point, PromptLevel, ScrollHandle, SharedString, Subscription, Task, WeakEntity, WindowHandle,
-    actions, anchored, deferred, px,
+    Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, ClipboardItem,
+    DismissEvent, Entity, EntityId, EventEmitter, FocusHandle, Focusable, MouseButton,
+    MouseDownEvent, PathPromptOptions, Point, PromptLevel, ScrollHandle, SharedString,
+    Subscription, Task, WeakEntity, WindowHandle, actions, anchored, deferred, px,
 };
 use menu;
 use notifications::status_toast::{StatusToast, ToastIcon};
@@ -4095,7 +4095,33 @@ impl SuperzentSidebar {
     ) {
         let entity = cx.entity();
         let context_menu = ContextMenu::build(window, cx, move |menu, _window, _cx| {
-            let mut menu = menu.entry("Rename Workspace", None, {
+            let mut menu = menu;
+
+            if let WorkspaceLocation::Local { worktree_path } = &workspace.location {
+                let reveal_path = worktree_path.clone();
+                menu = menu.entry(
+                    if cfg!(target_os = "macos") {
+                        "Reveal in Finder"
+                    } else if cfg!(target_os = "windows") {
+                        "Reveal in File Explorer"
+                    } else {
+                        "Reveal in File Manager"
+                    },
+                    None,
+                    move |_window, cx| cx.reveal_path(&reveal_path),
+                );
+
+                let copy_path = worktree_path.clone();
+                menu = menu.entry("Copy Path", None, move |_window, cx| {
+                    cx.write_to_clipboard(ClipboardItem::new_string(
+                        copy_path.to_string_lossy().into_owned(),
+                    ));
+                });
+
+                menu = menu.separator();
+            }
+
+            menu = menu.entry("Rename Workspace", None, {
                 let entity = entity.clone();
                 let workspace_id = workspace.id.clone();
                 move |window, cx| {


### PR DESCRIPTION
## Summary

Adds two entries at the top of the workspace right-click context menu in the left sidebar, separated from the existing **Rename Workspace** / **Close Workspace** group:

- **Reveal in Finder** — labeled per platform (Reveal in File Explorer on Windows, Reveal in File Manager on Linux), calls `cx.reveal_path` on the workspace's worktree path.
- **Copy Path** — copies the worktree's absolute path to the clipboard.

Both entries are only shown for local workspaces; SSH workspaces are unchanged since revealing a remote path in the local file manager is not meaningful.

## Test plan

- [x] Right-click a local workspace → menu shows, top-to-bottom: Reveal in Finder, Copy Path, separator, Rename Workspace, Close Workspace.
- [x] Reveal in Finder opens the worktree directory in Finder (macOS).
- [x] Copy Path places the absolute worktree path on the clipboard.
- [x] Rename Workspace and Close Workspace still work.
- [ ] SSH workspace right-click menu is unchanged.

Release Notes:

- Added "Reveal in Finder" and "Copy Path" entries to the workspace right-click menu in the sidebar.