### PR TITLE
superzent_ui: Add workspace creation preset controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ crates/docs_preprocessor/actions.json
 # Local documentation audit files
 /december-2025-releases.md
 /docs/december-2025-documentation-gaps.md
+
+# Local context files
+.context/

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -3039,7 +3039,7 @@ impl NewWorkspaceModal {
             .items_center()
             .justify_between()
             .child(
-                Label::new(selected_label.clone())
+                Label::new(selected_label)
                     .size(LabelSize::Small)
                     .color(Color::Default),
             )

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -20,7 +20,7 @@ use editor::{Editor, EditorEvent, actions::SelectAll};
 use git::repository::validate_worktree_directory;
 use git_ui::git_panel::GitPanel;
 use gpui::{
-    Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, ClipboardItem,
+    Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, ClipboardItem, Corner,
     DismissEvent, Entity, EntityId, EventEmitter, FocusHandle, Focusable, MouseButton,
     MouseDownEvent, PathPromptOptions, Point, PromptLevel, ScrollHandle, SharedString,
     Subscription, Task, WeakEntity, WindowHandle, actions, anchored, deferred, px,
@@ -2122,55 +2122,57 @@ async fn create_remote_workspace(
             .read(cx)
             .workspace_for_location(&workspace_location)
             .cloned();
-        let now = Utc::now();
-
-        WorkspaceEntry {
-            id: existing_workspace
-                .as_ref()
-                .map(|workspace| workspace.id.clone())
-                .unwrap_or_else(|| Uuid::new_v4().to_string()),
-            project_id: project.id.clone(),
-            kind: WorkspaceKind::Worktree,
-            name: branch_name.clone(),
-            display_name: existing_workspace
-                .as_ref()
-                .and_then(|workspace| workspace.display_name.clone()),
-            branch: branch_name.clone(),
-            location: workspace_location,
-            agent_preset_id: existing_workspace
-                .as_ref()
-                .map(|workspace| workspace.agent_preset_id.clone())
-                .unwrap_or(preset_id),
-            managed: true,
-            git_status: WorkspaceGitStatus::Available,
-            git_summary: existing_workspace
-                .as_ref()
-                .and_then(|workspace| workspace.git_summary.clone()),
-            attention_status: existing_workspace
-                .as_ref()
-                .map(|workspace| workspace.attention_status.clone())
-                .unwrap_or(WorkspaceAttentionStatus::Idle),
-            review_pending: existing_workspace
-                .as_ref()
-                .is_some_and(|workspace| workspace.review_pending),
-            last_attention_reason: existing_workspace
-                .as_ref()
-                .and_then(|workspace| workspace.last_attention_reason.clone()),
-            teardown_script_override: existing_workspace
-                .as_ref()
-                .and_then(|workspace| workspace.teardown_script_override.clone()),
-            created_at: existing_workspace
-                .as_ref()
-                .map(|workspace| workspace.created_at)
-                .unwrap_or(now),
-            last_opened_at: now,
-        }
+        build_created_remote_workspace_entry(
+            &project,
+            &branch_name,
+            workspace_location,
+            existing_workspace.as_ref(),
+            &preset_id,
+        )
     })?;
 
     Ok(WorkspaceCreationResult {
         workspace,
         notice: None,
     })
+}
+
+fn build_created_remote_workspace_entry(
+    project: &ProjectEntry,
+    branch_name: &str,
+    workspace_location: WorkspaceLocation,
+    existing_workspace: Option<&WorkspaceEntry>,
+    preset_id: &str,
+) -> WorkspaceEntry {
+    let now = Utc::now();
+
+    WorkspaceEntry {
+        id: existing_workspace
+            .map(|workspace| workspace.id.clone())
+            .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        project_id: project.id.clone(),
+        kind: WorkspaceKind::Worktree,
+        name: branch_name.to_string(),
+        display_name: existing_workspace.and_then(|workspace| workspace.display_name.clone()),
+        branch: branch_name.to_string(),
+        location: workspace_location,
+        agent_preset_id: preset_id.to_string(),
+        managed: true,
+        git_status: WorkspaceGitStatus::Available,
+        git_summary: existing_workspace.and_then(|workspace| workspace.git_summary.clone()),
+        attention_status: existing_workspace
+            .map(|workspace| workspace.attention_status.clone())
+            .unwrap_or(WorkspaceAttentionStatus::Idle),
+        review_pending: existing_workspace.is_some_and(|workspace| workspace.review_pending),
+        last_attention_reason: existing_workspace
+            .and_then(|workspace| workspace.last_attention_reason.clone()),
+        teardown_script_override: existing_workspace
+            .and_then(|workspace| workspace.teardown_script_override.clone()),
+        created_at: existing_workspace
+            .map(|workspace| workspace.created_at)
+            .unwrap_or(now),
+        last_opened_at: now,
+    }
 }
 
 async fn resolve_opened_workspace(
@@ -2291,12 +2293,32 @@ enum DirtyWorkspaceCreateChoice {
     CreateAndMoveChanges,
 }
 
+fn preset_or_default<'a>(presets: &'a [AgentPreset], preset_id: &str) -> &'a AgentPreset {
+    presets
+        .iter()
+        .find(|preset| preset.id == preset_id)
+        .unwrap_or_else(|| {
+            presets
+                .first()
+                .expect("Superzent requires at least one agent preset")
+        })
+}
+
+fn should_launch_new_workspace_preset<E>(
+    auto_launch: bool,
+    setup_result: Option<&Result<(), E>>,
+) -> bool {
+    auto_launch && setup_result.is_none_or(|result| result.is_ok())
+}
+
 fn spawn_new_workspace_request(
     workspace_handle: Entity<Workspace>,
     app_state: Arc<WorkspaceAppState>,
     project: ProjectEntry,
     branch_name: String,
     base_branch_override: Option<String>,
+    preset_id: String,
+    auto_launch: bool,
     setup_script: Option<String>,
     teardown_script: Option<String>,
     save_lifecycle_defaults: superzent_git::WorkspaceLifecycleDefaultSaveSelections,
@@ -2304,7 +2326,6 @@ fn spawn_new_workspace_request(
     cx: &mut App,
 ) {
     let store = SuperzentStore::global(cx);
-    let preset_id = store.read(cx).default_preset().id.clone();
     let base_workspace_path = {
         let store = store.read(cx);
         local_base_workspace_path_for_create_request(&workspace_handle, &project, &store, cx)
@@ -2526,9 +2547,8 @@ fn spawn_new_workspace_request(
                 }
             }
 
-            let should_launch_preset = setup_result
-                .as_ref()
-                .is_none_or(|result| result.is_ok());
+            let should_launch_preset =
+                should_launch_new_workspace_preset(auto_launch, setup_result.as_ref());
 
             if should_launch_preset {
                 let target_workspace = if let Some(visible_workspace) = visible_workspace.clone() {
@@ -2794,6 +2814,8 @@ struct NewWorkspaceModal {
     project: ProjectEntry,
     branch_name_editor: Entity<Editor>,
     base_branch_editor: Entity<Editor>,
+    selected_preset_id: String,
+    auto_launch: bool,
     setup_script_editor: Entity<Editor>,
     teardown_script_editor: Entity<Editor>,
     show_more_options: bool,
@@ -2829,6 +2851,10 @@ impl NewWorkspaceModal {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let selected_preset_id = {
+            let store = SuperzentStore::global(cx);
+            store.read(cx).default_preset().id.clone()
+        };
         let branch_name_editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
             editor.set_placeholder_text("feature/my-branch", window, cx);
@@ -2942,6 +2968,8 @@ impl NewWorkspaceModal {
             project,
             branch_name_editor,
             base_branch_editor,
+            selected_preset_id,
+            auto_launch: false,
             setup_script_editor,
             teardown_script_editor,
             show_more_options: false,
@@ -2984,6 +3012,72 @@ impl NewWorkspaceModal {
         } else {
             Some(teardown_script.to_string())
         }
+    }
+
+    fn resolved_preset_id(&self, cx: &App) -> String {
+        let store = SuperzentStore::global(cx);
+        let store = store.read(cx);
+        preset_or_default(store.presets(), &self.selected_preset_id)
+            .id
+            .clone()
+    }
+
+    fn preset_dropdown_menu(&self, window: &mut Window, cx: &mut Context<Self>) -> DropdownMenu {
+        let weak = cx.weak_entity();
+        let store = SuperzentStore::global(cx);
+        let (selected_label, presets) = {
+            let store = store.read(cx);
+            (
+                preset_or_default(store.presets(), &self.selected_preset_id)
+                    .label
+                    .clone(),
+                store.presets().to_vec(),
+            )
+        };
+        let trigger = h_flex()
+            .w_full()
+            .items_center()
+            .justify_between()
+            .child(
+                Label::new(selected_label.clone())
+                    .size(LabelSize::Small)
+                    .color(Color::Default),
+            )
+            .child(
+                Icon::new(IconName::ChevronUpDown)
+                    .size(IconSize::XSmall)
+                    .color(Color::Muted),
+            )
+            .into_any_element();
+
+        DropdownMenu::new_with_element(
+            "superzent-new-workspace-preset",
+            trigger,
+            ContextMenu::build(window, cx, move |mut menu, _, _| {
+                for preset in &presets {
+                    let weak = weak.clone();
+                    let preset_id = preset.id.clone();
+                    let label = preset.label.clone();
+                    menu = menu.entry(label, None, move |_window, cx| {
+                        weak.update(cx, |this, cx| {
+                            this.selected_preset_id = preset_id.clone();
+                            cx.notify();
+                        })
+                        .ok();
+                    });
+                }
+
+                menu
+            }),
+        )
+        .style(DropdownStyle::Outlined)
+        .full_width(true)
+        .no_chevron()
+        .attach(Corner::BottomLeft)
+        .offset(Point {
+            x: px(0.0),
+            y: px(2.0),
+        })
     }
 
     fn insert_variable(&mut self, variable: &str, window: &mut Window, cx: &mut Context<Self>) {
@@ -3067,6 +3161,7 @@ impl NewWorkspaceModal {
         }
 
         let app_state = workspace_handle.read(cx).app_state().clone();
+        let preset_id = self.resolved_preset_id(cx);
 
         spawn_new_workspace_request(
             workspace_handle,
@@ -3074,6 +3169,8 @@ impl NewWorkspaceModal {
             self.project.clone(),
             branch_name,
             self.base_branch(cx),
+            preset_id,
+            self.auto_launch,
             self.setup_script(cx),
             self.teardown_script(cx),
             self.save_lifecycle_defaults,
@@ -3121,22 +3218,66 @@ impl Render for NewWorkspaceModal {
                                         this.child(
                                             v_flex()
                                                 .gap_1()
-                                                .child(Label::new("Base Branch").size(LabelSize::Small))
+                                                .child(
+                                                    Label::new("Base Branch")
+                                                        .size(LabelSize::Small),
+                                                )
                                                 .child(self.base_branch_editor.clone())
-                                                .when_some(self.base_branch_notice.clone(), |this, notice| {
-                                                    this.child(
-                                                        Label::new(notice)
-                                                            .size(LabelSize::Small)
-                                                            .color(Color::Warning),
-                                                    )
-                                                })
-                                                .when_some(self.base_branch_error.clone(), |this, error| {
-                                                    this.child(
-                                                        Label::new(error)
-                                                            .size(LabelSize::Small)
-                                                            .color(Color::Error),
-                                                    )
-                                                })
+                                                .when_some(
+                                                    self.base_branch_notice.clone(),
+                                                    |this, notice| {
+                                                        this.child(
+                                                            Label::new(notice)
+                                                                .size(LabelSize::Small)
+                                                                .color(Color::Warning),
+                                                        )
+                                                    },
+                                                )
+                                                .when_some(
+                                                    self.base_branch_error.clone(),
+                                                    |this, error| {
+                                                        this.child(
+                                                            Label::new(error)
+                                                                .size(LabelSize::Small)
+                                                                .color(Color::Error),
+                                                        )
+                                                    },
+                                                ),
+                                        )
+                                    },
+                                )
+                                .child(
+                                    v_flex()
+                                        .gap_2()
+                                        .child(
+                                            v_flex()
+                                                .gap_1()
+                                                .child(Label::new("Preset").size(LabelSize::Small))
+                                                .child(self.preset_dropdown_menu(window, cx)),
+                                        )
+                                        .child(
+                                            Checkbox::new(
+                                                "superzent-new-workspace-auto-launch",
+                                                self.auto_launch.into(),
+                                            )
+                                            .label("Auto-launch after creation")
+                                            .fill()
+                                            .elevation(ElevationIndex::Surface)
+                                            .label_size(LabelSize::Small)
+                                            .on_click(cx.listener(
+                                                |this, selection, _, cx| {
+                                                    this.auto_launch =
+                                                        *selection == ToggleState::Selected;
+                                                    cx.notify();
+                                                },
+                                            )),
+                                        ),
+                                )
+                                .when(
+                                    matches!(self.project.location, ProjectLocation::Local { .. }),
+                                    |this| {
+                                        this.child(
+                                            v_flex()
                                                 .child(
                                                     div()
                                                         .w_full()
@@ -8563,6 +8704,19 @@ mod tests {
     use git::status::StatusCode;
     use std::path::PathBuf;
 
+    fn preset(id: &str, label: &str) -> AgentPreset {
+        AgentPreset {
+            id: id.to_string(),
+            label: label.to_string(),
+            launch_mode: PresetLaunchMode::Terminal,
+            command: label.to_ascii_lowercase(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            acp_agent_name: None,
+            attention_patterns: Vec::new(),
+        }
+    }
+
     fn workspace_entry(kind: WorkspaceKind) -> WorkspaceEntry {
         WorkspaceEntry {
             id: "workspace".to_string(),
@@ -8821,6 +8975,81 @@ mod tests {
             retried.save_lifecycle_defaults,
             options.save_lifecycle_defaults
         );
+    }
+
+    #[test]
+    fn build_created_remote_workspace_entry_uses_requested_preset_when_reusing_workspace() {
+        let project = ProjectEntry {
+            id: "project".to_string(),
+            name: "Remote Project".to_string(),
+            location: ProjectLocation::Ssh {
+                connection: ssh_connection(),
+                repo_root: "/repo/main".to_string(),
+            },
+            collapsed: false,
+            created_at: Utc::now(),
+            last_opened_at: Utc::now(),
+        };
+        let existing_workspace =
+            ssh_workspace_entry("workspace-remote", "project", "/repo/worktrees/feature-a");
+        let existing_workspace_id = existing_workspace.id.clone();
+        let workspace_location = WorkspaceLocation::Ssh {
+            connection: ssh_connection(),
+            worktree_path: "/repo/worktrees/feature-a".to_string(),
+        };
+
+        let workspace_entry = build_created_remote_workspace_entry(
+            &project,
+            "feature-a",
+            workspace_location,
+            Some(&existing_workspace),
+            "claude-code",
+        );
+
+        assert_eq!(workspace_entry.id, existing_workspace_id);
+        assert_eq!(workspace_entry.agent_preset_id, "claude-code".to_string());
+    }
+
+    #[test]
+    fn preset_or_default_prefers_matching_preset() {
+        let presets = vec![preset("codex", "Codex"), preset("claude", "Claude Code")];
+
+        assert_eq!(
+            preset_or_default(&presets, "claude").label,
+            "Claude Code".to_string()
+        );
+    }
+
+    #[test]
+    fn preset_or_default_falls_back_to_first_preset() {
+        let presets = vec![preset("codex", "Codex"), preset("claude", "Claude Code")];
+
+        assert_eq!(
+            preset_or_default(&presets, "missing").id,
+            "codex".to_string()
+        );
+    }
+
+    #[test]
+    fn should_launch_new_workspace_preset_requires_opt_in() {
+        assert!(!should_launch_new_workspace_preset::<()>(false, None));
+        assert!(!should_launch_new_workspace_preset(
+            false,
+            Some(&Ok::<(), ()>(()))
+        ));
+    }
+
+    #[test]
+    fn should_launch_new_workspace_preset_preserves_setup_success_guard() {
+        assert!(should_launch_new_workspace_preset::<()>(true, None));
+        assert!(should_launch_new_workspace_preset(
+            true,
+            Some(&Ok::<(), anyhow::Error>(()))
+        ));
+        assert!(!should_launch_new_workspace_preset(
+            true,
+            Some(&Err(anyhow::anyhow!("setup failed")))
+        ));
     }
 
     #[test]

--- a/docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md
+++ b/docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md
@@ -1,0 +1,49 @@
+# Workspace Creation Preset Control
+
+**Date:** 2026-04-15
+**Status:** Draft
+
+## Problem
+
+When creating a new workspace, the assigned agent preset is automatically launched without any user opt-in. There is no UI in the creation modal to choose which preset to use or to disable auto-launch. This leads to unintended preset execution every time a workspace is created.
+
+## Goals
+
+- Give users explicit control over preset selection and auto-launch at workspace creation time.
+- Default to NOT auto-launching, so preset execution only happens when the user consciously opts in.
+
+## Non-Goals
+
+- Changing the preset auto-launch behavior for existing workspaces opened from the sidebar.
+- Adding a global setting for default auto-launch preference (can be explored later).
+
+## Requirements
+
+### R1: Preset Selector in Creation Modal
+
+Add a preset dropdown to `NewWorkspaceModal` that lets the user choose which agent preset to assign to the new workspace.
+
+- Default selection: the project's current default preset (from `store.default_preset()`).
+- Shows all available presets from the store.
+
+### R2: Auto-Launch Toggle
+
+Add a toggle/checkbox in `NewWorkspaceModal` to control whether the selected preset should be automatically launched after workspace creation.
+
+- **Default: OFF** — preset is assigned to the workspace but not launched.
+- When ON, the current `launch_workspace_preset` flow runs as it does today.
+- When OFF, the workspace is created with the preset assigned (via `agent_preset_id`) but `should_launch_preset` is skipped.
+
+### R3: Pass Launch Preference Through Creation Flow
+
+The user's auto-launch choice needs to flow from `NewWorkspaceModal.confirm()` through `spawn_new_workspace_request` to the point where `should_launch_preset` is evaluated.
+
+## UI Placement
+
+The preset selector and auto-launch toggle should appear in the creation modal below the branch/base-branch fields and above (or alongside) the existing "More Options" section for setup/teardown scripts.
+
+## Success Criteria
+
+- Creating a workspace with auto-launch OFF results in the workspace appearing in the sidebar with its preset assigned but no terminal/ACP session started.
+- Creating a workspace with auto-launch ON behaves identically to current behavior.
+- The preset dropdown correctly reflects available presets and the selection is persisted to the workspace entry.

--- a/docs/plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md
+++ b/docs/plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md
@@ -1,0 +1,209 @@
+---
+title: "feat: Add preset selection and auto-launch toggle to workspace creation"
+type: feat
+status: active
+date: 2026-04-15
+origin: docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md
+---
+
+# feat: Add preset selection and auto-launch toggle to workspace creation
+
+## Overview
+
+Add a preset dropdown and an auto-launch toggle to `NewWorkspaceModal` so users can choose which agent preset to assign and whether it should automatically start after workspace creation. Currently, the default preset always auto-launches — this change makes that behavior opt-in, defaulting to OFF.
+
+## Problem Frame
+
+When creating a managed workspace, `spawn_new_workspace_request` unconditionally fetches the default preset and launches it after workspace creation succeeds. There is no UI in `NewWorkspaceModal` to select a different preset or to suppress auto-launch. Users experience unintended agent sessions starting every time they create a workspace (see origin: `docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md`).
+
+## Requirements Trace
+
+- R1. Preset selector dropdown in the creation modal, defaulting to `store.default_preset()`, showing all available presets.
+- R2. Auto-launch toggle, default OFF. When OFF, the preset is assigned but not launched. When ON, the current `launch_workspace_preset` flow runs.
+- R3. The user's preset choice and auto-launch preference flow from `confirm()` through `spawn_new_workspace_request` to the `should_launch_preset` evaluation.
+
+## Scope Boundaries
+
+- Do not change auto-launch behavior for existing workspaces opened from the sidebar.
+- Do not add a global/persistent setting for auto-launch default preference.
+- Do not change the preset selector in the status bar / pane header area.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/superzent_ui/src/lib.rs`
+  - `NewWorkspaceModal` struct (line ~2792): currently has `branch_name_editor`, `base_branch_editor`, `setup_script_editor`, `teardown_script_editor`, `show_more_options`, `save_lifecycle_defaults`.
+  - `NewWorkspaceModal::confirm()` (line ~3048): calls `spawn_new_workspace_request` with fixed params — does not pass preset ID or launch preference.
+  - `spawn_new_workspace_request` (line ~2294): hardcodes `let preset_id = store.read(cx).default_preset().id.clone()` at line ~2307.
+  - `should_launch_preset` logic (line ~2529): `setup_result.as_ref().is_none_or(|result| result.is_ok())` — unconditionally launches on success.
+  - `launch_workspace_preset` (line ~1209): the actual launch function, dispatches based on `PresetLaunchMode::Terminal` or `PresetLaunchMode::Acp`.
+  - Existing checkbox pattern in the modal (line ~3193): `Checkbox::new(...)` with `.label()`, `.fill()`, `.elevation()`, `.label_size()`, `.on_click(cx.listener(...))`.
+  - Existing preset dropdown pattern (line ~1036): `render_hidden_preset_dropdown` uses `ContextMenu::build` with entries per preset, wrapped in `DropdownMenu::new`.
+- `crates/superzent_model/src/lib.rs`
+  - `AgentPreset` struct (line ~78): `id`, `label`, `launch_mode`, `command`, `args`, `env`, `acp_agent_name`, `attention_patterns`.
+  - `SuperzentStore::presets()` (line ~640): returns `&[AgentPreset]`.
+  - `SuperzentStore::default_preset()` (line ~644): returns first preset.
+
+### Institutional Learnings
+
+- From `2026-04-06` lifecycle config plan: keep UI presentation and lifecycle execution as separate contracts rather than blending them into one opaque creation path. This aligns with passing the user's choice explicitly rather than embedding launch logic in the creation flow.
+
+## Key Technical Decisions
+
+- **Add fields to `NewWorkspaceModal`, not new parameters to `CreateWorkspaceOptions`:** The preset selection and auto-launch toggle are UI-layer concerns. `superzent_git::CreateWorkspaceOptions` should remain unaware of agent presets.
+
+  - Rationale: preset launch is already handled after worktree creation in the UI layer. Keeping it there maintains the existing separation.
+
+- **Add `preset_id` and `auto_launch` parameters to `spawn_new_workspace_request`:** Instead of the function reading `store.default_preset()` internally, the caller passes the selected preset ID and launch preference.
+
+  - Rationale: makes the function's behavior explicit and testable. The modal's `confirm()` already collects all other user inputs and passes them through.
+
+- **Modify `should_launch_preset` to incorporate the user's choice:** The existing condition (`setup_result.is_none_or(Ok)`) remains as a prerequisite, AND-ed with the new `auto_launch` flag.
+
+  - Rationale: even with auto-launch ON, a failed setup should still suppress launch — preserving the existing safety behavior.
+
+- **Use `DropdownMenu` for preset selection, `Checkbox` for auto-launch:** Both patterns already exist in the modal and adjacent UI. No new component types needed.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to place the new UI elements?** After the base-branch field, before the "More Options" expandable section. This matches the natural "what workspace will look like" → "what happens after creation" flow.
+- **Should auto-launch toggle be inside "More Options"?** No — it should be always visible since it controls a behavior users frequently don't want. Hiding it defeats the purpose.
+
+### Deferred to Implementation
+
+- Exact styling details (spacing, label text) will be refined during implementation to match the existing modal visual rhythm.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add preset and auto-launch fields to NewWorkspaceModal**
+
+  **Goal:** Extend `NewWorkspaceModal` with state for tracking the selected preset and auto-launch preference.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** None
+
+  **Files:**
+
+  - Modify: `crates/superzent_ui/src/lib.rs` — `NewWorkspaceModal` struct, its constructor (`new` / initialization site)
+
+  **Approach:**
+
+  - Add `selected_preset_id: String` field, initialized from `store.default_preset().id` when the modal is created.
+  - Add `auto_launch: bool` field, initialized to `false`.
+  - Read the store to get the preset list in the constructor for initializing the default.
+
+  **Patterns to follow:**
+
+  - Existing field initialization pattern in `NewWorkspaceModal::new()` for `save_lifecycle_defaults`, `show_more_options`.
+
+  **Test expectation:** none — pure state scaffolding with no behavioral change.
+
+  **Verification:**
+
+  - Modal compiles and opens with the new fields initialized to their defaults.
+
+- [ ] **Unit 2: Render preset dropdown and auto-launch toggle in the modal**
+
+  **Goal:** Add the preset selector and auto-launch checkbox to the modal's `Render` implementation.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+
+  - Modify: `crates/superzent_ui/src/lib.rs` — `Render for NewWorkspaceModal`
+
+  **Approach:**
+
+  - After the base-branch editor section and before the "More Options" toggle, add:
+    1. A "Preset" label + `DropdownMenu` showing all presets from the store. Selecting a preset updates `self.selected_preset_id` and calls `cx.notify()`.
+    2. A `Checkbox` for "Auto-launch after creation" bound to `self.auto_launch`, using the same pattern as the existing "Save as repo default" checkboxes.
+  - The dropdown should display the currently selected preset's label as trigger text.
+  - Use `ContextMenu::build` with entries per preset, following the `render_hidden_preset_dropdown` pattern.
+
+  **Patterns to follow:**
+
+  - `Checkbox::new(...)` pattern at line ~3193 for the toggle.
+  - `render_hidden_preset_dropdown` at line ~1036 for the preset menu structure.
+  - `DropdownMenu::new_with_element` for the dropdown trigger.
+
+  **Test scenarios:**
+
+  - Happy path: modal renders with preset dropdown showing the default preset label and auto-launch checkbox unchecked.
+  - Happy path: clicking a different preset in the dropdown updates the displayed label.
+  - Happy path: toggling the auto-launch checkbox updates its visual state.
+
+  **Verification:**
+
+  - Modal visually shows the preset dropdown and auto-launch toggle in the correct position.
+  - Interacting with both controls updates the modal's internal state.
+
+- [ ] **Unit 3: Pass preset selection and auto-launch through the creation flow**
+
+  **Goal:** Wire the user's choices from `confirm()` through `spawn_new_workspace_request` to control preset assignment and launch behavior.
+
+  **Requirements:** R1, R2, R3
+
+  **Dependencies:** Unit 1, Unit 2
+
+  **Files:**
+
+  - Modify: `crates/superzent_ui/src/lib.rs` — `NewWorkspaceModal::confirm()`, `spawn_new_workspace_request`, and the `should_launch_preset` logic block
+
+  **Approach:**
+
+  - In `confirm()`: pass `self.selected_preset_id.clone()` and `self.auto_launch` to `spawn_new_workspace_request`.
+  - Add `preset_id: String` and `auto_launch: bool` parameters to `spawn_new_workspace_request`.
+  - Remove the internal `let preset_id = store.read(cx).default_preset().id.clone()` line — use the passed `preset_id` instead.
+  - Modify the `should_launch_preset` condition from:
+    ```
+    setup_result.as_ref().is_none_or(|result| result.is_ok())
+    ```
+    to:
+    ```
+    auto_launch && setup_result.as_ref().is_none_or(|result| result.is_ok())
+    ```
+  - The workspace entry is still created with `agent_preset_id` set to the user's selected preset, regardless of auto-launch.
+
+  **Patterns to follow:**
+
+  - Existing parameter threading pattern: `confirm()` already extracts `self.base_branch(cx)`, `self.setup_script(cx)`, etc. and passes them through.
+
+  **Test scenarios:**
+
+  - Happy path: creating workspace with auto-launch OFF → workspace appears in sidebar with correct preset assigned, no terminal/ACP session started.
+  - Happy path: creating workspace with auto-launch ON → workspace created and preset launches (identical to current behavior).
+  - Happy path: selecting a non-default preset → workspace created with that preset's ID in `agent_preset_id`.
+  - Edge case: auto-launch ON but setup script fails → preset should NOT launch (existing safety behavior preserved).
+
+  **Verification:**
+
+  - Creating a workspace with auto-launch OFF produces a workspace entry with the selected preset but no running agent session.
+  - Creating a workspace with auto-launch ON behaves identically to the current (pre-change) behavior.
+  - The selected preset ID is correctly stored in the workspace entry's `agent_preset_id`.
+
+## System-Wide Impact
+
+- **Interaction graph:** `NewWorkspaceModal.confirm()` → `spawn_new_workspace_request` → `should_launch_preset` → `launch_workspace_preset`. Only the parameter threading and condition check change; `launch_workspace_preset` itself is untouched.
+- **Error propagation:** No change — setup failure still suppresses launch regardless of auto-launch setting.
+- **State lifecycle risks:** None — `auto_launch` is a transient modal field, not persisted. `selected_preset_id` flows into the existing `agent_preset_id` persistence path.
+- **API surface parity:** Other callers of `spawn_new_workspace_request` (if any) will need the new parameters. Verify there are no other call sites, or update them to pass `(default_preset_id, true)` to preserve existing behavior.
+- **Unchanged invariants:** The sidebar preset selector, existing workspace preset launch behavior, and `launch_workspace_preset` function signature are all unchanged.
+
+## Risks & Dependencies
+
+| Risk                                                                           | Mitigation                                                                                            |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Other call sites of `spawn_new_workspace_request` break after signature change | Grep for all callers during Unit 3 and update them with backward-compatible defaults                  |
+| Preset list empty when modal opens                                             | `default_preset()` already panics if no presets exist — this is an existing invariant, not a new risk |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md](docs/brainstorms/2026-04-15-workspace-creation-preset-control-requirements.md)
+- Related code: `crates/superzent_ui/src/lib.rs` (NewWorkspaceModal, spawn_new_workspace_request)
+- Related code: `crates/superzent_model/src/lib.rs` (AgentPreset, SuperzentStore)

--- a/docs/plans/2026-04-16-001-fix-workspace-creation-review-findings-plan.md
+++ b/docs/plans/2026-04-16-001-fix-workspace-creation-review-findings-plan.md
@@ -1,0 +1,121 @@
+---
+title: "fix: Preserve selected preset when reusing SSH workspace entries"
+type: fix
+status: active
+date: 2026-04-16
+origin: docs/plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md
+---
+
+# fix: Preserve selected preset when reusing SSH workspace entries
+
+## Overview
+
+Fix the review finding from the workspace creation preset-control work: when SSH workspace creation reuses an existing `WorkspaceEntry` for the target location, the selected preset from `NewWorkspaceModal` can be overwritten by stale stored workspace metadata. The fix should keep the selected preset as the source of truth for the current create request and add regression coverage for the SSH reuse path.
+
+## Problem Frame
+
+The preset-control change correctly threads `preset_id` through `confirm()` and `spawn_new_workspace_request`, but `create_remote_workspace()` still rebuilds the returned `WorkspaceEntry` by preferring `existing_workspace.agent_preset_id` over the newly selected `preset_id`. That breaks the intended contract from the origin plan: the preset chosen in the creation modal should become the workspace's assigned preset even when auto-launch is OFF.
+
+## Requirements Trace
+
+- R1. SSH workspace creation must preserve the selected preset from the current create request, even when an existing workspace entry already exists for the target SSH location.
+- R2. The fix must not change the existing behavior for unrelated reused metadata such as `id`, `display_name`, `git_summary`, and `attention_status`.
+- R3. Add regression coverage proving the SSH reuse path keeps the new `preset_id` instead of stale stored preset state.
+
+## Scope Boundaries
+
+- Do not change local workspace creation behavior.
+- Do not change sidebar preset-launch behavior for existing workspaces.
+- Do not add broader end-to-end modal UI tests in this pass unless they are required to verify the SSH reuse fix.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/superzent_ui/src/lib.rs`
+  - `create_remote_workspace()` currently prefers `existing_workspace.agent_preset_id` when rebuilding the returned `WorkspaceEntry`.
+  - `build_synced_local_workspace_entry()`, `build_local_workspace_bundle()`, and `build_remote_workspace_bundle()` show the existing pattern of selectively reusing workspace metadata from stored entries.
+  - Existing test helpers `preset()`, `ssh_connection()`, and `ssh_workspace_entry()` can support a focused unit regression test in the same file.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/restore-field-level-managed-workspace-default-saves-2026-04-13.md`
+  - Create-time selections should be threaded explicitly through retries and async create flows rather than reconstructed from stored defaults later.
+- `docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md`
+  - Keep transient create-time UI choices separate from long-lived workspace persistence.
+
+## Key Technical Decisions
+
+- **Prefer the incoming `preset_id` over `existing_workspace.agent_preset_id` in the SSH create path.**
+
+  - Rationale: the current create request is the authoritative source for the workspace's assigned preset. Reused metadata should preserve identity and display state, but not override a fresh user choice.
+
+- **Extract or isolate the workspace-entry construction enough to unit test the preset merge rule directly.**
+  - Rationale: a focused unit test in `crates/superzent_ui/src/lib.rs` is cheaper and more stable than trying to stand up a full SSH create flow test, while still proving the regression is fixed.
+
+## Implementation Units
+
+- [x] **Unit 1: Fix SSH workspace preset reuse**
+
+  **Goal:** Ensure `create_remote_workspace()` keeps the selected `preset_id` when reusing an existing workspace entry for the same SSH location.
+
+  **Requirements:** R1, R2
+
+  **Files:**
+
+  - Modify: `crates/superzent_ui/src/lib.rs`
+
+  **Approach:**
+
+  - Update the `WorkspaceEntry` construction in the SSH create path so `agent_preset_id` comes from the incoming `preset_id`, not the reused workspace entry.
+  - Preserve reuse for the unrelated fields that intentionally carry over (`id`, `display_name`, `git_summary`, `attention_status`, `review_pending`, `last_attention_reason`, `teardown_script_override`, timestamps).
+
+  **Patterns to follow:**
+
+  - Existing merge pattern in `build_remote_workspace_bundle()` and `build_synced_local_workspace_entry()`, while explicitly overriding only the field that should be request-owned.
+
+  **Verification:**
+
+  - Code review of the reconstructed `WorkspaceEntry` shows only `agent_preset_id` behavior changes for reused SSH entries.
+
+- [x] **Unit 2: Add regression coverage for the SSH reuse path**
+
+  **Goal:** Lock down the selected-preset behavior with a focused test.
+
+  **Requirements:** R3
+
+  **Files:**
+
+  - Modify: `crates/superzent_ui/src/lib.rs` (test module)
+
+  **Test file paths:**
+
+  - `crates/superzent_ui/src/lib.rs`
+
+  **Approach:**
+
+  - Add a pure helper if needed to make the merge rule testable without constructing a full async SSH workspace flow.
+  - Add a test that starts with an existing SSH workspace entry whose `agent_preset_id` differs from the requested `preset_id`, then asserts the rebuilt/reused workspace entry uses the requested preset.
+  - Keep the test narrow: verify preset assignment while preserving representative reused metadata such as `id`.
+
+  **Test scenarios:**
+
+  - Happy path: reused SSH workspace entry with stale preset + new requested preset -> resulting workspace entry uses the new requested preset.
+  - Happy path: reused SSH workspace entry still preserves stable metadata like `id`.
+
+  **Verification:**
+
+  - `cargo test -p superzent_ui --lib`
+
+## Risks & Dependencies
+
+| Risk                                                                        | Mitigation                                                                        |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| The fix accidentally changes other reuse semantics beyond `agent_preset_id` | Keep the implementation narrow and verify preserved fields in the regression test |
+| The test is hard to write against the async SSH create flow                 | Extract a small pure helper and test the merge rule directly                      |
+
+## Sources & References
+
+- Origin plan: `docs/plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md`
+- Related solution: `docs/solutions/logic-errors/restore-field-level-managed-workspace-default-saves-2026-04-13.md`
+- Related solution: `docs/solutions/best-practices/managed-workspace-lifecycle-source-of-truth-and-teardown-override-contract-2026-04-10.md`

--- a/docs/solutions/logic-errors/preserve-selected-preset-when-reusing-ssh-workspace-entries-2026-04-16.md
+++ b/docs/solutions/logic-errors/preserve-selected-preset-when-reusing-ssh-workspace-entries-2026-04-16.md
@@ -1,0 +1,142 @@
+---
+title: Preserve selected preset when reusing SSH workspace entries
+date: 2026-04-16
+category: logic-errors
+module: managed workspace create flow
+problem_type: logic_error
+component: tooling
+symptoms:
+  - The SSH create flow could ignore the preset selected in `NewWorkspaceModal` when an existing `WorkspaceEntry` was reused for the target location
+  - The rebuilt remote workspace entry could carry forward a stale `agent_preset_id` from stored workspace state instead of the current request's `preset_id`
+  - The created workspace could end up assigned the wrong preset even though the modal and request plumbing passed the selected preset through correctly
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [managed-workspace, create-flow, ssh, preset, workspace-entry]
+---
+
+# Preserve selected preset when reusing SSH workspace entries
+
+## Problem
+
+A review of the workspace creation preset-control work found that SSH
+workspace creation could silently ignore the preset selected in
+`NewWorkspaceModal`. The request path threaded `preset_id` correctly
+through `confirm()` and `spawn_new_workspace_request`, but
+`create_remote_workspace()` rebuilt the returned `WorkspaceEntry` by
+preferring stale metadata from an existing workspace entry for the same
+SSH location.
+
+## Symptoms
+
+- Creating an SSH workspace for a location that already had a
+  `WorkspaceEntry` could keep the old `agent_preset_id` instead of the
+  preset the user just picked in the modal.
+- The create flow looked successful in the UI, but the resulting
+  workspace could still be assigned the wrong agent preset.
+- The bug only became visible when the SSH create path reused existing
+  workspace metadata, which made it easy to miss during the initial
+  feature work.
+
+## What Didn't Work
+
+- Threading `preset_id` through the modal and into
+  `spawn_new_workspace_request` was necessary, but it did not fix the
+  SSH reuse branch. `create_remote_workspace()` still reconstructed the
+  entry from `existing_workspace` and could overwrite the fresh request
+  with stale `agent_preset_id` (session history).
+
+```rust
+agent_preset_id: existing_workspace
+    .as_ref()
+    .map(|workspace| workspace.agent_preset_id.clone())
+    .unwrap_or(preset_id),
+```
+
+- Reviewing only the modal plumbing gave false confidence. The request
+  shape was correct, but the later SSH reconciliation step still
+  re-derived a request-owned field from stored state (session history).
+
+## Solution
+
+`crates/superzent_ui/src/lib.rs` now uses a dedicated helper,
+`build_created_remote_workspace_entry(...)`, to rebuild the SSH
+workspace entry while preserving identity and display metadata from any
+reused workspace, but always taking the preset from the current
+request.
+
+The critical change is that `agent_preset_id` now comes from the
+requested `preset_id`, not from `existing_workspace`:
+
+```rust
+// Before
+agent_preset_id: existing_workspace
+    .as_ref()
+    .map(|workspace| workspace.agent_preset_id.clone())
+    .unwrap_or(preset_id),
+
+// After
+agent_preset_id: preset_id.to_string(),
+```
+
+The helper is called from `create_remote_workspace()` like this:
+
+```rust
+build_created_remote_workspace_entry(
+    &project,
+    &branch_name,
+    workspace_location,
+    existing_workspace.as_ref(),
+    &preset_id,
+)
+```
+
+A regression test,
+`build_created_remote_workspace_entry_uses_requested_preset_when_reusing_workspace`,
+verifies the reuse case directly. It constructs an existing SSH
+workspace entry with one preset, calls the helper with a different
+requested preset, and asserts that the resulting entry keeps the
+existing workspace identity while using the new preset:
+
+```rust
+let workspace_entry = build_created_remote_workspace_entry(
+    &project,
+    "feature-a",
+    workspace_location,
+    Some(&existing_workspace),
+    "claude-code",
+);
+
+assert_eq!(workspace_entry.id, existing_workspace_id);
+assert_eq!(workspace_entry.agent_preset_id, "claude-code".to_string());
+```
+
+## Why This Works
+
+The create request is now the source of truth for `agent_preset_id`.
+The helper still reuses durable metadata from the existing SSH workspace
+entry, but it stops treating the old preset as reusable state. That
+keeps workspace identity reuse intact without overriding the user's
+current selection.
+
+## Prevention
+
+- For create flows that can reuse existing objects, treat request-owned
+  fields as authoritative and reuse stored state only for identity or
+  durable metadata.
+- Keep a focused regression test around the reuse merge rule. If the SSH
+  path starts preferring stale workspace state again,
+  `build_created_remote_workspace_entry_uses_requested_preset_when_reusing_workspace`
+  should fail immediately.
+- There is still no full end-to-end SSH create-flow test covering modal
+  state through async creation and open. That remains a useful future
+  hardening step, but the helper-level regression test is the minimum
+  guardrail for this bug.
+
+## Related Issues
+
+- [docs/plans/2026-04-16-001-fix-workspace-creation-review-findings-plan.md](../../plans/2026-04-16-001-fix-workspace-creation-review-findings-plan.md)
+- [docs/plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md](../../plans/2026-04-15-001-feat-workspace-creation-preset-control-plan.md)
+- [restore-field-level-managed-workspace-default-saves-2026-04-13.md](./restore-field-level-managed-workspace-default-saves-2026-04-13.md)
+- [managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md](../ui-bugs/managed-workspace-create-progress-toasts-can-fail-to-appear-after-local-open-2026-04-12.md)
+- Verified with `cargo test -p superzent_ui --lib`


### PR DESCRIPTION
## Summary
Workspace creation now lets you choose an agent preset and keep auto-launch off by default. That choice is carried through both local and SSH creation paths, and the SSH reuse branch no longer falls back to stale preset metadata.

## What Changed
- added a preset dropdown and default-OFF auto-launch checkbox to `NewWorkspaceModal`
- threaded `preset_id` and `auto_launch` through `spawn_new_workspace_request` so launch only happens when opted in and setup succeeds
- fixed `create_remote_workspace()` to preserve the requested preset when reusing an existing SSH workspace entry
- added focused regression coverage for the SSH reuse path and documented the follow-up learning in `docs/solutions/`

## Testing
- `cargo test -p superzent_ui --lib`

Release Notes:

- Added preset selection and opt-in auto-launch for workspace creation, and fixed SSH workspace reuse to preserve the selected preset.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.4](https://img.shields.io/badge/GPT_5.4-000000?logoColor=white)