### PR TITLE
Merge CenterPaneFooter into StatusBar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1634,7 +1634,7 @@
   // Status bar-related settings.
   "status_bar": {
     // Whether to show the status bar.
-    "experimental.show": false,
+    "experimental.show": true,
     // Whether to show the active language button in the status bar.
     "active_language_button": true,
     // Whether to show the cursor position button in the status bar.

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -276,22 +276,12 @@ impl MultiWorkspace {
 
     pub fn open_sidebar(&mut self, cx: &mut Context<Self>) {
         self.sidebar_open = true;
-        for workspace in &self.workspaces {
-            workspace.update(cx, |workspace, cx| {
-                workspace.set_workspace_sidebar_open(true, cx);
-            });
-        }
         self.serialize(cx);
         cx.notify();
     }
 
     fn close_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.sidebar_open = false;
-        for workspace in &self.workspaces {
-            workspace.update(cx, |workspace, cx| {
-                workspace.set_workspace_sidebar_open(false, cx);
-            });
-        }
         let pane = self.workspace().read(cx).active_pane().clone();
         let pane_focus = pane.read(cx).focus_handle(cx);
         window.focus(&pane_focus, cx);
@@ -474,11 +464,6 @@ impl MultiWorkspace {
             self.record_workspace_usage(self.workspaces[index].entity_id());
             index
         } else {
-            if self.sidebar_open {
-                workspace.update(cx, |workspace, cx| {
-                    workspace.set_workspace_sidebar_open(true, cx);
-                });
-            }
             Self::subscribe_to_workspace(&workspace, cx);
             self.workspaces.push(workspace.clone());
             self.record_workspace_usage(workspace.entity_id());
@@ -502,12 +487,6 @@ impl MultiWorkspace {
         else {
             return false;
         };
-
-        if self.sidebar_open {
-            new_workspace.update(cx, |workspace, cx| {
-                workspace.set_workspace_sidebar_open(true, cx);
-            });
-        }
 
         Self::subscribe_to_workspace(&new_workspace, cx);
         let removed_workspace =

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -1,7 +1,6 @@
 use crate::{ItemHandle, Pane};
 use gpui::{
-    AnyView, App, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription,
-    Window,
+    AnyView, App, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, Window,
 };
 use std::any::TypeId;
 use ui::{h_flex, prelude::*};

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -1,10 +1,9 @@
 use crate::{ItemHandle, Pane};
 use gpui::{
-    AnyView, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
-    Subscription, Window,
+    AnyView, App, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription,
+    Window,
 };
 use std::any::TypeId;
-use theme::CLIENT_SIDE_DECORATION_ROUNDING;
 use ui::{h_flex, prelude::*};
 use util::ResultExt;
 
@@ -147,44 +146,9 @@ impl StatusItemStrip {
 pub struct StatusBar {
     items: StatusItemStrip,
     _observe_active_pane: Subscription,
-    workspace_sidebar_open: bool,
-}
-
-pub struct CenterPaneFooter {
-    items: StatusItemStrip,
-    _observe_active_pane: Subscription,
 }
 
 impl Render for StatusBar {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        h_flex()
-            .w_full()
-            .justify_between()
-            .gap(DynamicSpacing::Base08.rems(cx))
-            .py(DynamicSpacing::Base04.rems(cx))
-            .px(DynamicSpacing::Base06.rems(cx))
-            .bg(cx.theme().colors().status_bar_background)
-            .map(|el| match window.window_decorations() {
-                Decorations::Server => el,
-                Decorations::Client { tiling, .. } => el
-                    .when(!(tiling.bottom || tiling.right), |el| {
-                        el.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING)
-                    })
-                    .when(
-                        !(tiling.bottom || tiling.left) && !self.workspace_sidebar_open,
-                        |el| el.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING),
-                    )
-                    // This border is to avoid a transparent gap in the rounded corners
-                    .mb(px(-1.))
-                    .border_b(px(1.0))
-                    .border_color(cx.theme().colors().status_bar_background),
-            })
-            .child(self.items.render_left_tools())
-            .child(self.items.render_right_tools())
-    }
-}
-
-impl Render for CenterPaneFooter {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         h_flex()
             .w_full()
@@ -207,15 +171,13 @@ impl StatusBar {
             _observe_active_pane: cx.observe_in(active_pane, window, |this, _, window, cx| {
                 this.items.update_active_pane_item(window, cx)
             }),
-            workspace_sidebar_open: false,
         };
         this.items.update_active_pane_item(window, cx);
         this
     }
 
-    pub fn set_workspace_sidebar_open(&mut self, open: bool, cx: &mut Context<Self>) {
-        self.workspace_sidebar_open = open;
-        cx.notify();
+    pub fn has_items(&self) -> bool {
+        self.items.has_items()
     }
 
     pub fn add_left_item<T>(&mut self, item: Entity<T>, window: &mut Window, cx: &mut Context<Self>)
@@ -252,56 +214,6 @@ impl StatusBar {
 
     pub fn remove_item_at(&mut self, position: usize, cx: &mut Context<Self>) {
         self.items.remove_item_at(position);
-        cx.notify();
-    }
-
-    pub fn add_right_item<T>(
-        &mut self,
-        item: Entity<T>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) where
-        T: 'static + StatusItemView,
-    {
-        self.items.add_right_item(item, window, cx);
-        cx.notify();
-    }
-
-    pub fn set_active_pane(
-        &mut self,
-        active_pane: &Entity<Pane>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.items.set_active_pane(active_pane);
-        self._observe_active_pane = cx.observe_in(active_pane, window, |this, _, window, cx| {
-            this.items.update_active_pane_item(window, cx)
-        });
-        self.items.update_active_pane_item(window, cx);
-    }
-}
-
-impl CenterPaneFooter {
-    pub fn new(active_pane: &Entity<Pane>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let mut this = Self {
-            items: StatusItemStrip::new(active_pane),
-            _observe_active_pane: cx.observe_in(active_pane, window, |this, _, window, cx| {
-                this.items.update_active_pane_item(window, cx)
-            }),
-        };
-        this.items.update_active_pane_item(window, cx);
-        this
-    }
-
-    pub fn has_items(&self) -> bool {
-        self.items.has_items()
-    }
-
-    pub fn add_left_item<T>(&mut self, item: Entity<T>, window: &mut Window, cx: &mut Context<Self>)
-    where
-        T: 'static + StatusItemView,
-    {
-        self.items.add_left_item(item, window, cx);
         cx.notify();
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -109,8 +109,8 @@ use sqlez::{
     bindable::{Bind, Column, StaticColumnCount},
     statement::Statement,
 };
-pub use status_bar::StatusItemView;
 use status_bar::StatusBar;
+pub use status_bar::StatusItemView;
 use std::{
     any::TypeId,
     borrow::Cow,
@@ -1634,9 +1634,8 @@ impl Workspace {
         let left_dock = Dock::new(DockPosition::Left, modal_layer.clone(), window, cx);
         let bottom_dock = Dock::new(DockPosition::Bottom, modal_layer.clone(), window, cx);
         let right_dock = Dock::new(DockPosition::Right, modal_layer.clone(), window, cx);
-        let status_bar_bottom_dock_buttons = cx.new(|cx| {
-            PanelButtons::new_only(bottom_dock.clone(), STATUS_BAR_BOTTOM_PANELS, cx)
-        });
+        let status_bar_bottom_dock_buttons =
+            cx.new(|cx| PanelButtons::new_only(bottom_dock.clone(), STATUS_BAR_BOTTOM_PANELS, cx));
         let status_bar = cx.new(|cx| {
             let mut status_bar = StatusBar::new(&center_pane.clone(), window, cx);
             status_bar.add_right_item(status_bar_bottom_dock_buttons, window, cx);
@@ -7922,53 +7921,45 @@ impl Render for Workspace {
                                                 ))),
                                         ),
 
-                                    BottomDockLayout::Contained => {
-                                        div()
-                                            .flex()
-                                            .flex_row()
-                                            .h_full()
-                                            .children(self.render_dock(
-                                                DockPosition::Left,
-                                                &self.left_dock,
-                                                window,
-                                                cx,
-                                            ))
-                                            .child(
-                                                div()
-                                                    .flex()
-                                                    .flex_col()
-                                                    .flex_1()
-                                                    .overflow_hidden()
-                                                    .child(self.render_center_pane_stack(
-                                                        paddings.0,
-                                                        paddings.1,
-                                                        window,
-                                                        cx,
-                                                    ))
-                                                    .children(self.render_dock(
-                                                        DockPosition::Bottom,
-                                                        &self.bottom_dock,
-                                                        window,
-                                                        cx,
-                                                    ))
-                                                    .when(
-                                                        self.status_bar_visible(cx),
-                                                        |this| {
-                                                            this.child(
-                                                                self.render_status_bar_with_left_offset(
-                                                                    None,
-                                                                ),
-                                                            )
-                                                        },
-                                                    ),
-                                            )
-                                            .children(self.render_dock(
-                                                DockPosition::Right,
-                                                &self.right_dock,
-                                                window,
-                                                cx,
-                                            ))
-                                    }
+                                    BottomDockLayout::Contained => div()
+                                        .flex()
+                                        .flex_row()
+                                        .h_full()
+                                        .children(self.render_dock(
+                                            DockPosition::Left,
+                                            &self.left_dock,
+                                            window,
+                                            cx,
+                                        ))
+                                        .child(
+                                            div()
+                                                .flex()
+                                                .flex_col()
+                                                .flex_1()
+                                                .overflow_hidden()
+                                                .child(self.render_center_pane_stack(
+                                                    paddings.0, paddings.1, window, cx,
+                                                ))
+                                                .children(self.render_dock(
+                                                    DockPosition::Bottom,
+                                                    &self.bottom_dock,
+                                                    window,
+                                                    cx,
+                                                ))
+                                                .when(self.status_bar_visible(cx), |this| {
+                                                    this.child(
+                                                        self.render_status_bar_with_left_offset(
+                                                            None,
+                                                        ),
+                                                    )
+                                                }),
+                                        )
+                                        .children(self.render_dock(
+                                            DockPosition::Right,
+                                            &self.right_dock,
+                                            window,
+                                            cx,
+                                        )),
                                 }
                             }))
                             .when(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -110,7 +110,7 @@ use sqlez::{
     statement::Statement,
 };
 pub use status_bar::StatusItemView;
-use status_bar::{CenterPaneFooter, StatusBar};
+use status_bar::StatusBar;
 use std::{
     any::TypeId,
     borrow::Cow,
@@ -173,7 +173,7 @@ static ZED_WINDOW_POSITION: LazyLock<Option<Point<Pixels>>> = LazyLock::new(|| {
         .and_then(parse_pixel_position_env_var)
 });
 
-const CENTER_PANE_FOOTER_BOTTOM_PANELS: &[&str] = &["TerminalPanel", "DebugPanel"];
+const STATUS_BAR_BOTTOM_PANELS: &[&str] = &["TerminalPanel", "DebugPanel"];
 
 pub trait TerminalProvider {
     fn spawn(
@@ -1310,7 +1310,6 @@ pub struct Workspace {
     last_active_center_pane: Option<WeakEntity<Pane>>,
     last_active_view_id: Option<proto::ViewId>,
     status_bar: Entity<StatusBar>,
-    center_pane_footer: Entity<CenterPaneFooter>,
     pub(crate) modal_layer: Entity<ModalLayer>,
     toast_layer: Entity<ToastLayer>,
     titlebar_item: Option<AnyView>,
@@ -1635,23 +1634,11 @@ impl Workspace {
         let left_dock = Dock::new(DockPosition::Left, modal_layer.clone(), window, cx);
         let bottom_dock = Dock::new(DockPosition::Bottom, modal_layer.clone(), window, cx);
         let right_dock = Dock::new(DockPosition::Right, modal_layer.clone(), window, cx);
-        let left_dock_buttons = cx.new(|cx| PanelButtons::new(left_dock.clone(), cx));
         let status_bar_bottom_dock_buttons = cx.new(|cx| {
-            PanelButtons::new_except(bottom_dock.clone(), CENTER_PANE_FOOTER_BOTTOM_PANELS, cx)
-        });
-        let center_pane_footer_bottom_dock_buttons = cx.new(|cx| {
-            PanelButtons::new_only(bottom_dock.clone(), CENTER_PANE_FOOTER_BOTTOM_PANELS, cx)
-        });
-        let right_dock_buttons = cx.new(|cx| PanelButtons::new(right_dock.clone(), cx));
-        let center_pane_footer = cx.new(|cx| {
-            let mut center_pane_footer = CenterPaneFooter::new(&center_pane.clone(), window, cx);
-            center_pane_footer.add_right_item(center_pane_footer_bottom_dock_buttons, window, cx);
-            center_pane_footer
+            PanelButtons::new_only(bottom_dock.clone(), STATUS_BAR_BOTTOM_PANELS, cx)
         });
         let status_bar = cx.new(|cx| {
             let mut status_bar = StatusBar::new(&center_pane.clone(), window, cx);
-            status_bar.add_left_item(left_dock_buttons, window, cx);
-            status_bar.add_right_item(right_dock_buttons, window, cx);
             status_bar.add_right_item(status_bar_bottom_dock_buttons, window, cx);
             status_bar
         });
@@ -1731,7 +1718,6 @@ impl Workspace {
             last_active_center_pane: Some(center_pane.downgrade()),
             last_active_view_id: None,
             status_bar,
-            center_pane_footer,
             modal_layer,
             toast_layer,
             titlebar_item: None,
@@ -2194,22 +2180,8 @@ impl Workspace {
         &self.status_bar
     }
 
-    pub fn center_pane_footer(&self) -> &Entity<CenterPaneFooter> {
-        &self.center_pane_footer
-    }
-
-    pub fn set_workspace_sidebar_open(&self, open: bool, cx: &mut App) {
-        self.status_bar.update(cx, |status_bar, cx| {
-            status_bar.set_workspace_sidebar_open(open, cx);
-        });
-    }
-
     pub fn status_bar_visible(&self, cx: &App) -> bool {
         StatusBarSettings::get_global(cx).show
-    }
-
-    fn center_pane_footer_visible(&self, cx: &App) -> bool {
-        self.center_pane_footer.read(cx).has_items()
     }
 
     pub fn app_state(&self) -> &Arc<AppState> {
@@ -4800,10 +4772,6 @@ impl Workspace {
         self.status_bar.update(cx, |status_bar, cx| {
             status_bar.set_active_pane(pane, window, cx);
         });
-        self.center_pane_footer
-            .update(cx, |center_pane_footer, cx| {
-                center_pane_footer.set_active_pane(pane, window, cx);
-            });
     }
 
     fn handle_panel_focused(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -7099,7 +7067,7 @@ impl Workspace {
         )
     }
 
-    fn render_center_pane_footer_row(&self, window: &Window, cx: &App) -> Div {
+    fn render_status_bar_row(&self, window: &Window, cx: &App) -> Div {
         let left_dock_width = self.left_dock.read(cx).active_panel_size(window, cx);
         let right_dock_width = self.right_dock.read(cx).active_panel_size(window, cx);
 
@@ -7113,14 +7081,14 @@ impl Workspace {
                     .flex_1()
                     .min_w_0()
                     .overflow_hidden()
-                    .child(self.center_pane_footer.clone()),
+                    .child(self.status_bar.clone()),
             )
             .when_some(right_dock_width, |this, width| {
                 this.child(div().w(width).flex_none())
             })
     }
 
-    fn render_center_pane_footer_with_left_offset(&self, left_offset: Option<Pixels>) -> Div {
+    fn render_status_bar_with_left_offset(&self, left_offset: Option<Pixels>) -> Div {
         h_flex()
             .w_full()
             .when_some(left_offset, |this, width| {
@@ -7131,7 +7099,7 @@ impl Workspace {
                     .flex_1()
                     .min_w_0()
                     .overflow_hidden()
-                    .child(self.center_pane_footer.clone()),
+                    .child(self.status_bar.clone()),
             )
     }
 
@@ -7898,9 +7866,9 @@ impl Render for Workspace {
                                                     window,
                                                     cx,
                                                 )))
-                                                .when(self.center_pane_footer_visible(cx), |this| {
+                                                .when(self.status_bar_visible(cx), |this| {
                                                     this.child(
-                                                        self.render_center_pane_footer_with_left_offset(
+                                                        self.render_status_bar_with_left_offset(
                                                             self.left_dock
                                                                 .read(cx)
                                                                 .active_panel_size(window, cx),
@@ -7984,10 +7952,10 @@ impl Render for Workspace {
                                                         cx,
                                                     ))
                                                     .when(
-                                                        self.center_pane_footer_visible(cx),
+                                                        self.status_bar_visible(cx),
                                                         |this| {
                                                             this.child(
-                                                                self.render_center_pane_footer_with_left_offset(
+                                                                self.render_status_bar_with_left_offset(
                                                                     None,
                                                                 ),
                                                             )
@@ -8004,12 +7972,12 @@ impl Render for Workspace {
                                 }
                             }))
                             .when(
-                                self.center_pane_footer_visible(cx)
+                                self.status_bar_visible(cx)
                                     && matches!(
                                         bottom_dock_layout,
                                         BottomDockLayout::Full | BottomDockLayout::RightAligned
                                     ),
-                                |this| this.child(self.render_center_pane_footer_row(window, cx)),
+                                |this| this.child(self.render_status_bar_row(window, cx)),
                             )
                             .children(self.zoomed.as_ref().and_then(|view| {
                                 let zoomed_view = view.upgrade()?;
@@ -8036,9 +8004,6 @@ impl Render for Workspace {
                             }))
                             .children(self.render_notifications(window, cx)),
                     )
-                    .when(self.status_bar_visible(cx), |parent| {
-                        parent.child(self.status_bar.clone())
-                    })
                     .child(self.toast_layer.clone()),
             )
     }
@@ -13503,10 +13468,10 @@ mod tests {
         let (workspace, _cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
-        // Superzent hides the status bar by default.
+        // Superzent shows the status bar by default.
         workspace.read_with(cx, |workspace, cx| {
             let visible = workspace.status_bar_visible(cx);
-            assert!(!visible, "Status bar should be hidden by default");
+            assert!(visible, "Status bar should be visible by default");
         });
 
         // Test with status bar hidden

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -36,7 +36,6 @@ use gpui::{
     UpdateGlobal, Window, WindowHandle, WindowKind, WindowOptions, actions, image_cache, point, px,
     retain_all,
 };
-use image_viewer::ImageInfo;
 use language::Capability;
 use language_onboarding::BasedPyrightBanner;
 use language_tools::lsp_button::{self, LspButton};
@@ -493,7 +492,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             }
         });
 
-        let search_button = cx.new(|_| search::search_status_button::SearchButton::new());
         let diagnostic_summary =
             cx.new(|cx| diagnostics::items::DiagnosticIndicator::new(workspace, cx));
         let activity_indicator = activity_indicator::ActivityIndicator::new(
@@ -509,7 +507,6 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         let active_toolchain_language =
             cx.new(|cx| toolchain_selector::ActiveToolchain::new(workspace, window, cx));
         let vim_mode_indicator = cx.new(|cx| vim::ModeIndicator::new(window, cx));
-        let image_info = cx.new(|_cx| ImageInfo::new(workspace));
 
         let lsp_button_menu_handle = PopoverMenuHandle::default();
         let lsp_button =
@@ -526,25 +523,19 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
         let pending_keystroke_indicator =
             cx.new(|cx| superzent_ui::PendingKeystrokeIndicator::new(window, cx));
-        workspace
-            .center_pane_footer()
-            .update(cx, |center_pane_footer, cx| {
-                #[cfg(feature = "next_edit")]
-                center_pane_footer.add_left_item(edit_prediction_ui, window, cx);
-                center_pane_footer.add_left_item(lsp_button, window, cx);
-                center_pane_footer.add_left_item(diagnostic_summary, window, cx);
-                center_pane_footer.add_right_item(pending_keystroke_indicator, window, cx);
-                center_pane_footer.add_right_item(cursor_position, window, cx);
-                center_pane_footer.add_right_item(active_toolchain_language, window, cx);
-            });
         workspace.status_bar().update(cx, |status_bar, cx| {
-            status_bar.add_left_item(search_button, window, cx);
+            #[cfg(feature = "next_edit")]
+            status_bar.add_left_item(edit_prediction_ui, window, cx);
+            status_bar.add_left_item(lsp_button, window, cx);
+            status_bar.add_left_item(diagnostic_summary, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
+            status_bar.add_right_item(line_ending_indicator, window, cx);
             status_bar.add_right_item(active_buffer_encoding, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);
-            status_bar.add_right_item(line_ending_indicator, window, cx);
+            status_bar.add_right_item(active_toolchain_language, window, cx);
+            status_bar.add_right_item(cursor_position, window, cx);
+            status_bar.add_right_item(pending_keystroke_indicator, window, cx);
             status_bar.add_right_item(vim_mode_indicator, window, cx);
-            status_bar.add_right_item(image_info, window, cx);
         });
 
         let panels_task = initialize_panels(window, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -492,6 +492,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             }
         });
 
+        let search_button = cx.new(|_| search::search_status_button::SearchButton::new());
         let diagnostic_summary =
             cx.new(|cx| diagnostics::items::DiagnosticIndicator::new(workspace, cx));
         let activity_indicator = activity_indicator::ActivityIndicator::new(
@@ -527,6 +528,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             #[cfg(feature = "next_edit")]
             status_bar.add_left_item(edit_prediction_ui, window, cx);
             status_bar.add_left_item(lsp_button, window, cx);
+            status_bar.add_left_item(search_button, window, cx);
             status_bar.add_left_item(diagnostic_summary, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
             status_bar.add_right_item(line_ending_indicator, window, cx);

--- a/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
+++ b/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
@@ -22,12 +22,14 @@ Superzent currently maintains two separate bottom bars: `CenterPaneFooter` (visi
 - R4. The merged bar must display the following items, split left/right:
 
   Left (status/tool indicators):
+
   - Edit Prediction Button
   - LSP Button
   - Diagnostic Indicator
   - Activity Indicator
 
   Right (editor context info, in order):
+
   - Vim Mode Indicator
   - Pending Keystroke Indicator
   - Cursor Position

--- a/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
+++ b/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
@@ -25,6 +25,7 @@ Superzent currently maintains two separate bottom bars: `CenterPaneFooter` (visi
 
   - Edit Prediction Button
   - LSP Button
+  - Search Button
   - Diagnostic Indicator
   - Activity Indicator
 
@@ -41,7 +42,6 @@ Superzent currently maintains two separate bottom bars: `CenterPaneFooter` (visi
 
 - R5. The following current StatusBar items must be removed from registration:
   - Left/Right dock Panel Toggle Buttons
-  - Search Button
   - Image Info
 
 **Visual**

--- a/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
+++ b/docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
@@ -1,0 +1,63 @@
+---
+date: 2026-04-15
+topic: center-pane-footer-statusbar-merge
+---
+
+# Center Pane Footer / Status Bar Merge
+
+## Problem Frame
+
+Superzent currently maintains two separate bottom bars: `CenterPaneFooter` (visible, positioned between docks) and `StatusBar` (hidden by default, full window width). Both use the same `StatusItemStrip` infrastructure and `StatusItemView` trait. The CenterPaneFooter was introduced as Superzent's replacement for the upstream StatusBar, but maintaining a separate component increases divergence from Zed upstream and creates redundant code paths. Merging them reduces that divergence while preserving Superzent's desired layout and item composition.
+
+## Requirements
+
+**Structural**
+
+- R1. Remove `CenterPaneFooter` as a separate component. The `StatusBar` becomes the single bottom information bar.
+- R2. Position the `StatusBar` where `CenterPaneFooter` currently renders: inside the center pane column, between the left and right docks — not at the full window width.
+- R3. The `StatusBar` must be visible by default (`show: true`). The existing `status_bar.show` setting must continue to control visibility.
+
+**Item Composition**
+
+- R4. The merged bar must display the following items, split left/right:
+
+  Left (status/tool indicators):
+  - Edit Prediction Button
+  - LSP Button
+  - Diagnostic Indicator
+  - Activity Indicator
+
+  Right (editor context info, in order):
+  - Vim Mode Indicator
+  - Pending Keystroke Indicator
+  - Cursor Position
+  - Active Toolchain
+  - Buffer Language
+  - Buffer Encoding
+  - Line Ending Indicator
+  - **Terminal Panel + Debug Panel toggle buttons** (far right, preserving current `CENTER_PANE_FOOTER_BOTTOM_PANELS` behavior)
+
+- R5. The following current StatusBar items must be removed from registration:
+  - Left/Right dock Panel Toggle Buttons
+  - Search Button
+  - Image Info
+
+**Visual**
+
+- R6. The bar's visual style (border, background, padding) should follow the existing `StatusBar` render style, adapted for the narrower center-pane-width position.
+- R7. Window decoration handling (bottom corner rounding for client-side decorations) must be adjusted since the bar is no longer at the window bottom edge.
+
+## Non-Goals
+
+- N1. No new items or indicators are being added — this is a consolidation of existing items.
+- N2. No changes to the `StatusItemView` trait or `StatusItemStrip` internals.
+- N3. Left/Right dock panel toggle buttons do not need an alternative placement — they remain accessible via keyboard shortcuts and menus.
+
+## Success Criteria
+
+- S1. Only one bottom bar component exists in the codebase.
+- S2. The bar renders between docks at the center pane bottom, matching current CenterPaneFooter position.
+- S3. All specified items render correctly and respond to active pane changes.
+- S4. Terminal Panel and Debug Panel toggle buttons remain at the far right.
+- S5. `status_bar.show` setting still toggles visibility.
+- S6. Existing tests for StatusBar visibility pass (with updated default expectation).

--- a/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
+++ b/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
@@ -76,24 +76,29 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Dependencies:** None
 
   **Files:**
+
   - Modify: `crates/workspace/src/status_bar.rs`
 
   **Approach:**
+
   - Add `has_items() -> bool` method to StatusBar (delegate to `self.items.has_items()`)
   - Remove `workspace_sidebar_open` field and `set_workspace_sidebar_open()` method from StatusBar
   - Change StatusBar's `Render` impl to match CenterPaneFooter's style: top border (`border_t_1`), `panel_background` background, remove all client-side window decoration rounding logic
   - Delete the entire `CenterPaneFooter` struct, its `Render` impl, and its `impl` block
 
   **Patterns to follow:**
+
   - CenterPaneFooter's `Render` impl (status_bar.rs lines 187-200) is the target style
   - CenterPaneFooter's `has_items()` (line 296) is the pattern to port
 
   **Test scenarios:**
+
   - Happy path: StatusBar renders with top border and `panel_background` when items are present
   - Happy path: `has_items()` returns true when items are added, false when empty
   - Edge case: StatusBar with no items renders nothing (or empty bar) — verify `has_items()` returns false
 
   **Verification:**
+
   - `CenterPaneFooter` type no longer exists in the codebase
   - StatusBar compiles with new render style and `has_items()` method
 
@@ -106,13 +111,15 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Dependencies:** Unit 1
 
   **Files:**
+
   - Modify: `crates/workspace/src/workspace.rs`
 
   **Approach:**
+
   - Remove `center_pane_footer: Entity<CenterPaneFooter>` field from Workspace struct
   - Remove `center_pane_footer()` accessor and `center_pane_footer_visible()` method
   - Remove `CenterPaneFooter` from the `use status_bar::{...}` import
-  - In construction (lines 1638-1657): remove `center_pane_footer_bottom_dock_buttons` creation. Change `status_bar_bottom_dock_buttons` to use `PanelButtons::new_only` (was `new_except`) with `STATUS_BAR_BOTTOM_PANELS` — now the StatusBar gets *only* Terminal+Debug buttons instead of *everything except* them
+  - In construction (lines 1638-1657): remove `center_pane_footer_bottom_dock_buttons` creation. Change `status_bar_bottom_dock_buttons` to use `PanelButtons::new_only` (was `new_except`) with `STATUS_BAR_BOTTOM_PANELS` — now the StatusBar gets _only_ Terminal+Debug buttons instead of _everything except_ them
   - Remove `left_dock_buttons` and `right_dock_buttons` creation and their `add_left_item`/`add_right_item` calls on StatusBar (R5: removing left/right dock panel toggle buttons)
   - Remove `center_pane_footer` from struct initialization
   - In `set_status_item_active_pane()` (line 4794): remove the `center_pane_footer.update()` call, keep only the `status_bar.update()` call
@@ -120,14 +127,17 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   - Rename `CENTER_PANE_FOOTER_BOTTOM_PANELS` to `STATUS_BAR_BOTTOM_PANELS`
 
   **Patterns to follow:**
+
   - Existing StatusBar construction pattern (lines 1651-1656)
 
   **Test scenarios:**
+
   - Happy path: Workspace initializes successfully with only StatusBar, no CenterPaneFooter
   - Happy path: Active pane changes propagate to StatusBar items
   - Integration: Terminal and Debug panel buttons appear in StatusBar's right items
 
   **Verification:**
+
   - No references to `CenterPaneFooter` or `center_pane_footer` remain in workspace.rs
   - No references to `left_dock_buttons` or `right_dock_buttons` PanelButtons remain
   - Project compiles
@@ -141,9 +151,11 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Dependencies:** Unit 2
 
   **Files:**
+
   - Modify: `crates/workspace/src/workspace.rs`
 
   **Approach:**
+
   - Remove the old StatusBar rendering at the window bottom (lines 8039-8041)
   - Replace every `center_pane_footer_visible(cx)` / `center_pane_footer.clone()` occurrence in the four `BottomDockLayout` branches with `status_bar_visible(cx)` / `status_bar.clone()`
   - In `render_center_pane_footer_row()` and `render_center_pane_footer_with_left_offset()`: replace `self.center_pane_footer.clone()` with `self.status_bar.clone()`. Consider renaming these methods to `render_status_bar_row()` and `render_status_bar_with_left_offset()` for clarity.
@@ -154,9 +166,11 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
     - **RightAligned**: footer rendered as separate row after main content with dock-width spacers — same approach
 
   **Patterns to follow:**
+
   - The existing four-variant layout rendering pattern (lines 7850-8012) — same structure, just swapping the entity reference and visibility check
 
   **Test scenarios:**
+
   - Happy path: StatusBar renders in center pane footer position with `BottomDockLayout::Contained`
   - Happy path: StatusBar respects dock widths in `Full` and `RightAligned` layouts (dock-width spacers present)
   - Happy path: StatusBar respects left dock width in `LeftAligned` layout
@@ -164,6 +178,7 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   - Integration: `which_key` modal still adds bottom padding when StatusBar is visible
 
   **Verification:**
+
   - StatusBar no longer renders at window bottom edge
   - StatusBar renders between docks in all four layout variants
   - Visual inspection confirms correct positioning
@@ -177,9 +192,11 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Dependencies:** Unit 2
 
   **Files:**
+
   - Modify: `crates/zed/src/zed.rs`
 
   **Approach:**
+
   - Remove the `center_pane_footer().update()` call (lines 530-538)
   - Replace the `status_bar().update()` call (lines 540-548) with a single call registering all items in order:
     - Left: `edit_prediction_ui` (cfg-gated with `#[cfg(feature = "next_edit")]`), `lsp_button`, `diagnostic_summary`, `activity_indicator`
@@ -189,16 +206,19 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   - Verify right-side ordering: items are rendered in reverse order by `StatusItemStrip` (line 62 of status_bar.rs), so registration order must be reversed from desired display order. The desired display is: `[Vim][Keys][Cursor][Toolchain][Lang][Encoding][LineEnding][Terminal][Debug]`. Since Terminal+Debug are added first during construction, the remaining items added in zed.rs should be added in reverse display order: `line_ending_indicator`, `active_buffer_encoding`, `active_buffer_language`, `active_toolchain_language`, `cursor_position`, `pending_keystroke_indicator`, `vim_mode_indicator`
 
   **Patterns to follow:**
+
   - Current registration pattern in zed.rs (lines 530-548)
   - `StatusItemStrip::render_right_tools()` reverses item order (status_bar.rs line 62)
 
   **Test scenarios:**
+
   - Happy path: All 11 items render in correct left/right positions
   - Happy path: Terminal+Debug panel buttons appear at the far right
   - Happy path: Edit Prediction Button only appears when `next_edit` feature is enabled
   - Integration: Items respond to active pane changes (cursor position updates, language changes, etc.)
 
   **Verification:**
+
   - No `center_pane_footer()` calls remain in zed.rs
   - `search_button` and `image_info` variables are removed
   - Visual inspection confirms item ordering matches the spec
@@ -212,23 +232,28 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Dependencies:** Units 1-4
 
   **Files:**
+
   - Modify: `assets/settings/default.json`
   - Modify: `crates/workspace/src/workspace.rs` (test at line 13498)
 
   **Approach:**
+
   - In `assets/settings/default.json` line 1637: change `"experimental.show": false` to `"experimental.show": true`
   - In `test_status_bar_visibility` (workspace.rs line 13498): flip the first assertion from `assert!(!visible, "Status bar should be hidden by default")` to `assert!(visible, "Status bar should be visible by default")`
   - Update the test's comment `"Superzent hides the status bar by default"` to reflect the new default
 
   **Patterns to follow:**
+
   - Existing test structure at workspace.rs lines 13498-13535
 
   **Test scenarios:**
+
   - Happy path: `status_bar_visible()` returns `true` by default
   - Happy path: Setting `show: false` hides the bar
   - Happy path: Setting `show: true` shows the bar (no change from current)
 
   **Verification:**
+
   - `test_status_bar_visibility` passes with updated assertions
   - `./script/clippy` passes
 
@@ -243,11 +268,11 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
+| Risk                                                                                   | Mitigation                                                                                  |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Right-item ordering is reversed by `StatusItemStrip` — easy to get display order wrong | Carefully trace `render_right_tools()` reversal logic; verify visually after implementation |
-| `set_workspace_sidebar_open` removal may break callers in `MultiWorkspace` | Compile errors will surface immediately; search for all callers before removing |
-| `BottomDockLayout::Full` and `RightAligned` variants have distinct footer placement | Test all four variants manually or with layout tests |
+| `set_workspace_sidebar_open` removal may break callers in `MultiWorkspace`             | Compile errors will surface immediately; search for all callers before removing             |
+| `BottomDockLayout::Full` and `RightAligned` variants have distinct footer placement    | Test all four variants manually or with layout tests                                        |
 
 ## Sources & References
 

--- a/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
+++ b/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
@@ -21,8 +21,8 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
 - R1. Remove `CenterPaneFooter` as a separate component
 - R2. Position `StatusBar` in the center pane footer location (between docks)
 - R3. `StatusBar` visible by default (`show: true`), setting still controls visibility
-- R4. Item composition: Left (Edit Prediction, LSP, Diagnostics, Activity Indicator) / Right (Vim Mode, Pending Keystroke, Cursor Position, Active Toolchain, Buffer Language, Buffer Encoding, Line Endings, Terminal+Debug panel buttons)
-- R5. Remove: Left/Right dock panel toggle buttons, Search button, Image Info
+- R4. Item composition: Left (Edit Prediction, LSP, Search, Diagnostics, Activity Indicator) / Right (Vim Mode, Pending Keystroke, Cursor Position, Active Toolchain, Buffer Language, Buffer Encoding, Line Endings, Terminal+Debug panel buttons)
+- R5. Remove: Left/Right dock panel toggle buttons, Image Info
 - R6. Visual style follows existing StatusBar render style, adapted for center-pane width
 - R7. Window decoration handling adjusted for non-window-bottom position
 
@@ -199,10 +199,10 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
 
   - Remove the `center_pane_footer().update()` call (lines 530-538)
   - Replace the `status_bar().update()` call (lines 540-548) with a single call registering all items in order:
-    - Left: `edit_prediction_ui` (cfg-gated with `#[cfg(feature = "next_edit")]`), `lsp_button`, `diagnostic_summary`, `activity_indicator`
+    - Left: `edit_prediction_ui` (cfg-gated with `#[cfg(feature = "next_edit")]`), `lsp_button`, `search_button`, `diagnostic_summary`, `activity_indicator`
     - Right: `vim_mode_indicator`, `pending_keystroke_indicator`, `cursor_position`, `active_toolchain_language`, `active_buffer_language`, `active_buffer_encoding`, `line_ending_indicator`
     - Note: Terminal+Debug panel buttons are already added during workspace construction (Unit 2), so they should appear at the far right after these items
-  - Remove creation of `search_button` and `image_info` variables if they become unused after removing their registration
+  - Remove creation of `image_info` variable after removing its registration
   - Verify right-side ordering: items are rendered in reverse order by `StatusItemStrip` (line 62 of status_bar.rs), so registration order must be reversed from desired display order. The desired display is: `[Vim][Keys][Cursor][Toolchain][Lang][Encoding][LineEnding][Terminal][Debug]`. Since Terminal+Debug are added first during construction, the remaining items added in zed.rs should be added in reverse display order: `line_ending_indicator`, `active_buffer_encoding`, `active_buffer_language`, `active_toolchain_language`, `cursor_position`, `pending_keystroke_indicator`, `vim_mode_indicator`
 
   **Patterns to follow:**
@@ -220,7 +220,7 @@ Superzent maintains two structurally near-identical bottom bars — `CenterPaneF
   **Verification:**
 
   - No `center_pane_footer()` calls remain in zed.rs
-  - `search_button` and `image_info` variables are removed
+  - `image_info` variable is removed
   - Visual inspection confirms item ordering matches the spec
 
 - [ ] **Unit 5: Update settings default and tests**

--- a/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
+++ b/docs/plans/2026-04-15-001-refactor-center-pane-footer-statusbar-merge-plan.md
@@ -1,0 +1,256 @@
+---
+title: "refactor: Merge CenterPaneFooter into StatusBar"
+type: refactor
+status: active
+date: 2026-04-15
+origin: docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md
+---
+
+# Merge CenterPaneFooter into StatusBar
+
+## Overview
+
+Remove the `CenterPaneFooter` component and consolidate all bottom-bar functionality into the existing `StatusBar`. Reposition `StatusBar` from the window bottom edge to the center pane footer position (between left and right docks). This reduces upstream divergence while preserving Superzent's desired item composition and layout.
+
+## Problem Frame
+
+Superzent maintains two structurally near-identical bottom bars — `CenterPaneFooter` (visible, positioned between docks) and `StatusBar` (hidden by default, full window width). Both wrap the same `StatusItemStrip` infrastructure. The CenterPaneFooter exists solely because Superzent wanted a different item set and position than the upstream StatusBar. Maintaining two components increases merge friction with Zed upstream and duplicates active-pane tracking, item registration, and rendering logic. (see origin: `docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md`)
+
+## Requirements Trace
+
+- R1. Remove `CenterPaneFooter` as a separate component
+- R2. Position `StatusBar` in the center pane footer location (between docks)
+- R3. `StatusBar` visible by default (`show: true`), setting still controls visibility
+- R4. Item composition: Left (Edit Prediction, LSP, Diagnostics, Activity Indicator) / Right (Vim Mode, Pending Keystroke, Cursor Position, Active Toolchain, Buffer Language, Buffer Encoding, Line Endings, Terminal+Debug panel buttons)
+- R5. Remove: Left/Right dock panel toggle buttons, Search button, Image Info
+- R6. Visual style follows existing StatusBar render style, adapted for center-pane width
+- R7. Window decoration handling adjusted for non-window-bottom position
+
+## Scope Boundaries
+
+- No changes to `StatusItemView` trait or `StatusItemStrip` internals
+- No new items or indicators
+- Left/Right dock panel toggle buttons are not relocated — accessible via shortcuts and menus
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/workspace/src/status_bar.rs` — `StatusBar` (line 147) and `CenterPaneFooter` (line 153) are thin wrappers around `StatusItemStrip`. CenterPaneFooter has `has_items()` (line 296) that StatusBar lacks. StatusBar has `item_of_type`, `position_of_item`, `insert_item_after`, `remove_item_at` that CenterPaneFooter lacks.
+- `crates/workspace/src/workspace.rs` — Construction at lines 1639-1657, fields at 1312-1313, accessors at 2192-2213, active pane sync at 4794-4807, layout rendering across 4 `BottomDockLayout` variants (7850-8012), footer helpers at 7102-7136.
+- `crates/zed/src/zed.rs` lines 530-548 — Single external mutation point for both bars.
+- `CENTER_PANE_FOOTER_BOTTOM_PANELS` constant (workspace.rs line 176) — splits Terminal/Debug buttons to footer, rest to StatusBar.
+- `assets/settings/default.json` line 1637 — `"experimental.show": false`.
+
+### Institutional Learnings
+
+- The footer vs status bar distinction is a discoverability decision. When consolidating, items must land on the surface the shell actually renders (docs/solutions: `default-build-next-edit-surface-restoration`).
+- `#[cfg(feature = "next_edit")]` gates Edit Prediction Button — must be preserved after consolidation.
+
+## Key Technical Decisions
+
+- **StatusBar render style**: Use `CenterPaneFooter`'s current style (top border, `panel_background`) rather than StatusBar's current style (`status_bar_background`, no top border) since the bar is now inside the pane area, not at the window edge. This matches the visual expectation and avoids the window decoration rounding question entirely.
+- **Remove `workspace_sidebar_open` from StatusBar**: This field only controlled bottom-left corner rounding for client-side window decorations at the window bottom edge. Since the bar moves away from the window edge, this field and its propagation chain become dead code.
+- **Keep `has_items()` as belt-and-suspenders**: Add `has_items()` to StatusBar even though it will always have items. The check is cheap and prevents rendering an empty bar if item registration changes in the future.
+- **Rename `CENTER_PANE_FOOTER_BOTTOM_PANELS` to `STATUS_BAR_BOTTOM_PANELS`**: The constant still serves the same purpose (identifying which bottom dock panels get toggle buttons in the bar) but the old name references a component that no longer exists.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Should the bar use `status_bar_background` or `panel_background`?** Resolution: Use `panel_background` with top border, matching the current CenterPaneFooter visual. The bar sits inside the pane area, not at the window edge.
+- **Q: What happens to `which_key` modal positioning?** Resolution: `which_key_modal.rs` line 152 checks `status_bar_visible()` to add bottom padding. This still works correctly — it will now always account for the bar since `show` defaults to `true`.
+
+### Deferred to Implementation
+
+- Exact layout adjustments if any `BottomDockLayout` variant positions the center pane footer in a surprising way after testing.
+
+## Implementation Units
+
+- [ ] **Unit 1: Prepare StatusBar to absorb CenterPaneFooter's role**
+
+  **Goal:** Add missing capabilities to StatusBar and update its render style to match the center-pane-footer position.
+
+  **Requirements:** R1, R6, R7
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `crates/workspace/src/status_bar.rs`
+
+  **Approach:**
+  - Add `has_items() -> bool` method to StatusBar (delegate to `self.items.has_items()`)
+  - Remove `workspace_sidebar_open` field and `set_workspace_sidebar_open()` method from StatusBar
+  - Change StatusBar's `Render` impl to match CenterPaneFooter's style: top border (`border_t_1`), `panel_background` background, remove all client-side window decoration rounding logic
+  - Delete the entire `CenterPaneFooter` struct, its `Render` impl, and its `impl` block
+
+  **Patterns to follow:**
+  - CenterPaneFooter's `Render` impl (status_bar.rs lines 187-200) is the target style
+  - CenterPaneFooter's `has_items()` (line 296) is the pattern to port
+
+  **Test scenarios:**
+  - Happy path: StatusBar renders with top border and `panel_background` when items are present
+  - Happy path: `has_items()` returns true when items are added, false when empty
+  - Edge case: StatusBar with no items renders nothing (or empty bar) — verify `has_items()` returns false
+
+  **Verification:**
+  - `CenterPaneFooter` type no longer exists in the codebase
+  - StatusBar compiles with new render style and `has_items()` method
+
+- [ ] **Unit 2: Consolidate workspace construction and field management**
+
+  **Goal:** Remove all CenterPaneFooter references from Workspace struct and consolidate PanelButtons setup.
+
+  **Requirements:** R1, R4, R5
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `crates/workspace/src/workspace.rs`
+
+  **Approach:**
+  - Remove `center_pane_footer: Entity<CenterPaneFooter>` field from Workspace struct
+  - Remove `center_pane_footer()` accessor and `center_pane_footer_visible()` method
+  - Remove `CenterPaneFooter` from the `use status_bar::{...}` import
+  - In construction (lines 1638-1657): remove `center_pane_footer_bottom_dock_buttons` creation. Change `status_bar_bottom_dock_buttons` to use `PanelButtons::new_only` (was `new_except`) with `STATUS_BAR_BOTTOM_PANELS` — now the StatusBar gets *only* Terminal+Debug buttons instead of *everything except* them
+  - Remove `left_dock_buttons` and `right_dock_buttons` creation and their `add_left_item`/`add_right_item` calls on StatusBar (R5: removing left/right dock panel toggle buttons)
+  - Remove `center_pane_footer` from struct initialization
+  - In `set_status_item_active_pane()` (line 4794): remove the `center_pane_footer.update()` call, keep only the `status_bar.update()` call
+  - Remove `set_workspace_sidebar_open()` method from Workspace (dead code after Unit 1 removed the StatusBar field)
+  - Rename `CENTER_PANE_FOOTER_BOTTOM_PANELS` to `STATUS_BAR_BOTTOM_PANELS`
+
+  **Patterns to follow:**
+  - Existing StatusBar construction pattern (lines 1651-1656)
+
+  **Test scenarios:**
+  - Happy path: Workspace initializes successfully with only StatusBar, no CenterPaneFooter
+  - Happy path: Active pane changes propagate to StatusBar items
+  - Integration: Terminal and Debug panel buttons appear in StatusBar's right items
+
+  **Verification:**
+  - No references to `CenterPaneFooter` or `center_pane_footer` remain in workspace.rs
+  - No references to `left_dock_buttons` or `right_dock_buttons` PanelButtons remain
+  - Project compiles
+
+- [ ] **Unit 3: Reposition StatusBar rendering in workspace layout**
+
+  **Goal:** Move StatusBar from the window bottom edge to the center pane footer position, respecting all four `BottomDockLayout` variants.
+
+  **Requirements:** R2
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `crates/workspace/src/workspace.rs`
+
+  **Approach:**
+  - Remove the old StatusBar rendering at the window bottom (lines 8039-8041)
+  - Replace every `center_pane_footer_visible(cx)` / `center_pane_footer.clone()` occurrence in the four `BottomDockLayout` branches with `status_bar_visible(cx)` / `status_bar.clone()`
+  - In `render_center_pane_footer_row()` and `render_center_pane_footer_with_left_offset()`: replace `self.center_pane_footer.clone()` with `self.status_bar.clone()`. Consider renaming these methods to `render_status_bar_row()` and `render_status_bar_with_left_offset()` for clarity.
+  - The four layout variants are:
+    - **Contained**: footer rendered inside center column with no left offset — use `status_bar_visible(cx)` check, render `status_bar`
+    - **LeftAligned**: footer rendered inside left column with left dock width offset — same approach
+    - **Full**: footer rendered as separate row after main content with dock-width spacers — same approach
+    - **RightAligned**: footer rendered as separate row after main content with dock-width spacers — same approach
+
+  **Patterns to follow:**
+  - The existing four-variant layout rendering pattern (lines 7850-8012) — same structure, just swapping the entity reference and visibility check
+
+  **Test scenarios:**
+  - Happy path: StatusBar renders in center pane footer position with `BottomDockLayout::Contained`
+  - Happy path: StatusBar respects dock widths in `Full` and `RightAligned` layouts (dock-width spacers present)
+  - Happy path: StatusBar respects left dock width in `LeftAligned` layout
+  - Edge case: `status_bar.show = false` hides the bar in all four layout variants
+  - Integration: `which_key` modal still adds bottom padding when StatusBar is visible
+
+  **Verification:**
+  - StatusBar no longer renders at window bottom edge
+  - StatusBar renders between docks in all four layout variants
+  - Visual inspection confirms correct positioning
+
+- [ ] **Unit 4: Consolidate item registration**
+
+  **Goal:** Merge all status item registrations into a single `status_bar().update()` call with the correct item composition and ordering.
+
+  **Requirements:** R4, R5
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `crates/zed/src/zed.rs`
+
+  **Approach:**
+  - Remove the `center_pane_footer().update()` call (lines 530-538)
+  - Replace the `status_bar().update()` call (lines 540-548) with a single call registering all items in order:
+    - Left: `edit_prediction_ui` (cfg-gated with `#[cfg(feature = "next_edit")]`), `lsp_button`, `diagnostic_summary`, `activity_indicator`
+    - Right: `vim_mode_indicator`, `pending_keystroke_indicator`, `cursor_position`, `active_toolchain_language`, `active_buffer_language`, `active_buffer_encoding`, `line_ending_indicator`
+    - Note: Terminal+Debug panel buttons are already added during workspace construction (Unit 2), so they should appear at the far right after these items
+  - Remove creation of `search_button` and `image_info` variables if they become unused after removing their registration
+  - Verify right-side ordering: items are rendered in reverse order by `StatusItemStrip` (line 62 of status_bar.rs), so registration order must be reversed from desired display order. The desired display is: `[Vim][Keys][Cursor][Toolchain][Lang][Encoding][LineEnding][Terminal][Debug]`. Since Terminal+Debug are added first during construction, the remaining items added in zed.rs should be added in reverse display order: `line_ending_indicator`, `active_buffer_encoding`, `active_buffer_language`, `active_toolchain_language`, `cursor_position`, `pending_keystroke_indicator`, `vim_mode_indicator`
+
+  **Patterns to follow:**
+  - Current registration pattern in zed.rs (lines 530-548)
+  - `StatusItemStrip::render_right_tools()` reverses item order (status_bar.rs line 62)
+
+  **Test scenarios:**
+  - Happy path: All 11 items render in correct left/right positions
+  - Happy path: Terminal+Debug panel buttons appear at the far right
+  - Happy path: Edit Prediction Button only appears when `next_edit` feature is enabled
+  - Integration: Items respond to active pane changes (cursor position updates, language changes, etc.)
+
+  **Verification:**
+  - No `center_pane_footer()` calls remain in zed.rs
+  - `search_button` and `image_info` variables are removed
+  - Visual inspection confirms item ordering matches the spec
+
+- [ ] **Unit 5: Update settings default and tests**
+
+  **Goal:** Change StatusBar default visibility to `true` and update tests to match.
+
+  **Requirements:** R3, S5, S6
+
+  **Dependencies:** Units 1-4
+
+  **Files:**
+  - Modify: `assets/settings/default.json`
+  - Modify: `crates/workspace/src/workspace.rs` (test at line 13498)
+
+  **Approach:**
+  - In `assets/settings/default.json` line 1637: change `"experimental.show": false` to `"experimental.show": true`
+  - In `test_status_bar_visibility` (workspace.rs line 13498): flip the first assertion from `assert!(!visible, "Status bar should be hidden by default")` to `assert!(visible, "Status bar should be visible by default")`
+  - Update the test's comment `"Superzent hides the status bar by default"` to reflect the new default
+
+  **Patterns to follow:**
+  - Existing test structure at workspace.rs lines 13498-13535
+
+  **Test scenarios:**
+  - Happy path: `status_bar_visible()` returns `true` by default
+  - Happy path: Setting `show: false` hides the bar
+  - Happy path: Setting `show: true` shows the bar (no change from current)
+
+  **Verification:**
+  - `test_status_bar_visibility` passes with updated assertions
+  - `./script/clippy` passes
+
+## System-Wide Impact
+
+- **Interaction graph:** `MultiWorkspace` currently propagates sidebar state to `Workspace::set_workspace_sidebar_open()` → `StatusBar::set_workspace_sidebar_open()`. After removing this chain, verify `MultiWorkspace` callers compile (they will get a compile error pointing to the removed method, which is the desired signal).
+- **Error propagation:** No error paths affected — this is a pure UI restructuring.
+- **State lifecycle risks:** None — both bars already share the same active-pane subscription pattern.
+- **API surface parity:** `workspace.center_pane_footer()` accessor is removed. The only external caller is `zed.rs`, which will be updated in Unit 4.
+- **Integration coverage:** The `which_key` modal (line 152) uses `status_bar_visible()` for positioning. Since `show` now defaults to `true`, the modal will consistently add bottom padding. The `vim_test_context` (line 137) and `go_to_line` tests (lines 499-727) add items to `status_bar()` — these continue to work since StatusBar remains.
+- **Unchanged invariants:** `StatusItemView` trait, `StatusItemStrip` internals, and all individual status item components are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Right-item ordering is reversed by `StatusItemStrip` — easy to get display order wrong | Carefully trace `render_right_tools()` reversal logic; verify visually after implementation |
+| `set_workspace_sidebar_open` removal may break callers in `MultiWorkspace` | Compile errors will surface immediately; search for all callers before removing |
+| `BottomDockLayout::Full` and `RightAligned` variants have distinct footer placement | Test all four variants manually or with layout tests |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md](docs/brainstorms/2026-04-15-center-pane-footer-statusbar-merge-requirements.md)
+- Related code: `crates/workspace/src/status_bar.rs`, `crates/workspace/src/workspace.rs`, `crates/zed/src/zed.rs`
+- Institutional learning: `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`


### PR DESCRIPTION
## Summary

Superzent maintained two structurally identical bottom bars: `CenterPaneFooter` (visible, between docks) and `StatusBar` (hidden, full window width). Both wrapped the same `StatusItemStrip` infrastructure. This PR removes `CenterPaneFooter` and consolidates everything into `StatusBar`, repositioned to the center pane footer location.

Net result: 181 lines deleted, one fewer Superzent-specific component to maintain, and less merge friction with Zed upstream.

## Changes

- **StatusBar absorbs CenterPaneFooter's role**: Adopted its render style (`panel_background`, top border), removed window-decoration rounding logic that no longer applies
- **Repositioned StatusBar**: Moved from the window bottom edge to the center pane footer position (between left and right docks) across all four `BottomDockLayout` variants
- **Consolidated item registration**: Merged two separate item registration calls into one, with correct reverse-order semantics for right-side items
- **Removed unused items**: Left/right dock toggle buttons, search button, and image info are no longer registered in the bar
- **Default visibility changed to `true`**: StatusBar is now shown by default, controlled by the existing `status_bar.show` setting

Release Notes:

- Improved status bar by consolidating it into a single component positioned between the editor docks

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)