### PR TITLE
title_bar: Fix details sidebar toggle button when sidebar has focus

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -51,7 +51,7 @@ use update_version::UpdateVersion;
 use util::ResultExt;
 use workspace::{
     MultiWorkspace, ToggleRightDock, ToggleWorkspaceSidebar, ToggleWorktreeSecurity, Workspace,
-    notifications::NotifyResultExt,
+    dock::DockPosition, notifications::NotifyResultExt,
 };
 use zed_actions::OpenRemote;
 
@@ -426,8 +426,15 @@ impl TitleBar {
                                     )
                                 }
                             })
-                            .on_click(move |_, window, cx| {
-                                window.dispatch_action(Box::new(ToggleRightDock), cx);
+                            .on_click({
+                                let workspace = workspace.clone();
+                                move |_, window, cx| {
+                                    if let Some(workspace) = workspace.upgrade() {
+                                        workspace.update(cx, |workspace, cx| {
+                                            workspace.toggle_dock(DockPosition::Right, window, cx);
+                                        });
+                                    }
+                                }
                             }),
                     ),
             )

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -426,14 +426,11 @@ impl TitleBar {
                                     )
                                 }
                             })
-                            .on_click({
-                                let workspace = workspace.clone();
-                                move |_, window, cx| {
-                                    if let Some(workspace) = workspace.upgrade() {
-                                        workspace.update(cx, |workspace, cx| {
-                                            workspace.toggle_dock(DockPosition::Right, window, cx);
-                                        });
-                                    }
+                            .on_click(move |_, window, cx| {
+                                if let Some(workspace) = workspace.upgrade() {
+                                    workspace.update(cx, |workspace, cx| {
+                                        workspace.toggle_dock(DockPosition::Right, window, cx);
+                                    });
                                 }
                             }),
                     ),


### PR DESCRIPTION
## Summary

The top-right button in the superzent header dispatched `ToggleRightDock` via `window.dispatch_action`. That action's handler is registered on the `Workspace` view (`crates/workspace/src/workspace.rs:6672`). After the first click opens the dock, `toggle_dock` moves focus onto the sidebar panel — from that focus position the dispatched action didn't reach the Workspace handler, so clicking the button a second time did nothing until the user moved focus away first.

Fix: call `workspace.toggle_dock(DockPosition::Right, ...)` directly on the workspace entity from the button's `on_click`. This matches how the button already reads `workspace.right_dock().is_open()` for its icon state, and avoids dependence on current focus position. The keyboard shortcut still goes through the action path, which is unaffected.

The left-sidebar button in the same header uses `ToggleWorkspaceSidebar`, whose handler lives on `MultiWorkspace` (the outer root), so it's always reachable regardless of focus — which is why only the right button showed this symptom.

## Test plan

- [x] Click the top-right button → details sidebar opens.
- [x] Click it again without moving focus → sidebar hides.
- [ ] Keyboard shortcut (`cmd-alt-k` on macOS) still toggles the dock.
- [ ] Left-sidebar button behavior unchanged.

Release Notes:

- Fixed the top-right sidebar toggle button not hiding the details sidebar on a second click when the sidebar held focus.