### PR TITLE
Publish macOS arm64 remote server artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
         name: superzent-aarch64.dmg
         path: target/aarch64-apple-darwin/release/superzent-aarch64.dmg
         if-no-files-found: error
+    - name: '@actions/upload-artifact superzent-remote-server-macos-aarch64.gz'
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: superzent-remote-server-macos-aarch64.gz
+        path: target/superzent-remote-server-macos-aarch64.gz
+        if-no-files-found: error
     timeout-minutes: 360
   bundle_linux_remote_server_stable_x86_64:
     needs:
@@ -187,6 +193,7 @@ jobs:
       run: |
         mkdir -p release-artifacts
         cp "./artifacts/superzent-aarch64.dmg/superzent-aarch64.dmg" "release-artifacts/superzent-aarch64.dmg"
+        cp "./artifacts/superzent-remote-server-macos-aarch64.gz/superzent-remote-server-macos-aarch64.gz" "release-artifacts/superzent-remote-server-macos-aarch64.gz"
         cp "./artifacts/superzent-remote-server-linux-x86_64.gz/superzent-remote-server-linux-x86_64.gz" "release-artifacts/superzent-remote-server-linux-x86_64.gz"
         cp "./artifacts/superzent-remote-server-linux-aarch64.gz/superzent-remote-server-linux-aarch64.gz" "release-artifacts/superzent-remote-server-linux-aarch64.gz"
         shasum -a 256 "release-artifacts/superzent-aarch64.dmg" > "release-artifacts/sha256sums.txt"

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -9,6 +9,7 @@ use crate::tasks::workflows::{
 };
 
 const RELEASE_ARTIFACT: &str = "superzent-aarch64.dmg";
+const REMOTE_SERVER_MACOS_AARCH64_ARTIFACT: &str = assets::REMOTE_SERVER_MACOS_AARCH64;
 const REMOTE_SERVER_LINUX_AARCH64_ARTIFACT: &str = assets::REMOTE_SERVER_LINUX_AARCH64;
 const REMOTE_SERVER_LINUX_X86_64_ARTIFACT: &str = assets::REMOTE_SERVER_LINUX_X86_64;
 const CHECKSUM_ARTIFACT: &str = "sha256sums.txt";
@@ -124,8 +125,14 @@ fn bundle_mac_stable(validate_release_tag: &NamedJob, valid_release_tag: &JobOut
             .add_step(steps::setup_node())
             .add_step(steps::clear_target_dir_if_large(Platform::Mac))
             .add_step(named::bash("./script/bundle-mac aarch64-apple-darwin"))
+            // Unlike upstream Zed, Superzent currently only publishes the macOS aarch64 bundle.
+            // Keep the matching Darwin arm64 remote-server archive on the same job so SSH remoting
+            // can fetch a prebuilt binary for Apple Silicon hosts from the release assets.
             .add_step(upload_artifact(&format!(
                 "target/aarch64-apple-darwin/release/{RELEASE_ARTIFACT}"
+            )))
+            .add_step(upload_artifact(&format!(
+                "target/{REMOTE_SERVER_MACOS_AARCH64_ARTIFACT}"
             ))),
     }
 }
@@ -196,6 +203,7 @@ fn publish_release(deps: &[&NamedJob], valid_release_tag: &JobOutput) -> NamedJo
         r#"
         mkdir -p release-artifacts
         cp "./artifacts/{release_artifact}/{release_artifact}" "release-artifacts/{release_artifact}"
+        cp "./artifacts/{remote_server_macos_aarch64_artifact}/{remote_server_macos_aarch64_artifact}" "release-artifacts/{remote_server_macos_aarch64_artifact}"
         cp "./artifacts/{remote_server_linux_x86_64_artifact}/{remote_server_linux_x86_64_artifact}" "release-artifacts/{remote_server_linux_x86_64_artifact}"
         cp "./artifacts/{remote_server_linux_aarch64_artifact}/{remote_server_linux_aarch64_artifact}" "release-artifacts/{remote_server_linux_aarch64_artifact}"
         shasum -a 256 "release-artifacts/{release_artifact}" > "release-artifacts/{checksum_artifact}"
@@ -213,6 +221,7 @@ fn publish_release(deps: &[&NamedJob], valid_release_tag: &JobOutput) -> NamedJo
           release-artifacts/*
         "#,
         release_artifact = RELEASE_ARTIFACT,
+        remote_server_macos_aarch64_artifact = REMOTE_SERVER_MACOS_AARCH64_ARTIFACT,
         remote_server_linux_x86_64_artifact = REMOTE_SERVER_LINUX_X86_64_ARTIFACT,
         remote_server_linux_aarch64_artifact = REMOTE_SERVER_LINUX_AARCH64_ARTIFACT,
         checksum_artifact = CHECKSUM_ARTIFACT,

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -347,6 +347,7 @@ impl serde::Serialize for WorkflowSecret {
 
 pub mod assets {
     pub const MAC_AARCH64: &str = "superzent-aarch64.dmg";
+    pub const REMOTE_SERVER_MACOS_AARCH64: &str = "superzent-remote-server-macos-aarch64.gz";
     pub const REMOTE_SERVER_LINUX_AARCH64: &str = "superzent-remote-server-linux-aarch64.gz";
     pub const REMOTE_SERVER_LINUX_X86_64: &str = "superzent-remote-server-linux-x86_64.gz";
 }


### PR DESCRIPTION
## Summary
Superzent already builds `superzent-remote-server-macos-aarch64.gz` during the macOS bundle step, but the release workflow never published that archive. That left SSH remoting on Apple Silicon macOS hosts without the matching prebuilt remote-server asset even though the build output already existed.

This change uploads the macOS arm64 remote-server archive from the macOS release job, includes it in the final release asset set, and leaves a short xtask comment explaining why this fork only keeps the Darwin arm64 remote-server artifact.

## Testing
- `cargo xtask workflows`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)

Release Notes:

- Improved SSH remoting release assets for macOS Apple Silicon hosts.