### PR TITLE
Backport Zed 1.0 next-edit and ACP polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "action_log",
  "agent-client-protocol",
  "anyhow",
+ "async-pipe",
  "async-trait",
  "chrono",
  "client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "smol",
  "theme",
  "ui",
  "util",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -780,9 +780,14 @@
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "alt-k": "editor::AcceptNextWordEditPrediction",
       "alt-j": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -853,9 +853,14 @@
     "context": "Editor && edit_prediction",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "ctrl-cmd-right": "editor::AcceptNextWordEditPrediction",
       "ctrl-cmd-down": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -776,9 +776,15 @@
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "tab": "editor::AcceptEditPrediction",
       "alt-k": "editor::AcceptNextWordEditPrediction",
       "alt-j": "editor::AcceptNextLineEditPrediction",
+    },
+  },
+  {
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": "editor::AcceptEditPrediction",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1068,7 +1068,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && edit_prediction_mode == eager",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.

--- a/crates/acp_tools/Cargo.toml
+++ b/crates/acp_tools/Cargo.toml
@@ -22,6 +22,7 @@ markdown.workspace = true
 project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+smol.workspace = true
 settings.workspace = true
 theme.workspace = true
 ui.workspace = true

--- a/crates/acp_tools/src/acp_tools.rs
+++ b/crates/acp_tools/src/acp_tools.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     fmt::Display,
     rc::{Rc, Weak},
     sync::Arc,
@@ -25,6 +25,8 @@ use workspace::{
 
 actions!(dev, [OpenAcpLogs]);
 
+const MAX_BACKLOG_MESSAGES: usize = 2000;
+
 pub fn init(cx: &mut App) {
     cx.observe_new(
         |workspace: &mut Workspace, _window, _cx: &mut Context<Workspace>| {
@@ -45,6 +47,9 @@ impl Global for GlobalAcpConnectionRegistry {}
 #[derive(Default)]
 pub struct AcpConnectionRegistry {
     active_connection: RefCell<Option<ActiveConnection>>,
+    backlog: RefCell<VecDeque<acp::StreamMessage>>,
+    subscribers: RefCell<Vec<smol::channel::Sender<acp::StreamMessage>>>,
+    _capture_task: RefCell<Option<Task<()>>>,
 }
 
 struct ActiveConnection {
@@ -73,7 +78,47 @@ impl AcpConnectionRegistry {
             agent_id,
             connection: Rc::downgrade(connection),
         }));
+        self.backlog.borrow_mut().clear();
+        self.subscribers.borrow_mut().clear();
+
+        let mut receiver = connection.subscribe();
+        self._capture_task
+            .replace(Some(cx.spawn(async move |this, cx| {
+                while let Ok(message) = receiver.recv().await {
+                    this.update(cx, |this, _cx| {
+                        this.record_stream_message(message);
+                    })
+                    .ok();
+                }
+            })));
         cx.notify();
+    }
+
+    fn record_stream_message(&self, message: acp::StreamMessage) {
+        let mut backlog = self.backlog.borrow_mut();
+        if backlog.len() == MAX_BACKLOG_MESSAGES {
+            backlog.pop_front();
+        }
+        backlog.push_back(message.clone());
+        drop(backlog);
+
+        let mut subscribers = self.subscribers.borrow_mut();
+        subscribers.retain(|subscriber| !subscriber.is_closed());
+        for subscriber in subscribers.iter() {
+            subscriber.try_send(message.clone()).log_err();
+        }
+    }
+
+    fn subscribe(
+        &self,
+    ) -> (
+        Vec<acp::StreamMessage>,
+        smol::channel::Receiver<acp::StreamMessage>,
+    ) {
+        let backlog = self.backlog.borrow().iter().cloned().collect();
+        let (sender, receiver) = smol::channel::unbounded();
+        self.subscribers.borrow_mut().push(sender);
+        (backlog, receiver)
     }
 }
 
@@ -118,22 +163,34 @@ impl AcpTools {
     }
 
     fn update_connection(&mut self, cx: &mut Context<Self>) {
-        let active_connection = self.connection_registry.read(cx).active_connection.borrow();
-        let Some(active_connection) = active_connection.as_ref() else {
+        let Some((agent_id, connection_weak)) =
+            self.connection_registry.read_with(cx, |registry, _| {
+                registry
+                    .active_connection
+                    .borrow()
+                    .as_ref()
+                    .map(|active_connection| {
+                        (
+                            active_connection.agent_id.clone(),
+                            active_connection.connection.clone(),
+                        )
+                    })
+            })
+        else {
+            self.watched_connection = None;
             return;
         };
 
         if let Some(watched_connection) = self.watched_connection.as_ref() {
-            if Weak::ptr_eq(
-                &watched_connection.connection,
-                &active_connection.connection,
-            ) {
+            if Weak::ptr_eq(&watched_connection.connection, &connection_weak) {
                 return;
             }
         }
 
-        if let Some(connection) = active_connection.connection.upgrade() {
-            let mut receiver = connection.subscribe();
+        if connection_weak.upgrade().is_some() {
+            let (backlog, receiver) = self
+                .connection_registry
+                .update(cx, |registry, _| registry.subscribe());
             let task = cx.spawn(async move |this, cx| {
                 while let Ok(message) = receiver.recv().await {
                     this.update(cx, |this, cx| {
@@ -144,14 +201,18 @@ impl AcpTools {
             });
 
             self.watched_connection = Some(WatchedConnection {
-                agent_id: active_connection.agent_id.clone(),
+                agent_id,
                 messages: vec![],
                 list_state: ListState::new(0, ListAlignment::Bottom, px(2048.)),
-                connection: active_connection.connection.clone(),
+                connection: connection_weak,
                 incoming_request_methods: HashMap::default(),
                 outgoing_request_methods: HashMap::default(),
                 _task: task,
             });
+
+            for message in backlog {
+                self.push_stream_message(message, cx);
+            }
         }
     }
 

--- a/crates/acp_tools/src/acp_tools.rs
+++ b/crates/acp_tools/src/acp_tools.rs
@@ -47,9 +47,15 @@ impl Global for GlobalAcpConnectionRegistry {}
 #[derive(Default)]
 pub struct AcpConnectionRegistry {
     active_connection: RefCell<Option<ActiveConnection>>,
-    backlog: RefCell<VecDeque<acp::StreamMessage>>,
-    subscribers: RefCell<Vec<smol::channel::Sender<acp::StreamMessage>>>,
+    backlog: RefCell<VecDeque<AcpLogEntry>>,
+    subscribers: RefCell<Vec<smol::channel::Sender<AcpLogEntry>>>,
     _capture_task: RefCell<Option<Task<()>>>,
+}
+
+#[derive(Clone)]
+enum AcpLogEntry {
+    Stream(acp::StreamMessage),
+    Stderr { line: SharedString },
 }
 
 struct ActiveConnection {
@@ -95,26 +101,47 @@ impl AcpConnectionRegistry {
     }
 
     fn record_stream_message(&self, message: acp::StreamMessage) {
+        self.record_entry(AcpLogEntry::Stream(message));
+    }
+
+    pub fn record_stderr_line(
+        &self,
+        connection: &Weak<acp::ClientSideConnection>,
+        line: impl Into<SharedString>,
+    ) {
+        let is_active = self
+            .active_connection
+            .borrow()
+            .as_ref()
+            .is_some_and(|active_connection| {
+                Weak::ptr_eq(&active_connection.connection, connection)
+            });
+        if !is_active {
+            return;
+        }
+        self.record_stderr_entry(line);
+    }
+
+    fn record_stderr_entry(&self, line: impl Into<SharedString>) {
+        self.record_entry(AcpLogEntry::Stderr { line: line.into() });
+    }
+
+    fn record_entry(&self, entry: AcpLogEntry) {
         let mut backlog = self.backlog.borrow_mut();
         if backlog.len() == MAX_BACKLOG_MESSAGES {
             backlog.pop_front();
         }
-        backlog.push_back(message.clone());
+        backlog.push_back(entry.clone());
         drop(backlog);
 
         let mut subscribers = self.subscribers.borrow_mut();
         subscribers.retain(|subscriber| !subscriber.is_closed());
         for subscriber in subscribers.iter() {
-            subscriber.try_send(message.clone()).log_err();
+            subscriber.try_send(entry.clone()).log_err();
         }
     }
 
-    fn subscribe(
-        &self,
-    ) -> (
-        Vec<acp::StreamMessage>,
-        smol::channel::Receiver<acp::StreamMessage>,
-    ) {
+    fn subscribe(&self) -> (Vec<AcpLogEntry>, smol::channel::Receiver<AcpLogEntry>) {
         let backlog = self.backlog.borrow().iter().cloned().collect();
         let (sender, receiver) = smol::channel::unbounded();
         self.subscribers.borrow_mut().push(sender);
@@ -192,9 +219,9 @@ impl AcpTools {
                 .connection_registry
                 .update(cx, |registry, _| registry.subscribe());
             let task = cx.spawn(async move |this, cx| {
-                while let Ok(message) = receiver.recv().await {
+                while let Ok(entry) = receiver.recv().await {
                     this.update(cx, |this, cx| {
-                        this.push_stream_message(message, cx);
+                        this.push_log_entry(entry, cx);
                     })
                     .ok();
                 }
@@ -210,9 +237,16 @@ impl AcpTools {
                 _task: task,
             });
 
-            for message in backlog {
-                self.push_stream_message(message, cx);
+            for entry in backlog {
+                self.push_log_entry(entry, cx);
             }
+        }
+    }
+
+    fn push_log_entry(&mut self, entry: AcpLogEntry, cx: &mut Context<Self>) {
+        match entry {
+            AcpLogEntry::Stream(message) => self.push_stream_message(message, cx),
+            AcpLogEntry::Stderr { line } => self.push_stderr_line(line, cx),
         }
     }
 
@@ -267,7 +301,7 @@ impl AcpTools {
             name: method,
             message_type,
             request_id,
-            direction: stream_message.direction,
+            direction: Some(stream_message.direction),
             collapsed_params_md: match params.as_ref() {
                 Ok(params) => params
                     .as_ref()
@@ -290,6 +324,28 @@ impl AcpTools {
         cx.notify();
     }
 
+    fn push_stderr_line(&mut self, line: SharedString, cx: &mut Context<Self>) {
+        let Some(connection) = self.watched_connection.as_mut() else {
+            return;
+        };
+        let language_registry = self.project.read(cx).languages().clone();
+        let index = connection.messages.len();
+        let params = serde_json::json!({ "line": line.to_string() });
+        let message = WatchedConnectionMessage {
+            name: "stderr".into(),
+            message_type: MessageType::Stderr,
+            request_id: None,
+            direction: None,
+            collapsed_params_md: Some(collapsed_params_md(&params, &language_registry, cx)),
+            expanded_params_md: None,
+            params: Ok(Some(params)),
+        };
+
+        connection.messages.push(message);
+        connection.list_state.splice(index..index, 1);
+        cx.notify();
+    }
+
     fn serialize_observed_messages(&self) -> Option<String> {
         let connection = self.watched_connection.as_ref()?;
 
@@ -304,8 +360,9 @@ impl AcpTools {
                 };
                 Some(serde_json::json!({
                     "_direction": match message.direction {
-                        acp::StreamMessageDirection::Incoming => "incoming",
-                        acp::StreamMessageDirection::Outgoing => "outgoing",
+                        Some(acp::StreamMessageDirection::Incoming) => "incoming",
+                        Some(acp::StreamMessageDirection::Outgoing) => "outgoing",
+                        None => "stderr",
                     },
                     "_type": message.message_type.to_string().to_lowercase(),
                     "id": message.request_id,
@@ -386,11 +443,16 @@ impl AcpTools {
                     .gap_2()
                     .flex_shrink_0()
                     .child(match message.direction {
-                        acp::StreamMessageDirection::Incoming => Icon::new(IconName::ArrowDown)
-                            .color(Color::Error)
-                            .size(IconSize::Small),
-                        acp::StreamMessageDirection::Outgoing => Icon::new(IconName::ArrowUp)
+                        Some(acp::StreamMessageDirection::Incoming) => {
+                            Icon::new(IconName::ArrowDown)
+                                .color(Color::Error)
+                                .size(IconSize::Small)
+                        }
+                        Some(acp::StreamMessageDirection::Outgoing) => Icon::new(IconName::ArrowUp)
                             .color(Color::Success)
+                            .size(IconSize::Small),
+                        None => Icon::new(IconName::Warning)
+                            .color(Color::Warning)
                             .size(IconSize::Small),
                     })
                     .child(
@@ -460,7 +522,7 @@ impl AcpTools {
 struct WatchedConnectionMessage {
     name: SharedString,
     request_id: Option<acp::RequestId>,
-    direction: acp::StreamMessageDirection,
+    direction: Option<acp::StreamMessageDirection>,
     message_type: MessageType,
     params: Result<Option<serde_json::Value>, acp::Error>,
     collapsed_params_md: Option<Entity<Markdown>>,
@@ -520,6 +582,7 @@ enum MessageType {
     Request,
     Response,
     Notification,
+    Stderr,
 }
 
 impl Display for MessageType {
@@ -528,6 +591,7 @@ impl Display for MessageType {
             MessageType::Request => write!(f, "Request"),
             MessageType::Response => write!(f, "Response"),
             MessageType::Notification => write!(f, "Notification"),
+            MessageType::Stderr => write!(f, "Stderr"),
         }
     }
 }
@@ -671,5 +735,24 @@ impl ToolbarItemView for AcpToolsToolbarItemView {
             cx.notify();
         }
         ToolbarItemLocation::Hidden
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_backlog_includes_stderr_lines() {
+        let registry = AcpConnectionRegistry::default();
+
+        registry.record_stderr_entry("agent failed to start");
+
+        let (backlog, _receiver) = registry.subscribe();
+        assert_eq!(backlog.len(), 1);
+        let AcpLogEntry::Stderr { line } = &backlog[0] else {
+            panic!("expected stderr log entry");
+        };
+        assert_eq!(line.as_ref(), "agent failed to start");
     }
 }

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -58,6 +58,7 @@ libc.workspace = true
 nix.workspace = true
 
 [dev-dependencies]
+async-pipe.workspace = true
 client = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 fs.workspace = true
@@ -66,4 +67,5 @@ indoc.workspace = true
 acp_thread = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 gpui_tokio.workspace = true
+project = { workspace = true, features = ["test-support"] }
 reqwest_client = { workspace = true, features = ["test-support"] }

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -255,18 +255,6 @@ impl AcpConnection {
 
         let io_task = cx.background_spawn(io_task);
 
-        let stderr_task = cx.background_spawn(async move {
-            let mut stderr = BufReader::new(stderr);
-            let mut line = String::new();
-            while let Ok(n) = stderr.read_line(&mut line).await
-                && n > 0
-            {
-                log::warn!("agent stderr: {}", line.trim());
-                line.clear();
-            }
-            Ok(())
-        });
-
         let wait_task = cx.spawn({
             let sessions = sessions.clone();
             let status_fut = child.status();
@@ -279,10 +267,32 @@ impl AcpConnection {
 
         let connection = Rc::new(connection);
 
-        cx.update(|cx| {
-            AcpConnectionRegistry::default_global(cx).update(cx, |registry, cx| {
+        let connection_registry = cx.update(|cx| {
+            let registry = AcpConnectionRegistry::default_global(cx);
+            registry.update(cx, |registry, cx| {
                 registry.set_active_connection(agent_id.clone(), &connection, cx)
             });
+            registry
+        });
+
+        let stderr_task = cx.spawn({
+            let connection_registry = connection_registry.clone();
+            let connection_weak = Rc::downgrade(&connection);
+            async move |cx| {
+                let mut stderr = BufReader::new(stderr);
+                let mut line = String::new();
+                while let Ok(n) = stderr.read_line(&mut line).await
+                    && n > 0
+                {
+                    let stderr_line = line.trim().to_string();
+                    log::warn!("agent stderr: {}", stderr_line);
+                    connection_registry.update(cx, |registry, _| {
+                        registry.record_stderr_line(&connection_weak, stderr_line)
+                    });
+                    line.clear();
+                }
+                Ok(())
+            }
         });
 
         let response = connection

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -7,8 +7,9 @@ use action_log::ActionLog;
 use agent_client_protocol::{self as acp, Agent as _, ErrorCode};
 use anyhow::anyhow;
 use collections::HashMap;
-use futures::AsyncBufReadExt as _;
+use futures::future::Shared;
 use futures::io::BufReader;
+use futures::{AsyncBufReadExt as _, FutureExt as _};
 use project::agent_server_store::AgentServerCommand;
 use project::{AgentId, Project};
 use serde::Deserialize;
@@ -21,6 +22,7 @@ use util::process::Child;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::{any::Any, cell::RefCell};
 use thiserror::Error;
 
@@ -43,18 +45,31 @@ pub struct AcpConnection {
     telemetry_id: SharedString,
     connection: Rc<acp::ClientSideConnection>,
     sessions: Rc<RefCell<HashMap<acp::SessionId, AcpSession>>>,
+    pending_sessions: Rc<RefCell<HashMap<acp::SessionId, PendingAcpSession>>>,
     auth_methods: Vec<acp::AuthMethod>,
     agent_capabilities: acp::AgentCapabilities,
     default_mode: Option<acp::SessionModeId>,
     default_model: Option<acp::ModelId>,
     default_config_options: HashMap<String, String>,
-    child: Child,
+    child: Option<Child>,
     session_list: Option<Rc<AcpSessionList>>,
     _io_task: Task<Result<(), acp::Error>>,
     _wait_task: Task<Result<()>>,
     _stderr_task: Task<Result<()>>,
 }
 
+struct PendingAcpSession {
+    task: Shared<Task<Result<Entity<AcpThread>, Arc<anyhow::Error>>>>,
+    ref_count: usize,
+}
+
+struct SessionConfigResponse {
+    modes: Option<acp::SessionModeState>,
+    models: Option<acp::SessionModelState>,
+    config_options: Option<Vec<acp::SessionConfigOption>>,
+}
+
+#[derive(Clone)]
 struct ConfigOptions {
     config_options: Rc<RefCell<Vec<acp::SessionConfigOption>>>,
     tx: Rc<RefCell<watch::Sender<()>>>,
@@ -78,6 +93,7 @@ pub struct AcpSession {
     models: Option<Rc<RefCell<acp::SessionModelState>>>,
     session_modes: Option<Rc<RefCell<acp::SessionModeState>>>,
     config_options: Option<ConfigOptions>,
+    ref_count: usize,
 }
 
 pub struct AcpSessionList {
@@ -212,6 +228,7 @@ impl AcpConnection {
         log::trace!("Spawned (pid: {})", child.id());
 
         let sessions = Rc::new(RefCell::new(HashMap::default()));
+        let pending_sessions = Rc::new(RefCell::new(HashMap::default()));
 
         let (release_channel, version): (Option<&str>, String) = cx.update(|cx| {
             (
@@ -255,16 +272,7 @@ impl AcpConnection {
             let status_fut = child.status();
             async move |cx| {
                 let status = status_fut.await?;
-
-                for session in sessions.borrow().values() {
-                    session
-                        .thread
-                        .update(cx, |thread, cx| {
-                            thread.emit_load_error(LoadError::Exited { status }, cx)
-                        })
-                        .ok();
-                }
-
+                emit_load_error_to_all_sessions(&sessions, LoadError::Exited { status }, cx);
                 anyhow::Ok(())
             }
         });
@@ -349,6 +357,7 @@ impl AcpConnection {
             display_name,
             telemetry_id,
             sessions,
+            pending_sessions,
             agent_capabilities: response.agent_capabilities,
             default_mode,
             default_model,
@@ -357,12 +366,133 @@ impl AcpConnection {
             _io_task: io_task,
             _wait_task: wait_task,
             _stderr_task: stderr_task,
-            child,
+            child: Some(child),
         })
     }
 
     pub fn prompt_capabilities(&self) -> &acp::PromptCapabilities {
         &self.agent_capabilities.prompt_capabilities
+    }
+
+    fn open_or_create_session(
+        self: Rc<Self>,
+        session_id: acp::SessionId,
+        project: Entity<Project>,
+        work_dirs: PathList,
+        title: Option<SharedString>,
+        rpc_call: impl FnOnce(
+            Rc<acp::ClientSideConnection>,
+            acp::SessionId,
+            PathBuf,
+        )
+            -> futures::future::LocalBoxFuture<'static, Result<SessionConfigResponse>>
+        + 'static,
+        cx: &mut App,
+    ) -> Task<Result<Entity<AcpThread>>> {
+        if let Some(pending) = self.pending_sessions.borrow_mut().get_mut(&session_id) {
+            pending.ref_count += 1;
+            let task = pending.task.clone();
+            return cx
+                .foreground_executor()
+                .spawn(async move { task.await.map_err(|err| anyhow!(err)) });
+        }
+
+        if let Some(session) = self.sessions.borrow_mut().get_mut(&session_id) {
+            session.ref_count += 1;
+            if let Some(thread) = session.thread.upgrade() {
+                return Task::ready(Ok(thread));
+            }
+        }
+
+        let Some(cwd) = work_dirs.ordered_paths().next().cloned() else {
+            return Task::ready(Err(anyhow!("Working directory cannot be empty")));
+        };
+
+        let shared_task = cx
+            .spawn({
+                let session_id = session_id.clone();
+                let this = self.clone();
+                async move |cx| {
+                    let action_log = cx.new(|_| ActionLog::new(project.clone()));
+                    let thread: Entity<AcpThread> = cx.new(|cx| {
+                        AcpThread::new(
+                            None,
+                            title.unwrap_or_else(|| this.display_name.clone()),
+                            Some(work_dirs),
+                            this.clone(),
+                            project,
+                            action_log,
+                            session_id.clone(),
+                            watch::Receiver::constant(
+                                this.agent_capabilities.prompt_capabilities.clone(),
+                            ),
+                            cx,
+                        )
+                    });
+
+                    this.sessions.borrow_mut().insert(
+                        session_id.clone(),
+                        AcpSession {
+                            thread: thread.downgrade(),
+                            suppress_abort_err: false,
+                            session_modes: None,
+                            models: None,
+                            config_options: None,
+                            ref_count: 1,
+                        },
+                    );
+
+                    let response =
+                        match rpc_call(this.connection.clone(), session_id.clone(), cwd).await {
+                            Ok(response) => response,
+                            Err(err) => {
+                                this.sessions.borrow_mut().remove(&session_id);
+                                this.pending_sessions.borrow_mut().remove(&session_id);
+                                return Err(Arc::new(err));
+                            }
+                        };
+
+                    let (modes, models, config_options) =
+                        config_state(response.modes, response.models, response.config_options);
+
+                    if let Some(config_opts) = config_options.as_ref() {
+                        this.apply_default_config_options(&session_id, config_opts, cx);
+                    }
+
+                    let ref_count = this
+                        .pending_sessions
+                        .borrow_mut()
+                        .remove(&session_id)
+                        .map_or(1, |pending| pending.ref_count);
+
+                    {
+                        let mut sessions = this.sessions.borrow_mut();
+                        let Some(session) = sessions.get_mut(&session_id) else {
+                            return Err(Arc::new(anyhow!(
+                                "session was closed before load completed"
+                            )));
+                        };
+                        session.session_modes = modes;
+                        session.models = models;
+                        session.config_options = config_options.map(ConfigOptions::new);
+                        session.ref_count = ref_count;
+                    }
+
+                    Ok(thread)
+                }
+            })
+            .shared();
+
+        self.pending_sessions.borrow_mut().insert(
+            session_id,
+            PendingAcpSession {
+                task: shared_task.clone(),
+                ref_count: 1,
+            },
+        );
+
+        cx.foreground_executor()
+            .spawn(async move { shared_task.await.map_err(|err| anyhow!(err)) })
     }
 
     fn apply_default_config_options(
@@ -462,9 +592,29 @@ impl AcpConnection {
     }
 }
 
+fn emit_load_error_to_all_sessions(
+    sessions: &Rc<RefCell<HashMap<acp::SessionId, AcpSession>>>,
+    error: LoadError,
+    cx: &mut AsyncApp,
+) {
+    let threads = sessions
+        .borrow()
+        .values()
+        .map(|session| session.thread.clone())
+        .collect::<Vec<_>>();
+
+    for thread in threads {
+        thread
+            .update(cx, |thread, cx| thread.emit_load_error(error.clone(), cx))
+            .ok();
+    }
+}
+
 impl Drop for AcpConnection {
     fn drop(&mut self) {
-        self.child.kill().log_err();
+        if let Some(child) = self.child.as_mut() {
+            child.kill().log_err();
+        }
     }
 }
 
@@ -604,6 +754,7 @@ impl AgentConnection for AcpConnection {
                     session_modes: modes,
                     models,
                     config_options: config_options.map(ConfigOptions::new),
+                    ref_count: 1,
                 },
             );
 
@@ -635,69 +786,29 @@ impl AgentConnection for AcpConnection {
                 "Loading sessions is not supported by this agent.".into()
             ))));
         }
-        // TODO: remove this once ACP supports multiple working directories
-        let Some(cwd) = work_dirs.ordered_paths().next().cloned() else {
-            return Task::ready(Err(anyhow!("Working directory cannot be empty")));
-        };
-
         let mcp_servers = mcp_servers_for_project(&project, cx);
-        let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let title = title.unwrap_or_else(|| self.display_name.clone());
-        let thread: Entity<AcpThread> = cx.new(|cx| {
-            AcpThread::new(
-                None,
-                title,
-                Some(work_dirs.clone()),
-                self.clone(),
-                project,
-                action_log,
-                session_id.clone(),
-                watch::Receiver::constant(self.agent_capabilities.prompt_capabilities.clone()),
-                cx,
-            )
-        });
-
-        self.sessions.borrow_mut().insert(
-            session_id.clone(),
-            AcpSession {
-                thread: thread.downgrade(),
-                suppress_abort_err: false,
-                session_modes: None,
-                models: None,
-                config_options: None,
+        self.open_or_create_session(
+            session_id,
+            project,
+            work_dirs,
+            title,
+            move |connection, session_id, cwd| {
+                Box::pin(async move {
+                    let response = connection
+                        .load_session(
+                            acp::LoadSessionRequest::new(session_id, cwd).mcp_servers(mcp_servers),
+                        )
+                        .await
+                        .map_err(map_acp_error)?;
+                    Ok(SessionConfigResponse {
+                        modes: response.modes,
+                        models: response.models,
+                        config_options: response.config_options,
+                    })
+                })
             },
-        );
-
-        cx.spawn(async move |cx| {
-            let response = match self
-                .connection
-                .load_session(
-                    acp::LoadSessionRequest::new(session_id.clone(), cwd).mcp_servers(mcp_servers),
-                )
-                .await
-            {
-                Ok(response) => response,
-                Err(err) => {
-                    self.sessions.borrow_mut().remove(&session_id);
-                    return Err(map_acp_error(err));
-                }
-            };
-
-            let (modes, models, config_options) =
-                config_state(response.modes, response.models, response.config_options);
-
-            if let Some(config_opts) = config_options.as_ref() {
-                self.apply_default_config_options(&session_id, config_opts, cx);
-            }
-
-            if let Some(session) = self.sessions.borrow_mut().get_mut(&session_id) {
-                session.session_modes = modes;
-                session.models = models;
-                session.config_options = config_options.map(ConfigOptions::new);
-            }
-
-            Ok(thread)
-        })
+            cx,
+        )
     }
 
     fn resume_session(
@@ -718,70 +829,30 @@ impl AgentConnection for AcpConnection {
                 "Resuming sessions is not supported by this agent.".into()
             ))));
         }
-        // TODO: remove this once ACP supports multiple working directories
-        let Some(cwd) = work_dirs.ordered_paths().next().cloned() else {
-            return Task::ready(Err(anyhow!("Working directory cannot be empty")));
-        };
-
         let mcp_servers = mcp_servers_for_project(&project, cx);
-        let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let title = title.unwrap_or_else(|| self.display_name.clone());
-        let thread: Entity<AcpThread> = cx.new(|cx| {
-            AcpThread::new(
-                None,
-                title,
-                Some(work_dirs),
-                self.clone(),
-                project,
-                action_log,
-                session_id.clone(),
-                watch::Receiver::constant(self.agent_capabilities.prompt_capabilities.clone()),
-                cx,
-            )
-        });
-
-        self.sessions.borrow_mut().insert(
-            session_id.clone(),
-            AcpSession {
-                thread: thread.downgrade(),
-                suppress_abort_err: false,
-                session_modes: None,
-                models: None,
-                config_options: None,
+        self.open_or_create_session(
+            session_id,
+            project,
+            work_dirs,
+            title,
+            move |connection, session_id, cwd| {
+                Box::pin(async move {
+                    let response = connection
+                        .resume_session(
+                            acp::ResumeSessionRequest::new(session_id, cwd)
+                                .mcp_servers(mcp_servers),
+                        )
+                        .await
+                        .map_err(map_acp_error)?;
+                    Ok(SessionConfigResponse {
+                        modes: response.modes,
+                        models: response.models,
+                        config_options: response.config_options,
+                    })
+                })
             },
-        );
-
-        cx.spawn(async move |cx| {
-            let response = match self
-                .connection
-                .resume_session(
-                    acp::ResumeSessionRequest::new(session_id.clone(), cwd)
-                        .mcp_servers(mcp_servers),
-                )
-                .await
-            {
-                Ok(response) => response,
-                Err(err) => {
-                    self.sessions.borrow_mut().remove(&session_id);
-                    return Err(map_acp_error(err));
-                }
-            };
-
-            let (modes, models, config_options) =
-                config_state(response.modes, response.models, response.config_options);
-
-            if let Some(config_opts) = config_options.as_ref() {
-                self.apply_default_config_options(&session_id, config_opts, cx);
-            }
-
-            if let Some(session) = self.sessions.borrow_mut().get_mut(&session_id) {
-                session.session_modes = modes;
-                session.models = models;
-                session.config_options = config_options.map(ConfigOptions::new);
-            }
-
-            Ok(thread)
-        })
+            cx,
+        )
     }
 
     fn supports_close_session(&self) -> bool {
@@ -799,12 +870,48 @@ impl AgentConnection for AcpConnection {
             ))));
         }
 
+        let pending_ref_count = {
+            let mut pending_sessions = self.pending_sessions.borrow_mut();
+            pending_sessions.get_mut(session_id).map(|pending| {
+                pending.ref_count = pending.ref_count.saturating_sub(1);
+                pending.ref_count
+            })
+        };
+        match pending_ref_count {
+            Some(0) => {
+                self.pending_sessions.borrow_mut().remove(session_id);
+                self.sessions.borrow_mut().remove(session_id);
+
+                let conn = self.connection.clone();
+                let session_id = session_id.clone();
+                return cx.foreground_executor().spawn(async move {
+                    conn.close_session(acp::CloseSessionRequest::new(session_id))
+                        .await?;
+                    Ok(())
+                });
+            }
+            Some(_) => return Task::ready(Ok(())),
+            None => {}
+        }
+
+        let mut sessions = self.sessions.borrow_mut();
+        let Some(session) = sessions.get_mut(session_id) else {
+            return Task::ready(Ok(()));
+        };
+
+        session.ref_count = session.ref_count.saturating_sub(1);
+        if session.ref_count > 0 {
+            return Task::ready(Ok(()));
+        }
+
+        sessions.remove(session_id);
+        drop(sessions);
+
         let conn = self.connection.clone();
         let session_id = session_id.clone();
         cx.foreground_executor().spawn(async move {
-            conn.close_session(acp::CloseSessionRequest::new(session_id.clone()))
+            conn.close_session(acp::CloseSessionRequest::new(session_id))
                 .await?;
-            self.sessions.borrow_mut().remove(&session_id);
             Ok(())
         })
     }
@@ -976,6 +1083,459 @@ fn map_acp_error(err: acp::Error) -> anyhow::Error {
         anyhow!(error)
     } else {
         anyhow!(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    struct FakeAcpAgent {
+        load_session_count: Arc<AtomicUsize>,
+        close_session_count: Arc<AtomicUsize>,
+        load_session_updates: Rc<RefCell<Vec<acp::SessionUpdate>>>,
+        load_session_gate: Rc<RefCell<Option<smol::channel::Receiver<()>>>>,
+        client: Rc<RefCell<Option<Rc<acp::AgentSideConnection>>>>,
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl acp::Agent for FakeAcpAgent {
+        async fn initialize(
+            &self,
+            args: acp::InitializeRequest,
+        ) -> acp::Result<acp::InitializeResponse> {
+            Ok(
+                acp::InitializeResponse::new(args.protocol_version).agent_capabilities(
+                    acp::AgentCapabilities::default()
+                        .load_session(true)
+                        .session_capabilities(
+                            acp::SessionCapabilities::default()
+                                .close(acp::SessionCloseCapabilities::new()),
+                        ),
+                ),
+            )
+        }
+
+        async fn authenticate(
+            &self,
+            _: acp::AuthenticateRequest,
+        ) -> acp::Result<acp::AuthenticateResponse> {
+            Ok(Default::default())
+        }
+
+        async fn new_session(
+            &self,
+            _: acp::NewSessionRequest,
+        ) -> acp::Result<acp::NewSessionResponse> {
+            Ok(acp::NewSessionResponse::new(acp::SessionId::new("unused")))
+        }
+
+        async fn prompt(&self, _: acp::PromptRequest) -> acp::Result<acp::PromptResponse> {
+            Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+        }
+
+        async fn cancel(&self, _: acp::CancelNotification) -> acp::Result<()> {
+            Ok(())
+        }
+
+        async fn load_session(
+            &self,
+            args: acp::LoadSessionRequest,
+        ) -> acp::Result<acp::LoadSessionResponse> {
+            self.load_session_count.fetch_add(1, Ordering::SeqCst);
+
+            let updates = std::mem::take(&mut *self.load_session_updates.borrow_mut());
+            if !updates.is_empty() {
+                let client = self
+                    .client
+                    .borrow()
+                    .clone()
+                    .expect("client should be set before load_session is called");
+                for update in updates {
+                    use acp::Client as _;
+                    client
+                        .session_notification(acp::SessionNotification::new(
+                            args.session_id.clone(),
+                            update,
+                        ))
+                        .await?;
+                }
+            }
+
+            let gate = self.load_session_gate.borrow_mut().take();
+            if let Some(gate) = gate {
+                gate.recv().await.ok();
+            }
+
+            Ok(acp::LoadSessionResponse::new())
+        }
+
+        async fn close_session(
+            &self,
+            _: acp::CloseSessionRequest,
+        ) -> acp::Result<acp::CloseSessionResponse> {
+            self.close_session_count.fetch_add(1, Ordering::SeqCst);
+            Ok(acp::CloseSessionResponse::new())
+        }
+    }
+
+    async fn connect_fake_agent(
+        cx: &mut gpui::TestAppContext,
+    ) -> (
+        Rc<AcpConnection>,
+        Entity<Project>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+        Rc<RefCell<Vec<acp::SessionUpdate>>>,
+        Rc<RefCell<Option<smol::channel::Receiver<()>>>>,
+        Task<anyhow::Result<()>>,
+    ) {
+        cx.update(|cx| {
+            let store = settings::SettingsStore::test(cx);
+            cx.set_global(store);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+        fs.insert_tree("/", serde_json::json!({ "a": {} })).await;
+        let project = Project::test(fs, [std::path::Path::new("/a")], cx).await;
+
+        let load_count = Arc::new(AtomicUsize::new(0));
+        let close_count = Arc::new(AtomicUsize::new(0));
+        let load_session_updates = Rc::new(RefCell::new(Vec::new()));
+        let load_session_gate = Rc::new(RefCell::new(None));
+        let agent_client = Rc::new(RefCell::new(None));
+
+        let (client_to_agent_writer, client_to_agent_reader) = async_pipe::pipe();
+        let (agent_to_client_writer, agent_to_client_reader) = async_pipe::pipe();
+
+        let sessions = Rc::new(RefCell::new(HashMap::default()));
+        let session_list_container = Rc::new(RefCell::new(None));
+        let foreground = cx.foreground_executor().clone();
+
+        let client_delegate = ClientDelegate {
+            sessions: sessions.clone(),
+            session_list: session_list_container,
+            cx: cx.to_async(),
+        };
+
+        let (client_connection, client_io_task) = acp::ClientSideConnection::new(
+            client_delegate,
+            client_to_agent_writer,
+            agent_to_client_reader,
+            {
+                let foreground = foreground.clone();
+                move |future| {
+                    foreground.spawn(future).detach();
+                }
+            },
+        );
+
+        let fake_agent = FakeAcpAgent {
+            load_session_count: load_count.clone(),
+            close_session_count: close_count.clone(),
+            load_session_updates: load_session_updates.clone(),
+            load_session_gate: load_session_gate.clone(),
+            client: agent_client.clone(),
+        };
+
+        let (agent_connection, agent_io_task) = acp::AgentSideConnection::new(
+            fake_agent,
+            agent_to_client_writer,
+            client_to_agent_reader,
+            {
+                let foreground = foreground.clone();
+                move |future| {
+                    foreground.spawn(future).detach();
+                }
+            },
+        );
+        *agent_client.borrow_mut() = Some(Rc::new(agent_connection));
+
+        let client_io_task = cx.background_spawn(client_io_task);
+        let agent_io_task = cx.background_spawn(agent_io_task);
+
+        let response = client_connection
+            .initialize(acp::InitializeRequest::new(acp::ProtocolVersion::V1))
+            .await
+            .expect("failed to initialize ACP connection");
+
+        let connection = AcpConnection {
+            id: AgentId::new("test"),
+            display_name: "Test".into(),
+            telemetry_id: "test".into(),
+            connection: Rc::new(client_connection),
+            sessions,
+            pending_sessions: Rc::new(RefCell::new(HashMap::default())),
+            auth_methods: vec![],
+            agent_capabilities: response.agent_capabilities,
+            default_mode: None,
+            default_model: None,
+            default_config_options: HashMap::default(),
+            child: None,
+            session_list: None,
+            _io_task: client_io_task,
+            _wait_task: Task::ready(Ok(())),
+            _stderr_task: Task::ready(Ok(())),
+        };
+
+        let keep_agent_alive = cx.background_spawn(async move {
+            agent_io_task.await.ok();
+            anyhow::Ok(())
+        });
+
+        (
+            Rc::new(connection),
+            project,
+            load_count,
+            close_count,
+            load_session_updates,
+            load_session_gate,
+            keep_agent_alive,
+        )
+    }
+
+    #[gpui::test]
+    async fn test_loaded_sessions_keep_state_until_last_close(cx: &mut gpui::TestAppContext) {
+        let (
+            connection,
+            project,
+            load_count,
+            close_count,
+            _load_session_updates,
+            _load_session_gate,
+            _keep_agent_alive,
+        ) = connect_fake_agent(cx).await;
+
+        let session_id = acp::SessionId::new("session-1");
+        let work_dirs = PathList::new(&[std::path::Path::new("/a")]);
+
+        let first_load = cx.update(|cx| {
+            connection.clone().load_session(
+                session_id.clone(),
+                project.clone(),
+                work_dirs.clone(),
+                None,
+                cx,
+            )
+        });
+        let second_load = cx.update(|cx| {
+            connection.clone().load_session(
+                session_id.clone(),
+                project.clone(),
+                work_dirs.clone(),
+                None,
+                cx,
+            )
+        });
+
+        let first_thread = first_load.await.expect("first load failed");
+        let second_thread = second_load.await.expect("second load failed");
+        cx.run_until_parked();
+
+        assert_eq!(first_thread.entity_id(), second_thread.entity_id());
+        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+
+        cx.update(|cx| connection.clone().close_session(&session_id, cx))
+            .await
+            .expect("first close failed");
+
+        assert_eq!(close_count.load(Ordering::SeqCst), 0);
+        assert!(connection.sessions.borrow().contains_key(&session_id));
+
+        cx.update(|cx| connection.clone().close_session(&session_id, cx))
+            .await
+            .expect("second close failed");
+        cx.run_until_parked();
+
+        assert_eq!(close_count.load(Ordering::SeqCst), 1);
+        assert!(!connection.sessions.borrow().contains_key(&session_id));
+    }
+
+    #[gpui::test]
+    async fn test_load_session_replays_notifications_sent_before_response(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (
+            connection,
+            project,
+            _load_count,
+            _close_count,
+            load_session_updates,
+            _load_session_gate,
+            _keep_agent_alive,
+        ) = connect_fake_agent(cx).await;
+
+        *load_session_updates.borrow_mut() = vec![
+            acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new("hello agent".into())),
+            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new("hi user".into())),
+        ];
+
+        let session_id = acp::SessionId::new("session-replay");
+        let work_dirs = PathList::new(&[std::path::Path::new("/a")]);
+
+        let thread = cx
+            .update(|cx| {
+                connection.clone().load_session(
+                    session_id.clone(),
+                    project.clone(),
+                    work_dirs,
+                    None,
+                    cx,
+                )
+            })
+            .await
+            .expect("load_session failed");
+        cx.run_until_parked();
+
+        let entries = thread.read_with(cx, |thread, _| {
+            thread
+                .entries()
+                .iter()
+                .map(|entry| match entry {
+                    acp_thread::AgentThreadEntry::UserMessage(_) => "user",
+                    acp_thread::AgentThreadEntry::AssistantMessage(_) => "assistant",
+                    acp_thread::AgentThreadEntry::ToolCall(_) => "tool_call",
+                })
+                .collect::<Vec<_>>()
+        });
+
+        assert_eq!(entries, vec!["user", "assistant"]);
+    }
+
+    #[gpui::test]
+    async fn test_close_session_during_in_flight_load(cx: &mut gpui::TestAppContext) {
+        let (
+            connection,
+            project,
+            load_count,
+            close_count,
+            _load_session_updates,
+            load_session_gate,
+            _keep_agent_alive,
+        ) = connect_fake_agent(cx).await;
+
+        let (gate_tx, gate_rx) = smol::channel::bounded::<()>(1);
+        *load_session_gate.borrow_mut() = Some(gate_rx);
+
+        let session_id = acp::SessionId::new("session-close-during-load");
+        let work_dirs = PathList::new(&[std::path::Path::new("/a")]);
+
+        let load_task = cx.update(|cx| {
+            connection.clone().load_session(
+                session_id.clone(),
+                project.clone(),
+                work_dirs,
+                None,
+                cx,
+            )
+        });
+
+        cx.run_until_parked();
+        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+        assert!(
+            connection
+                .pending_sessions
+                .borrow()
+                .contains_key(&session_id)
+        );
+        assert!(connection.sessions.borrow().contains_key(&session_id));
+
+        let close_task = cx.update(|cx| connection.clone().close_session(&session_id, cx));
+        gate_tx.send(()).await.expect("gate send failed");
+        drop(gate_tx);
+
+        let load_result = load_task.await;
+        close_task.await.expect("close failed");
+        cx.run_until_parked();
+
+        let err = load_result.expect_err("load should fail after close-during-load");
+        assert!(
+            err.to_string()
+                .contains("session was closed before load completed"),
+            "expected close-during-load error, got: {err}"
+        );
+        assert_eq!(close_count.load(Ordering::SeqCst), 1);
+        assert!(!connection.sessions.borrow().contains_key(&session_id));
+        assert!(
+            !connection
+                .pending_sessions
+                .borrow()
+                .contains_key(&session_id)
+        );
+    }
+
+    #[gpui::test]
+    async fn test_close_during_load_preserves_other_concurrent_loader(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (
+            connection,
+            project,
+            load_count,
+            close_count,
+            _load_session_updates,
+            load_session_gate,
+            _keep_agent_alive,
+        ) = connect_fake_agent(cx).await;
+
+        let (gate_tx, gate_rx) = smol::channel::bounded::<()>(1);
+        *load_session_gate.borrow_mut() = Some(gate_rx);
+
+        let session_id = acp::SessionId::new("session-concurrent-close");
+        let work_dirs = PathList::new(&[std::path::Path::new("/a")]);
+
+        let first_load = cx.update(|cx| {
+            connection.clone().load_session(
+                session_id.clone(),
+                project.clone(),
+                work_dirs.clone(),
+                None,
+                cx,
+            )
+        });
+        let second_load = cx.update(|cx| {
+            connection.clone().load_session(
+                session_id.clone(),
+                project.clone(),
+                work_dirs.clone(),
+                None,
+                cx,
+            )
+        });
+
+        cx.run_until_parked();
+        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+
+        cx.update(|cx| connection.clone().close_session(&session_id, cx))
+            .await
+            .expect("close during load failed");
+        assert_eq!(close_count.load(Ordering::SeqCst), 0);
+
+        gate_tx.send(()).await.expect("gate send failed");
+        drop(gate_tx);
+
+        let first_thread = first_load.await.expect("first load should still succeed");
+        let second_thread = second_load.await.expect("second load should still succeed");
+        cx.run_until_parked();
+
+        assert_eq!(first_thread.entity_id(), second_thread.entity_id());
+        assert!(connection.sessions.borrow().contains_key(&session_id));
+        assert!(
+            !connection
+                .pending_sessions
+                .borrow()
+                .contains_key(&session_id)
+        );
+
+        cx.update(|cx| connection.clone().close_session(&session_id, cx))
+            .await
+            .expect("final close failed");
+        cx.run_until_parked();
+
+        assert_eq!(close_count.load(Ordering::SeqCst), 1);
+        assert!(!connection.sessions.borrow().contains_key(&session_id));
     }
 }
 
@@ -1272,17 +1832,24 @@ impl acp::Client for ClientDelegate {
         &self,
         notification: acp::SessionNotification,
     ) -> Result<(), acp::Error> {
-        let sessions = self.sessions.borrow();
-        let session = sessions
-            .get(&notification.session_id)
-            .context("Failed to get session")?;
+        let (thread, session_modes, session_config_options) = {
+            let sessions = self.sessions.borrow();
+            let session = sessions
+                .get(&notification.session_id)
+                .context("Failed to get session")?;
+            (
+                session.thread.clone(),
+                session.session_modes.clone(),
+                session.config_options.clone(),
+            )
+        };
 
         if let acp::SessionUpdate::CurrentModeUpdate(acp::CurrentModeUpdate {
             current_mode_id,
             ..
         }) = &notification.update
         {
-            if let Some(session_modes) = &session.session_modes {
+            if let Some(session_modes) = &session_modes {
                 session_modes.borrow_mut().current_mode_id = current_mode_id.clone();
             }
         }
@@ -1292,7 +1859,7 @@ impl acp::Client for ClientDelegate {
             ..
         }) = &notification.update
         {
-            if let Some(opts) = &session.config_options {
+            if let Some(opts) = &session_config_options {
                 *opts.config_options.borrow_mut() = config_options.clone();
                 opts.tx.borrow_mut().send(()).ok();
             }
@@ -1319,7 +1886,7 @@ impl acp::Client for ClientDelegate {
                             .and_then(|v| v.as_str().map(PathBuf::from));
 
                         // Create a minimal display-only lower-level terminal and register it.
-                        let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
+                        let _ = thread.update(&mut self.cx.clone(), |thread, cx| {
                             let builder = TerminalBuilder::new_display_only(
                                 CursorShape::default(),
                                 AlternateScroll::On,
@@ -1347,7 +1914,7 @@ impl acp::Client for ClientDelegate {
         }
 
         // Forward the update to the acp_thread as usual.
-        session.thread.update(&mut self.cx.clone(), |thread, cx| {
+        thread.update(&mut self.cx.clone(), |thread, cx| {
             thread.handle_session_update(notification.update.clone(), cx)
         })??;
 
@@ -1359,7 +1926,7 @@ impl acp::Client for ClientDelegate {
                         let terminal_id = acp::TerminalId::new(id_str);
                         if let Some(s) = term_out.get("data").and_then(|v| v.as_str()) {
                             let data = s.as_bytes().to_vec();
-                            let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
+                            let _ = thread.update(&mut self.cx.clone(), |thread, cx| {
                                 thread.on_terminal_provider_event(
                                     TerminalProviderEvent::Output { terminal_id, data },
                                     cx,
@@ -1386,7 +1953,7 @@ impl acp::Client for ClientDelegate {
                                     .and_then(|v| v.as_str().map(|s| s.to_string())),
                             );
 
-                        let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
+                        let _ = thread.update(&mut self.cx.clone(), |thread, cx| {
                             thread.on_terminal_provider_event(
                                 TerminalProviderEvent::Exit {
                                     terminal_id,

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -444,6 +444,7 @@ impl AuthState {
 
 struct LoadingView {
     session_id: Option<acp::SessionId>,
+    connection: Rc<RefCell<Option<Rc<dyn AgentConnection>>>>,
     _load_task: Task<()>,
 }
 
@@ -508,6 +509,17 @@ impl ConversationView {
         cx.on_release(|this, cx| {
             if let Some(connected) = this.as_connected() {
                 connected.close_all_sessions(cx).detach();
+            } else if let ServerState::Loading(loading) = &this.server_state {
+                loading.update(cx, |loading, cx| {
+                    if let Some(session_id) = loading.session_id.as_ref()
+                        && let Some(connection) = loading.connection.borrow().clone()
+                        && connection.supports_close_session()
+                    {
+                        connection
+                            .close_session(session_id, cx)
+                            .detach_and_log_err(cx);
+                    }
+                });
             }
             for window in this.notifications.drain(..) {
                 window
@@ -667,6 +679,8 @@ impl ConversationView {
         let connect_result = connection_entry.read(cx).wait_for_connection();
 
         let load_session_id = resume_session_id.clone();
+        let loading_connection = Rc::new(RefCell::new(None));
+        let loading_connection_for_task = loading_connection.clone();
         let load_task = cx.spawn_in(window, async move |this, cx| {
             let (connection, history) = match connect_result.await {
                 Ok(AgentConnectedState {
@@ -684,6 +698,7 @@ impl ConversationView {
             };
 
             telemetry::event!("Agent Thread Started", agent = connection.telemetry_id());
+            *loading_connection_for_task.borrow_mut() = Some(connection.clone());
 
             let mut resumed_without_history = false;
             let result = if let Some(session_id) = load_session_id.clone() {
@@ -803,6 +818,7 @@ impl ConversationView {
 
         let loading_view = cx.new(|_cx| LoadingView {
             session_id: resume_session_id,
+            connection: loading_connection,
             _load_task: load_task,
         });
 
@@ -6561,6 +6577,54 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_loading_view_close_closes_pending_session(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
+        let connection_store =
+            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+
+        let connection = LoadingCloseConnection::new();
+        let session_id = SessionId::new("loading-session");
+        let conversation_view = cx.update(|window, cx| {
+            cx.new(|cx| {
+                ConversationView::new(
+                    Rc::new(StubAgentServer::new(connection.clone())),
+                    connection_store,
+                    Agent::Custom { id: "Test".into() },
+                    Some(session_id.clone()),
+                    Some(PathList::new(&[Path::new("/project")])),
+                    None,
+                    None,
+                    workspace.downgrade(),
+                    project,
+                    Some(thread_store),
+                    None,
+                    window,
+                    cx,
+                )
+            })
+        });
+
+        cx.run_until_parked();
+        assert!(conversation_view.read_with(cx, |view, _| view.is_loading()));
+
+        let weak_view = conversation_view.downgrade();
+        drop(conversation_view);
+        cx.update(|_window, _cx| {});
+        cx.run_until_parked();
+
+        assert!(!weak_view.is_upgradable());
+        assert_eq!(connection.closed_sessions.lock().as_slice(), &[session_id]);
+    }
+
+    #[gpui::test]
     async fn test_close_session_returns_error_when_unsupported(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -6594,6 +6658,114 @@ pub(crate) mod tests {
             result.unwrap_err().to_string().contains("not supported"),
             "Error message should indicate that closing is not supported"
         );
+    }
+
+    #[derive(Clone)]
+    struct LoadingCloseConnection {
+        closed_sessions: Arc<Mutex<Vec<acp::SessionId>>>,
+    }
+
+    impl LoadingCloseConnection {
+        fn new() -> Self {
+            Self {
+                closed_sessions: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl AgentConnection for LoadingCloseConnection {
+        fn agent_id(&self) -> AgentId {
+            AgentId::new("loading-close")
+        }
+
+        fn telemetry_id(&self) -> SharedString {
+            "loading-close".into()
+        }
+
+        fn new_session(
+            self: Rc<Self>,
+            _project: Entity<Project>,
+            _work_dirs: PathList,
+            _cx: &mut App,
+        ) -> Task<Result<Entity<AcpThread>>> {
+            panic!("test should load an existing session")
+        }
+
+        fn supports_load_session(&self) -> bool {
+            true
+        }
+
+        fn load_session(
+            self: Rc<Self>,
+            session_id: acp::SessionId,
+            project: Entity<Project>,
+            work_dirs: PathList,
+            _title: Option<SharedString>,
+            cx: &mut App,
+        ) -> Task<Result<Entity<AcpThread>>> {
+            let action_log = cx.new(|_| ActionLog::new(project.clone()));
+            let thread = cx.new(|cx| {
+                AcpThread::new(
+                    None,
+                    "LoadingCloseConnection",
+                    Some(work_dirs),
+                    self,
+                    project,
+                    action_log,
+                    session_id,
+                    watch::Receiver::constant(
+                        acp::PromptCapabilities::new()
+                            .image(true)
+                            .audio(true)
+                            .embedded_context(true),
+                    ),
+                    cx,
+                )
+            });
+
+            cx.foreground_executor().spawn(async move {
+                let (sender, receiver) = smol::channel::bounded::<()>(1);
+                let _sender = sender;
+                receiver.recv().await?;
+                Ok(thread)
+            })
+        }
+
+        fn supports_close_session(&self) -> bool {
+            true
+        }
+
+        fn close_session(
+            self: Rc<Self>,
+            session_id: &acp::SessionId,
+            _cx: &mut App,
+        ) -> Task<Result<()>> {
+            self.closed_sessions.lock().push(session_id.clone());
+            Task::ready(Ok(()))
+        }
+
+        fn auth_methods(&self) -> &[acp::AuthMethod] {
+            &[]
+        }
+
+        fn authenticate(&self, _method_id: acp::AuthMethodId, _cx: &mut App) -> Task<Result<()>> {
+            Task::ready(Ok(()))
+        }
+
+        fn prompt(
+            &self,
+            _id: Option<acp_thread::UserMessageId>,
+            _params: acp::PromptRequest,
+            _cx: &mut App,
+        ) -> Task<Result<acp::PromptResponse>> {
+            Task::ready(Ok(acp::PromptResponse::new(acp::StopReason::EndTurn)))
+        }
+
+        fn cancel(&self, _session_id: &acp::SessionId, _cx: &mut App) {}
+
+        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
+            self
+        }
     }
 
     #[derive(Clone)]

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -654,6 +654,28 @@ impl EditPredictionButton {
         menu
     }
 
+    fn add_configure_providers_item(&self, menu: ContextMenu) -> ContextMenu {
+        menu.separator().item(
+            ContextMenuEntry::new("Configure Providers")
+                .icon(IconName::Settings)
+                .icon_position(IconPosition::Start)
+                .icon_color(Color::Muted)
+                .handler(move |window, cx| {
+                    telemetry::event!(
+                        "Edit Prediction Menu Action",
+                        action = "configure_providers",
+                    );
+                    window.dispatch_action(
+                        OpenSettingsAt {
+                            path: "edit_predictions.providers".to_string(),
+                        }
+                        .boxed_clone(),
+                        cx,
+                    );
+                }),
+        )
+    }
+
     pub fn build_copilot_start_menu(
         &mut self,
         window: &mut Window,
@@ -661,7 +683,7 @@ impl EditPredictionButton {
     ) -> Entity<ContextMenu> {
         let fs = self.fs.clone();
         let project = self.project.clone();
-        ContextMenu::build(window, cx, |menu, _, _| {
+        ContextMenu::build(window, cx, |menu, _, cx| {
             let menu = menu
                 .entry("Sign In to Copilot", None, move |window, cx| {
                     telemetry::event!(
@@ -689,16 +711,9 @@ impl EditPredictionButton {
                     }
                 });
 
-            if zed_hosted_provider_supported() {
-                menu.separator().entry("Use Zed AI", None, {
-                    let fs = fs.clone();
-                    move |_window, cx| {
-                        set_completion_provider(fs.clone(), cx, EditPredictionProvider::Zed)
-                    }
-                })
-            } else {
-                menu
-            }
+            let menu =
+                self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
+            self.add_configure_providers_item(menu)
         })
     }
 
@@ -1038,6 +1053,7 @@ impl EditPredictionButton {
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
 
+            let menu = self.add_configure_providers_item(menu);
             menu.separator()
                 .item(
                     ContextMenuEntry::new("Copilot: Next Edit Suggestions")
@@ -1078,7 +1094,7 @@ impl EditPredictionButton {
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Codestral, cx);
 
-            menu
+            self.add_configure_providers_item(menu)
         })
     }
 
@@ -1321,27 +1337,7 @@ impl EditPredictionButton {
                 }
             }
 
-            menu = menu.separator().item(
-                ContextMenuEntry::new("Configure Providers")
-                    .icon(IconName::Settings)
-                    .icon_position(IconPosition::Start)
-                    .icon_color(Color::Muted)
-                    .handler(move |window, cx| {
-                        telemetry::event!(
-                            "Edit Prediction Menu Action",
-                            action = "configure_providers",
-                        );
-                        window.dispatch_action(
-                            OpenSettingsAt {
-                                path: "edit_predictions.providers".to_string(),
-                            }
-                            .boxed_clone(),
-                            cx,
-                        );
-                    }),
-            );
-
-            menu
+            self.add_configure_providers_item(menu)
         })
     }
 

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -1,11 +1,14 @@
 use edit_prediction_types::{
     EditPredictionDelegate, EditPredictionIconSet, PredictedCursorPosition,
 };
+use futures::StreamExt;
 use gpui::{Entity, KeyBinding, Modifiers, prelude::*};
 use indoc::indoc;
+use language::EditPredictionsMode;
 use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
 use std::{
     ops::Range,
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{self, AtomicUsize},
@@ -15,8 +18,9 @@ use text::{Point, ToOffset};
 use ui::prelude::*;
 
 use crate::{
-    AcceptEditPrediction, EditPrediction, MenuEditPredictionsPolicy, editor_tests::init_test,
-    test::editor_test_context::EditorTestContext,
+    AcceptEditPrediction, CodeContextMenu, EditPrediction, MenuEditPredictionsPolicy,
+    editor_tests::{init_test, update_test_language_settings},
+    test::{editor_lsp_test_context::EditorLspTestContext, editor_test_context::EditorTestContext},
 };
 use rpc::proto::PeerId;
 use workspace::CollaboratorId;
@@ -478,6 +482,199 @@ async fn test_edit_prediction_preview_cleanup_on_toggle_off(cx: &mut gpui::TestA
     });
 }
 
+#[gpui::test]
+async fn test_edit_prediction_preview_activates_when_prediction_arrives_with_modifier_held(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
+    });
+    cx.update(|cx| cx.bind_keys([KeyBinding::new("ctrl-shift-a", AcceptEditPrediction, None)]));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.set_state("let x = ˇ;");
+
+    cx.editor(|editor, _, _| {
+        assert!(!editor.has_active_edit_prediction());
+        assert!(!editor.edit_prediction_preview_is_active());
+    });
+
+    cx.simulate_modifiers_change(Modifiers::control_shift());
+    cx.run_until_parked();
+
+    cx.editor(|editor, _, _| {
+        assert!(!editor.has_active_edit_prediction());
+        assert!(editor.edit_prediction_preview_is_active());
+    });
+
+    propose_edits(&provider, vec![(8..8, "42")], &mut cx);
+    cx.update_editor(|editor, window, cx| {
+        editor.set_menu_edit_predictions_policy(MenuEditPredictionsPolicy::ByProvider);
+        editor.update_visible_edit_prediction(window, cx)
+    });
+
+    cx.editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(
+            editor.edit_prediction_preview_is_active(),
+            "prediction preview should activate immediately when the prediction arrives while the preview modifier is still held",
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_hidden_edit_prediction_does_not_open_snippet_menu_on_word_input(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = hidden_edit_prediction_snippet_test_context(cx).await;
+    cx.simulate_input("t");
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(editor.context_menu.borrow().is_none());
+    });
+}
+
+#[gpui::test]
+async fn test_hidden_edit_prediction_opens_snippet_menu_for_strong_prefix_match(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let mut cx = hidden_edit_prediction_snippet_test_context(cx).await;
+    cx.simulate_input("t");
+    cx.run_until_parked();
+    cx.simulate_input("h");
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, _, _| {
+        let Some(CodeContextMenu::Completions(menu)) = &*editor.context_menu.borrow() else {
+            panic!("expected completions menu");
+        };
+        let entries = menu.entries.borrow();
+        assert!(entries.iter().any(|entry| entry.string == "Theta"));
+    });
+}
+
+#[gpui::test]
+async fn test_edit_prediction_preview_does_not_hide_code_actions_on_modifier_press(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx, |_| {});
+    update_test_language_settings(cx, &|settings| {
+        settings.edit_predictions.get_or_insert_default().mode = Some(EditPredictionsMode::Subtle);
+    });
+    cx.update(|cx| {
+        cx.bind_keys([KeyBinding::new(
+            "ctrl-enter",
+            AcceptEditPrediction,
+            Some("Editor && edit_prediction_conflict && !showing_completions"),
+        )]);
+    });
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            code_action_provider: Some(lsp::CodeActionProviderCapability::Simple(true)),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+    cx.set_state(indoc! {"
+        fn main() {
+            let valueˇ = 1;
+        }
+    "});
+
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    cx.update_editor(|editor, window, cx| {
+        editor.set_edit_prediction_provider(Some(provider.clone()), window, cx);
+    });
+
+    let snapshot = cx.buffer_snapshot();
+    let edit_position = snapshot.anchor_after(Point::new(1, 13));
+    cx.update(|_, cx| {
+        provider.update(cx, |provider, _| {
+            provider.set_edit_prediction(Some(edit_prediction_types::EditPrediction::Local {
+                id: None,
+                edits: vec![(edit_position..edit_position, " + 1".into())],
+                cursor_position: None,
+                edit_preview: None,
+            }))
+        })
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.set_menu_edit_predictions_policy(MenuEditPredictionsPolicy::ByProvider);
+        editor.update_visible_edit_prediction(window, cx);
+    });
+    cx.update_editor(|editor, _, _| {
+        assert!(editor.has_active_edit_prediction());
+        assert!(editor.stale_edit_prediction_in_menu.is_none());
+    });
+
+    let mut code_action_requests = cx.set_request_handler::<lsp::request::CodeActionRequest, _, _>(
+        move |_, _, _| async move {
+            Ok(Some(vec![lsp::CodeActionOrCommand::CodeAction(
+                lsp::CodeAction {
+                    title: "Inline value".to_string(),
+                    kind: Some(lsp::CodeActionKind::QUICKFIX),
+                    ..Default::default()
+                },
+            )]))
+        },
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.toggle_code_actions(
+            &crate::actions::ToggleCodeActions {
+                deployed_from: None,
+                quick_launch: false,
+            },
+            window,
+            cx,
+        );
+    });
+    code_action_requests.next().await;
+    cx.run_until_parked();
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+
+    cx.update_editor(|editor, _, _| {
+        assert!(!editor.has_active_edit_prediction());
+        assert!(editor.stale_edit_prediction_in_menu.is_some());
+        assert!(editor.context_menu_visible());
+        assert!(matches!(
+            editor.context_menu.borrow().as_ref(),
+            Some(CodeContextMenu::CodeActions(_))
+        ));
+        assert!(!editor.edit_prediction_preview_is_active());
+    });
+
+    cx.simulate_modifiers_change(Modifiers::control());
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            !editor.edit_prediction_preview_is_active(),
+            "modifier-only press should not activate edit prediction preview while code actions are open"
+        );
+        assert!(
+            editor.context_menu_visible(),
+            "modifier-only press should not hide the code actions menu"
+        );
+        assert!(matches!(
+            editor.context_menu.borrow().as_ref(),
+            Some(CodeContextMenu::CodeActions(_))
+        ));
+    });
+}
+
 fn assert_editor_active_edit_completion(
     cx: &mut EditorTestContext,
     assert: impl FnOnce(MultiBufferSnapshot, &Vec<(Range<Anchor>, Arc<str>)>),
@@ -583,6 +780,37 @@ fn propose_edits_with_cursor_position_in_insertion<T: ToOffset>(
             }))
         })
     });
+}
+
+async fn hidden_edit_prediction_snippet_test_context(
+    cx: &mut gpui::TestAppContext,
+) -> EditorTestContext {
+    let mut cx = EditorTestContext::new(cx).await;
+    let provider = cx.new(|_| FakeEditPredictionDelegate::default());
+    assign_editor_completion_provider(provider.clone(), &mut cx);
+    cx.update_editor(|editor, _, cx| {
+        editor.set_menu_edit_predictions_policy(MenuEditPredictionsPolicy::Never);
+        editor.project().unwrap().update(cx, |project, cx| {
+            project.snippets().update(cx, |snippets, _cx| {
+                let snippet = project::snippet_provider::Snippet {
+                    prefix: vec!["Theta".to_string(), "turnstile".to_string()],
+                    body: "⊢".to_string(),
+                    description: Some("unicode symbol".to_string()),
+                    name: "unicode snippets".to_string(),
+                };
+                snippets.add_snippet_for_test(
+                    None,
+                    PathBuf::from("test_snippets.json"),
+                    vec![Arc::new(snippet)],
+                );
+            });
+        })
+    });
+    cx.set_state("ˇ");
+
+    propose_edits(&provider, vec![(0..0, "x")], &mut cx);
+    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
+    cx
 }
 
 fn assign_editor_completion_provider(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2880,6 +2880,11 @@ impl Editor {
                 key_context.add("copilot_suggestion");
             }
         }
+        if self.edit_prediction_requires_modifier() {
+            key_context.set("edit_prediction_mode", "subtle");
+        } else {
+            key_context.set("edit_prediction_mode", "eager");
+        }
 
         if self.selection_mark_mode {
             key_context.add("selection_mode");
@@ -5617,7 +5622,7 @@ impl Editor {
             _ => self.open_or_update_completions_menu(
                 None,
                 Some(text.to_owned()).filter(|x| !x.is_empty()),
-                true,
+                trigger_in_words,
                 window,
                 cx,
             ),
@@ -6116,8 +6121,15 @@ impl Editor {
         let provider_responses = if let Some(provider) = &provider
             && load_provider_completions
         {
-            let trigger_character =
-                trigger.filter(|trigger| buffer.read(cx).completion_triggers().contains(trigger));
+            let trigger_character = trigger
+                .as_ref()
+                .filter(|trigger| {
+                    buffer
+                        .read(cx)
+                        .completion_triggers()
+                        .contains(trigger.as_str())
+                })
+                .cloned();
             let completion_context = CompletionContext {
                 trigger_kind: match &trigger_character {
                     Some(_) => CompletionTriggerKind::TRIGGER_CHARACTER,
@@ -6172,16 +6184,51 @@ impl Editor {
             Task::ready(BTreeMap::default())
         };
 
+        let snippet_char_classifier = buffer_snapshot
+            .char_classifier_at(buffer_position)
+            .scope_context(Some(CharScopeContext::Completion));
+
         let snippets = if let Some(provider) = &provider
             && provider.show_snippets()
             && let Some(project) = self.project()
         {
-            let char_classifier = buffer_snapshot
-                .char_classifier_at(buffer_position)
-                .scope_context(Some(CharScopeContext::Completion));
-            project.update(cx, |project, cx| {
-                snippet_completions(project, &buffer, buffer_position, char_classifier, cx)
-            })
+            let word_trigger = trigger.as_ref().is_some_and(|trigger| {
+                !trigger.is_empty()
+                    && trigger
+                        .chars()
+                        .all(|character| snippet_char_classifier.is_word(character))
+            });
+            let requires_strong_snippet_match = !menu_is_open && !trigger_in_words && word_trigger;
+            let load_snippet_completions = !requires_strong_snippet_match
+                || query.as_ref().is_some_and(|query| {
+                    let project = project.read(cx);
+                    has_strong_snippet_prefix_match(
+                        &project,
+                        &buffer,
+                        buffer_position,
+                        &snippet_char_classifier,
+                        query,
+                        cx,
+                    )
+                });
+
+            if load_snippet_completions {
+                project.update(cx, |project, cx| {
+                    snippet_completions(
+                        project,
+                        &buffer,
+                        buffer_position,
+                        snippet_char_classifier,
+                        cx,
+                    )
+                })
+            } else {
+                Task::ready(Ok(CompletionResponse {
+                    completions: Vec::new(),
+                    display_options: Default::default(),
+                    is_incomplete: false,
+                }))
+            }
         } else {
             Task::ready(Ok(CompletionResponse {
                 completions: Vec::new(),
@@ -8505,6 +8552,10 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let can_supersede_active_menu =
+            self.context_menu.borrow().as_ref().is_none_or(|menu| {
+                !menu.visible() || matches!(menu, CodeContextMenu::Completions(_))
+            });
         let mut modifiers_held = false;
 
         // Check bindings for all granularities.
@@ -8521,7 +8572,9 @@ impl Editor {
                 .keystroke()
             {
                 modifiers_held = modifiers_held
-                    || (keystroke.modifiers() == modifiers && keystroke.modifiers().modified());
+                    || (can_supersede_active_menu
+                        && keystroke.modifiers() == modifiers
+                        && keystroke.modifiers().modified());
             }
         }
 
@@ -27452,6 +27505,33 @@ impl CodeActionProvider for Entity<Project> {
             project.apply_code_action(buffer_handle, action, push_to_history, cx)
         })
     }
+}
+
+fn has_strong_snippet_prefix_match(
+    project: &Project,
+    buffer: &Entity<Buffer>,
+    buffer_anchor: text::Anchor,
+    classifier: &CharClassifier,
+    query: &str,
+    cx: &App,
+) -> bool {
+    if query.chars().take(2).count() < 2 {
+        return false;
+    }
+
+    let query = query.to_lowercase();
+    let is_word_char = |character| classifier.is_word(character);
+    let languages = buffer.read(cx).languages_at(buffer_anchor);
+    let snippet_store = project.snippets().read(cx);
+
+    languages.iter().any(|language| {
+        snippet_store
+            .snippets_for(Some(language.lsp_id()), cx)
+            .iter()
+            .flat_map(|snippet| snippet.prefix.iter())
+            .flat_map(|prefix| snippet_candidate_suffixes(prefix, &is_word_char))
+            .any(|candidate| candidate.to_lowercase().starts_with(&query))
+    })
 }
 
 fn snippet_completions(

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -21,7 +21,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{RegisterSetting, SettingsStore};
 use sha2::{Digest, Sha256};
-use task::Shell;
 use util::{ResultExt as _, debug_panic};
 
 use crate::ProjectEnvironment;
@@ -989,11 +988,7 @@ impl ExternalAgentServer for LocalExtensionArchiveAgent {
             // Get project environment
             let mut env = project_environment
                 .update(cx, |project_environment, cx| {
-                    project_environment.local_directory_environment(
-                        &Shell::System,
-                        paths::home_dir().as_path().into(),
-                        cx,
-                    )
+                    project_environment.default_environment(cx)
                 })?
                 .await
                 .unwrap_or_default();
@@ -1186,11 +1181,7 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
         cx.spawn(async move |cx| {
             let mut env = project_environment
                 .update(cx, |project_environment, cx| {
-                    project_environment.local_directory_environment(
-                        &Shell::System,
-                        paths::home_dir().as_path().into(),
-                        cx,
-                    )
+                    project_environment.default_environment(cx)
                 })?
                 .await
                 .unwrap_or_default();
@@ -1365,11 +1356,7 @@ impl ExternalAgentServer for LocalRegistryNpxAgent {
         cx.spawn(async move |cx| {
             let mut env = project_environment
                 .update(cx, |project_environment, cx| {
-                    project_environment.local_directory_environment(
-                        &Shell::System,
-                        paths::home_dir().as_path().into(),
-                        cx,
-                    )
+                    project_environment.default_environment(cx)
                 })?
                 .await
                 .unwrap_or_default();
@@ -1426,11 +1413,7 @@ impl ExternalAgentServer for LocalCustomAgent {
         cx.spawn(async move |cx| {
             let mut env = project_environment
                 .update(cx, |project_environment, cx| {
-                    project_environment.local_directory_environment(
-                        &Shell::System,
-                        paths::home_dir().as_path().into(),
-                        cx,
-                    )
+                    project_environment.default_environment(cx)
                 })?
                 .await
                 .unwrap_or_default();

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -194,6 +194,35 @@ impl ProjectEnvironment {
         .unwrap_or_else(|| Task::ready(None).shared())
     }
 
+    /// Returns the project environment using the default worktree path.
+    /// This ensures project-specific environment variables are loaded from
+    /// the project directory rather than the home directory.
+    pub fn default_environment(
+        &mut self,
+        cx: &mut App,
+    ) -> Shared<Task<Option<HashMap<String, String>>>> {
+        let abs_path = self
+            .worktree_store
+            .read_with(cx, |worktree_store, cx| {
+                worktree_store
+                    .visible_worktrees(cx)
+                    .next()
+                    .and_then(|worktree| {
+                        let worktree = worktree.read(cx);
+                        let abs_path = worktree.abs_path();
+                        if worktree.is_single_file() {
+                            abs_path.parent().map(Arc::<Path>::from)
+                        } else {
+                            Some(abs_path)
+                        }
+                    })
+            })
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| paths::home_dir().as_path().into());
+        self.local_directory_environment(&Shell::System, abs_path, cx)
+    }
+
     /// Returns the project environment, if possible.
     /// If the project was opened from the CLI, then the inherited CLI environment is returned.
     /// If it wasn't opened from the CLI, and an absolute path is given, then a shell is spawned in

--- a/docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md
+++ b/docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md
@@ -30,6 +30,7 @@ The previous upstream sync phase focused on editor, search, terminal, and picker
 ## Key Flows
 
 - F1. Candidate selection
+
   - **Trigger:** A sync pass evaluates Zed 1.0-era upstream changes.
   - **Actors:** A3
   - **Steps:** Review next-edit/provider and ACP registry/external-agent commits; classify each candidate as must, maybe, or skip; reject candidates that require upstream hosted AI or docked agent surfaces.
@@ -37,6 +38,7 @@ The previous upstream sync phase focused on editor, search, terminal, and picker
   - **Covered by:** R1, R2, R3, R4, R15
 
 - F2. Default-build next-edit validation
+
   - **Trigger:** A next-edit/provider candidate is selected.
   - **Actors:** A1, A3
   - **Steps:** Apply the candidate; verify allowed providers remain discoverable and usable in the default build; confirm unsupported Zed-hosted provider paths stay hidden or treated as unconfigured.

--- a/docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md
+++ b/docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md
@@ -1,0 +1,178 @@
+---
+date: 2026-05-03
+topic: zed-1-0-next-edit-acp-registry-sync
+---
+
+# Zed 1.0 Next-Edit And ACP Registry Sync
+
+## Summary
+
+Backport Zed 1.0-era next-edit and ACP registry/external-agent polish that improves Superzent's default build without importing upstream hosted AI, telemetry, or docked agent product surfaces.
+
+---
+
+## Problem Frame
+
+Zed 1.0 makes AI-native editing and ACP-based agents central to the editor experience. Superzent shares part of that direction, but its product shape is narrower: local-first multi-workspace editing, terminal-heavy external agent workflows, center-pane ACP chat tabs, and non-Zed-hosted next-edit in the default build.
+
+The previous upstream sync phase focused on editor, search, terminal, and picker improvements while explicitly deferring broad upstream agent/sidebar/chat architecture. The next sync should continue that selectivity. The useful work now is not to copy Zed's Parallel Agents or Threads Sidebar shape, but to keep Superzent's existing next-edit and external ACP-agent surfaces reliable as Zed 1.0-era fixes land upstream.
+
+---
+
+## Actors
+
+- A1. Superzent user: Uses the default build for local repositories, worktrees, center-pane ACP tabs, and next-edit.
+- A2. External ACP agent: Runs through ACP registry or agent-server configuration and is expected to work inside Superzent's ACP tab flow.
+- A3. Sync implementer: Selects upstream commits, adapts them to Superzent's feature split, and verifies default-build behavior.
+
+---
+
+## Key Flows
+
+- F1. Candidate selection
+  - **Trigger:** A sync pass evaluates Zed 1.0-era upstream changes.
+  - **Actors:** A3
+  - **Steps:** Review next-edit/provider and ACP registry/external-agent commits; classify each candidate as must, maybe, or skip; reject candidates that require upstream hosted AI or docked agent surfaces.
+  - **Outcome:** Planning receives a bounded candidate list rather than a broad upstream merge target.
+  - **Covered by:** R1, R2, R3, R4, R15
+
+- F2. Default-build next-edit validation
+  - **Trigger:** A next-edit/provider candidate is selected.
+  - **Actors:** A1, A3
+  - **Steps:** Apply the candidate; verify allowed providers remain discoverable and usable in the default build; confirm unsupported Zed-hosted provider paths stay hidden or treated as unconfigured.
+  - **Outcome:** Superzent keeps next-edit parity without expanding into hosted AI.
+  - **Covered by:** R5, R6, R7, R8, R9
+
+- F3. ACP registry/external-agent validation
+  - **Trigger:** An ACP registry or external-agent candidate is selected.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Apply the candidate; verify registry-installed or configured external agents can start or resume through Superzent's center-pane ACP tab flow; confirm debug and configuration surfaces help local diagnosis without requiring upstream Agent Panel restoration.
+  - **Outcome:** External ACP agents become more reliable while preserving Superzent's center-pane product model.
+  - **Covered by:** R10, R11, R12, R13, R14
+
+---
+
+## Requirements
+
+**Selection Strategy**
+
+- R1. This sync phase must use upstream commit or PR-level cherry-picks rather than merging all of `upstream/main`, `v1.0.0`, or `v1.0.x`.
+- R2. Candidate selection must be limited to default-build next-edit parity and ACP registry/external-agent polish.
+- R3. Any candidate touching AI, ACP, providers, or agent UI must be reviewed against Superzent's default `lite + acp_tabs + next_edit` build and the heavier `full` feature split before inclusion.
+- R4. Selected changes must preserve Superzent's center-pane ACP tab model and must not require restoring Zed's docked Agent Panel, native text-thread product surface, or Threads Sidebar.
+
+**Next-Edit Parity**
+
+- R5. The default build must continue to support Superzent's existing non-Zed-hosted next-edit provider scope.
+- R6. Provider setup and status entry points for allowed providers should remain discoverable in the default build.
+- R7. Correctness fixes for prediction display, cursor movement, provider setup entry points, and prediction menu behavior should be prioritized when they do not depend on Zed-hosted provider behavior.
+- R8. Provider protocol or model-support updates may be included only when they improve allowed provider behavior without exposing Zed-hosted provider choices in the default build.
+- R9. Existing or stale Zed-hosted provider settings must continue to recover through the unsupported/unconfigured path rather than activating a hosted provider in the default build.
+
+**ACP Registry And External Agents**
+
+- R10. ACP registry install, update, debug, and configuration flows should be evaluated only insofar as they support external agents in Superzent's default build.
+- R11. Registry-installed or configured external agents should open, resume, and report failures through Superzent's center-pane ACP tab flow.
+- R12. External agent working-directory, environment, and configuration behavior should remain scoped to the user's active project/workspace context.
+- R13. ACP debug and logging improvements should be included when they help diagnose local external-agent failures without adding telemetry or hosted-service dependence.
+- R14. External-agent session history, import, or resume fixes may be selected only when they fit Superzent's ACP tab/history direction and do not require the upstream Threads Sidebar as the primary surface.
+- R15. Candidates that mainly support upstream Parallel Agents, hosted Zed Agent, Zeta telemetry, Business/team management, collaboration, calls, or DeltaDB should be classified as skip for this phase.
+
+---
+
+## Initial Candidate Shortlist
+
+**Must Evaluate: Next-Edit**
+
+- `2460a5c5df` ep: Fix moving cursor to a predicted position (#55079)
+- `a7ca17fcb2` edit_prediction_ui: Add configure providers menu item to Copilot and Codestral (#53691)
+- `7a6a95c2cd` editor: Fix edit predictions polluting completions menu (#50403)
+- `8b822f9e10` Fix regression preventing new predictions from being previewed in subtle mode (#51887)
+- `db7bc734e2` Fix ep preview closing menus (#54194)
+
+**Must Evaluate: ACP Registry / External Agents**
+
+- `2ca94a6032` acp: Register ACP sessions before load replay (#54431)
+- `102805a73f` agent_ui: Preserve session resume state after load errors (#54411)
+- `a5e78b02de` Fix double borrow panic when ACP process dies (#54135)
+- `f7ab907216` Fix agent servers loading environment from home dir instead of project dir (#52763)
+- `73127da4b7` acp_tools: Always capture ACP transport and stderr into the log ring (#54536)
+
+**Maybe Evaluate**
+
+- `6e900b43ec` agent_ui: Handle pagination of session/list correctly when importing (#54427)
+- `c91b917383` agent_ui: Sort thread import agents by display name (#54417)
+- `1c1b03c3d6` acp: Improve ACP debug view (#54769)
+- `07e9a2d25a` acp: Use npm --prefix for registry npx agents (#53560)
+- `d1177dc43` acp: Support terminal auth methods (#51999)
+- `8f0826f543` acp: Set agent server cwd from project paths (#52005)
+- `3ee2f5b811` acp: Add agent websites to the registry page (#52002)
+- `809e701163` acp: Notify when we receive new versions from the registry (#52818)
+- `57e01b3701` language_models: Fix misleading copy when hosted models are disabled (#53971)
+- `f051447a8d` open_ai: Use responses API for all models (#54910)
+
+**Skip By Default**
+
+- Zed Agent-native changes whose value depends on hosted Zed Agent behavior.
+- Zeta model, training, telemetry, or Agent Metrics changes.
+- Parallel Agents, Threads Sidebar, docked Agent Panel, and native text-thread product-shape changes.
+- Collaboration, calls, Business/team management, and DeltaDB-oriented changes.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5, R6, R7, R9.** Given a Superzent default-build user with a supported non-Zed-hosted next-edit provider configured, when next-edit parity fixes are applied, inline predictions and setup/status entry points continue to work without exposing Zed-hosted provider choices.
+- AE2. **Covers R10, R11, R13.** Given a registry-installed external ACP agent that fails to start, when the user opens the relevant debug surface, the failure has enough local transport or stderr context to diagnose it without relying on hosted telemetry.
+- AE3. **Covers R4, R14, R15.** Given an upstream candidate whose user value depends on the Threads Sidebar or docked Agent Panel, when it is reviewed for this phase, it is skipped or deferred even if the underlying fix is useful to Zed.
+- AE4. **Covers R1, R3.** Given a candidate that touches shared provider or ACP code, when planning evaluates it, the plan explicitly checks default-build behavior before treating the cherry-pick as accepted.
+
+---
+
+## Success Criteria
+
+- The next sync plan has a small, defensible must/maybe/skip list for Zed 1.0-era next-edit and ACP registry work.
+- The default Superzent build preserves non-Zed-hosted next-edit and center-pane ACP tabs after selected candidates are applied.
+- Users get reliability, setup, and debugging improvements without seeing new Zed-hosted AI, telemetry, Agent Metrics, docked Agent Panel, or Threads Sidebar surfaces.
+- Planning can proceed without inventing product scope, inclusion criteria, or explicit exclusions for this sync phase.
+
+---
+
+## Scope Boundaries
+
+- Do not merge broad upstream AI, ACP, agent UI, or sidebar architecture.
+- Do not restore Zed's docked Agent Panel or native text-thread product surface in the default build.
+- Do not expose Zed-hosted next-edit providers, Zeta defaults, Zeta telemetry, or Agent Metrics.
+- Do not adopt Parallel Agents, Threads Sidebar, worktree-thread orchestration, or agent metrics dashboards in this phase.
+- Do not include collaboration, calls, Business/team management, or DeltaDB work.
+- Do not treat general editor/search/terminal sync as part of this phase except where a candidate directly affects next-edit or ACP external-agent behavior.
+
+---
+
+## Key Decisions
+
+- Start with next-edit parity before ACP registry polish: the next-edit surface is already part of Superzent's default build and has a narrower validation path.
+- Treat ACP registry work as external-agent reliability, not product-shape migration: registry-installed agents should improve center-pane ACP tabs, not pull in the upstream Agent Panel.
+- Keep cherry-picks small and auditable: upstream 1.0 includes broad agentic product work, but Superzent should only absorb fixes that support its current product identity.
+- Preserve explicit provider boundaries: non-Zed-hosted provider support is in scope; Zed-hosted provider exposure is not.
+
+---
+
+## Dependencies / Assumptions
+
+- Zed 1.0 shipped on 2026-04-29 and emphasizes AI-native editing, multiple agents, edit predictions, and ACP.
+- Superzent's README defines the default app build as `lite + acp_tabs + next_edit` and explicitly excludes Zed-hosted AI surfaces, cloud collaboration, calls, the docked Agent Panel, and native text threads.
+- `docs/brainstorms/2026-04-05-default-build-next-edit-requirements.md` remains the baseline for default-build next-edit provider scope.
+- `docs/brainstorms/2026-04-23-upstream-sync-editor-search-requirements.md` remains the baseline for selective upstream sync and broad-agent/sidebar exclusion.
+- Planning must re-check whether each candidate is already present in Superzent under a different local commit or has been superseded by a Superzent-specific adaptation.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1-R3][Technical] Which shortlisted candidates cherry-pick cleanly, which are already present under different local commits, and which require Superzent-specific adaptation?
+- [Affects R5-R9][Technical] Which next-edit fixes are reachable in the default build without bringing in Zed-hosted provider UI or telemetry paths?
+- [Affects R10-R14][Technical] Which ACP registry and external-agent fixes fit Superzent's center-pane ACP tab flow without requiring the upstream Threads Sidebar or docked Agent Panel?
+- [Affects R8][Needs research] Does the OpenAI responses API update improve allowed provider behavior in Superzent, or is it too coupled to upstream hosted/model churn for this phase?

--- a/docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md
+++ b/docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md
@@ -1,0 +1,766 @@
+---
+title: "feat: Backport Zed 1.0 next-edit and ACP polish"
+type: feat
+status: active
+date: 2026-05-03
+origin: docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md
+---
+
+# Backport Zed 1.0 Next-Edit and ACP Polish
+
+## Overview
+
+Selectively backport Zed 1.0-era next-edit and ACP Registry/external-agent polish into
+Superzent without absorbing upstream hosted AI, telemetry, Agent Panel, Threads Sidebar, or broad
+agent architecture changes. The work should preserve Superzent's default build as
+`lite + acp_tabs + next_edit`, keep next-edit focused on non-Zed-hosted providers, and keep ACP
+workflows routed through center-pane external-agent tabs.
+
+This is not a full upstream sync. It is a commit/PR-level parity pass for the two surfaces that are
+already core to Superzent: default-build next-edit and external ACP agents.
+
+---
+
+## Problem Frame
+
+Zed 1.0 makes edit prediction and agent workflows first-class product surfaces. Superzent already
+has its own product split: next-edit is in the default build, while hosted AI and broader upstream
+agent surfaces remain outside the default experience. The useful sync opportunity is therefore not
+to import Zed's hosted AI model. It is to pull in the correctness fixes, provider setup polish, and
+external-agent reliability work that make Superzent's existing default surfaces feel current.
+
+The current repo already includes:
+
+- default feature split in `crates/zed/Cargo.toml`, with `default = ["lite", "acp_tabs",
+  "next_edit"]`
+- build-aware edit prediction provider policy in `crates/edit_prediction_ui/src/provider_policy.rs`
+- default-build edit prediction registry tests in `crates/zed/src/zed/edit_prediction_registry.rs`
+- center-pane ACP tab support and external-agent UI under `crates/agent_ui`
+- ACP process/session wiring under `crates/agent_servers`
+- registry/external-agent environment wiring under `crates/project/src/agent_server_store.rs`
+- local ACP debugging surface under `crates/acp_tools`
+
+The main risk is accidental product drift: some upstream commits near the desired fixes assume
+Zed-hosted providers, docked agent panels, native text threads, or newer ACP debug-view architecture.
+Every accepted change needs a Superzent boundary review before conflict resolution.
+
+---
+
+## Requirements Trace
+
+- R1. Use upstream commit or PR-level cherry-picks only; do not merge all of `upstream/main`.
+- R2. Start with the listed next-edit and ACP/external-agent candidates before broadening scope.
+- R3. Preserve Superzent's `lite + acp_tabs + next_edit` default build and `full` split.
+- R4. Do not add upstream docked Agent Panel, native text threads, Threads Sidebar, hosted Zed Agent,
+  cloud collaboration, calls, DeltaDB, or Zeta telemetry to the default build.
+- R5. Keep default-build next-edit centered on non-Zed-hosted providers.
+- R6. Improve provider setup/status entry points for Copilot, Codestral, and other supported
+  non-Zed-hosted providers.
+- R7. Backport next-edit correctness fixes that affect prediction preview, cursor movement,
+  completions, menus, or subtle mode.
+- R8. Only accept provider protocol/model updates when they improve supported providers without
+  exposing hosted Zed providers in the default build.
+- R9. Treat stale Zed-hosted provider settings in the default build as unsupported or unconfigured.
+- R10. Keep ACP Registry work limited to external ACP agents that users can install, update, debug,
+  or configure locally.
+- R11. Preserve center-pane ACP tab behavior for open, resume, and failure flows.
+- R12. Ensure external-agent execution context uses the active project/workspace rather than an
+  unrelated home-directory default when project context exists.
+- R13. Keep logging/debugging local; do not introduce telemetry.
+- R14. Preserve or improve ACP resume/history behavior only when it does not require the Threads
+  Sidebar or native text-thread architecture.
+- R15. Skip Zed-hosted Agent, Parallel Agents, Zeta telemetry, Business plan, collaboration, calls,
+  and DeltaDB changes in this phase.
+
+---
+
+## Scope Boundaries
+
+- Do not import Zed-hosted Agent, Parallel Agents, native text threads, Threads Sidebar, or the
+  docked upstream Agent Panel as default-build surfaces.
+- Do not enable Zed-hosted/Zeta edit prediction in the default build.
+- Do not perform a broad OpenAI-compatible provider protocol migration unless it is proven necessary
+  for a supported next-edit provider in this phase.
+- Do not rewrite ACP Registry as a marketplace or redesign its information architecture.
+- Do not rewrite ACP SDK/process/session architecture beyond what the accepted fixes require.
+- Do not edit `.rules` or policy files as part of the implementation. If a non-obvious recurring
+  pattern is discovered, propose it under "Suggested .rules additions" in the PR body.
+
+### Deferred to Separate Tasks
+
+- Broad ACP debug-view modernization if `73127da4b7` requires upstream's newer log-tap architecture
+  wholesale.
+- OpenAI Responses API adoption for general language model providers.
+- Zed-hosted provider copy, pricing, telemetry, and account flows.
+- Parallel-agent orchestration and native text-thread history import fixes.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/zed/Cargo.toml` already defines Superzent's default/full build split. Any feature-gate
+  changes must preserve default `next_edit` isolation from hosted AI/chat.
+- `crates/edit_prediction_ui/src/provider_policy.rs` centralizes supported provider policy and
+  already normalizes unsupported Zed-hosted providers to `None` when the hosted feature is disabled.
+- `crates/zed/src/zed/edit_prediction_registry.rs` already imports that provider policy and has
+  tests around supported provider assignment and stale provider configuration.
+- `crates/edit_prediction_ui/src/edit_prediction_button.rs` already has a common provider menu, but
+  upstream's Zed 1.0-era provider setup polish adds better `Configure Providers` entry points for
+  Copilot and Codestral menus.
+- `crates/editor/src/editor.rs` and `crates/editor/src/edit_prediction_tests.rs` are the main
+  surfaces for prediction preview, completions-menu, code-action-menu, and subtle-mode behavior.
+- `crates/agent_servers/src/acp.rs` currently opens ACP sessions without upstream's newer pending
+  session/ref-count handling, so replay/load/close concurrency fixes need manual adaptation.
+- `crates/agent_ui/src/conversation_view.rs` and `crates/agent_ui/src/agent_panel.rs` own the
+  center-pane external-agent conversation state that must survive load errors and process exits.
+- `crates/project/src/agent_server_store.rs` currently prepares local registry/custom agent
+  environments using a home-directory fallback in paths where project context should be preferred.
+- `crates/acp_tools/src/acp_tools.rs` has an older active-connection debug surface. Upstream ACP log
+  ring work may require a smaller Superzent-specific adaptation rather than a direct import.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`:
+  keep next-edit separate from hosted AI/chat boot, centralize provider policy, preserve setup-list
+  vs runtime-available-list separation, and normalize stale `provider: "zed"` outside full builds.
+- `docs/solutions/best-practices/gpui-window-reborrow-and-cross-workspace-item-transfer-2026-04-21.md`:
+  avoid `WindowHandle::*` re-borrows from render/action paths; center-pane ACP UI changes should use
+  existing GPUI entity/window patterns and weak handles where async work crosses windows.
+- Existing upstream-sync plans in `docs/plans/` use wave-based candidate acceptance with explicit
+  defer gates. This plan follows that pattern because several Zed 1.0 candidates are useful only if
+  they can be adapted without broad product drift.
+
+### Upstream Candidate Notes
+
+Active next-edit candidates:
+
+- `a7ca17fcb2` edit_prediction_ui: Add configure providers menu item to Copilot and Codestral
+  (#53691)
+- `7a6a95c2cd` editor: Fix edit predictions polluting completions menu (#50403)
+- `8b822f9e10` Fix regression preventing new predictions from being previewed in subtle mode
+  (#51887)
+- `db7bc734e2` Fix ep preview closing menus (#54194)
+
+Active ACP/external-agent candidates:
+
+- `f7ab907216` Fix agent servers loading environment from home dir instead of project dir (#52763)
+- `2ca94a6032` acp: Register ACP sessions before load replay (#54431)
+- `102805a73f` agent_ui: Preserve session resume state after load errors (#54411)
+- `a5e78b02de` Fix double borrow panic when ACP process dies (#54135)
+- `73127da4b7` acp_tools: Always capture ACP transport and stderr into the log ring (#54536)
+
+Evaluate/defer candidates:
+
+- `2460a5c5df` ep: Fix moving cursor to a predicted position (#55079), because it primarily touches
+  hosted Zeta/V3 response handling.
+- `57e01b3701` and `f051447a8d`, because they are hosted-model/provider-protocol changes with
+  broader language model blast radius.
+- `6e900b43ec` and `c91b917383`, because their upstream target file is absent in the current
+  Superzent tree and the behavior appears superseded or differently located.
+- `1c1b03c3d6`, `07e9a2d25a`, `d1177dc43`, `8f0826f543`, `3ee2f5b811`, and `809e701163`, because
+  they may be useful follow-ups but touch broader ACP debug, runtime, auth, registry UI, or project
+  surfaces than the core phase requires.
+
+### External References
+
+- Zed 1.0 announcement: `https://zed.dev/blog/zed-1-0`
+- ACP Registry announcement: `https://zed.dev/blog/acp-registry`
+- Parallel Agents announcement: `https://zed.dev/blog/parallel-agents` (exclusion context only)
+
+---
+
+## Key Technical Decisions
+
+- **Next-edit first, ACP second.** Land next-edit provider UX and editor correctness before ACP
+  reliability work because next-edit is already in the default build and has narrower focused test
+  surfaces.
+- **Provider policy remains centralized.** Any provider-list or runtime-assignment change must go
+  through the existing provider policy split rather than reintroducing local ad hoc filtering.
+- **Editor correctness fixes are accepted when provider-neutral.** Completions-menu, code-action
+  menu, subtle-preview, keymap, and preview cleanup fixes should apply to the editor surface without
+  depending on hosted Zed providers.
+- **Hosted/provider-protocol commits require a default-build gate.** If a candidate's user-visible
+  value only exists for Zeta, hosted models, telemetry, or cloud language model surfaces, defer it.
+- **External-agent environment must prefer project context.** Registry/custom/npx/archive agents
+  should launch with active project/workspace environment when available, preserving existing
+  fallback behavior only when project context cannot be derived.
+- **ACP session reliability should adapt, not transplant, newer upstream architecture.** Import the
+  behavior around pending load sessions, resume-state preservation, and process-death failure
+  reporting while keeping Superzent's center-pane ACP tab model.
+- **ACP logging is a gated trial.** Capture transport and stderr into local bounded logs if it can
+  be done without a broad debug-view rewrite; otherwise document it as follow-up.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this start with Zed 1.0's edit prediction/ACP polish or larger upstream agent features?**
+  Start with next-edit and ACP polish only.
+- **Should the phase include Zed-hosted Agent, Zeta telemetry, or Parallel Agents?** No. These are
+  out of scope for the default build.
+- **Should ACP Registry polish be treated as a new product surface?** No. It should validate and
+  improve the existing external-agent install/update/debug path.
+- **Should `73127da4b7` be mandatory?** No. It is accepted only if it can be adapted without pulling
+  a broad ACP debug-view rewrite.
+
+### Deferred to Implementation
+
+- Which upstream commits cherry-pick cleanly versus require manual adaptation.
+- Whether `2460a5c5df` has any provider-neutral value for Superzent after hosted Zeta paths are
+  excluded.
+- Whether ACP log-ring support can be implemented as a small local capture layer over the current
+  `acp_tools` surface.
+- Whether any registry version-notification or registry-website polish is low-risk enough to include
+  after the core ACP reliability fixes land.
+
+---
+
+## High-Level Technical Design
+
+> This diagram is directional guidance for execution review. It is not an implementation recipe.
+
+```mermaid
+flowchart TD
+    A[U1 Preflight candidate and boundary map] --> B[U2 Provider setup menu parity]
+    B --> C[U3 Editor next-edit correctness]
+    C --> D[U4 Hosted/protocol candidate gate]
+    D --> E[U5 External-agent env/cwd correctness]
+    E --> F[U6 ACP session lifecycle reliability]
+    F --> G[U7 ACP debug and registry polish gate]
+    G --> H[U8 Default/full build and docs verification]
+    D -->|hosted only| X[Defer candidate]
+    G -->|broad debug rewrite needed| Y[Defer candidate]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Preflight candidate map and Superzent boundary gates**
+
+  **Goal:** Establish the accepted, deferred, and trial candidate set before any code change lands.
+
+  **Requirements:** R1, R2, R3, R4, R8, R15
+
+  **Dependencies:** None
+
+  **Files:**
+
+  - Read: `docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md`
+  - Read: `README.md`
+  - Read: `crates/zed/Cargo.toml`
+  - Read: `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`
+  - Read: `docs/solutions/best-practices/gpui-window-reborrow-and-cross-workspace-item-transfer-2026-04-21.md`
+
+  **Approach:**
+
+  - Confirm worktree state and record any pre-existing unrelated changes before code edits.
+  - For each candidate commit, inspect the upstream file list before applying it.
+  - Classify candidates as accepted, adapted, already-present, superseded, or deferred.
+  - Stop and reclassify any candidate that unexpectedly touches hosted AI, Agent Panel, Threads
+    Sidebar, cloud/collab/calls, or broad language model infrastructure.
+
+  **Patterns to follow:**
+
+  - Existing upstream-sync wave planning in
+    `docs/plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md`
+  - Default-build provider policy learning in
+    `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`
+
+  **Test scenarios:**
+
+  - No behavioral tests are expected for this unit; it is a preflight and classification unit.
+
+  **Verification:**
+
+  - Candidate order, accepted/deferred classification, and Superzent-specific hard gates are visible
+    in execution notes or the PR body before implementation proceeds.
+
+- U2. **Backport next-edit provider setup menu parity**
+
+  **Goal:** Improve provider discovery and setup entry points for supported non-Zed-hosted
+  next-edit providers.
+
+  **Requirements:** R5, R6, R8, R9
+
+  **Dependencies:** U1
+
+  **Candidate order:**
+
+  - `a7ca17fcb2` edit_prediction_ui: Add configure providers menu item to Copilot and Codestral
+    (#53691)
+
+  **Files:**
+
+  - Modify: `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+  - Test: `crates/edit_prediction_ui/src/edit_prediction_button.rs` or the nearest existing UI/menu
+    coverage if this module has no practical component test harness
+
+  **Approach:**
+
+  - Adapt upstream's provider-menu entry point polish to the current Superzent
+    `edit_prediction_button` structure.
+  - Keep the existing provider policy split as the source of truth for whether Zed-hosted providers
+    are visible.
+  - Ensure Copilot and Codestral menus include a clear path to provider configuration without
+    surfacing hosted Zed provider options in the default build.
+  - Preserve full-build hosted-provider behavior where it is already feature-gated.
+
+  **Patterns to follow:**
+
+  - Existing provider menu construction in `crates/edit_prediction_ui/src/edit_prediction_button.rs`
+  - Existing provider filtering in `crates/edit_prediction_ui/src/provider_policy.rs`
+
+  **Test scenarios:**
+
+  - Happy path: Copilot and Codestral provider menus expose provider configuration from the default
+    build.
+  - Edge case: default-build provider menus do not expose Zed-hosted provider setup.
+  - Edge case: stale `provider: "zed"` settings still route users toward supported provider setup
+    rather than an unusable hosted state.
+  - Integration: full builds keep any existing hosted-provider feature-gated behavior.
+
+  **Verification:**
+
+  - Provider setup entry points exist for supported providers in default builds.
+  - Provider lists and runtime availability still agree with the central provider policy.
+
+- U3. **Backport editor next-edit menu and preview correctness**
+
+  **Goal:** Fix editor-level next-edit regressions around completions menus, code-action menus,
+  subtle preview mode, and preview keybindings.
+
+  **Requirements:** R5, R7, R9
+
+  **Dependencies:** U1, U2
+
+  **Candidate order:**
+
+  - `7a6a95c2cd` editor: Fix edit predictions polluting completions menu (#50403)
+  - `8b822f9e10` Fix regression preventing new predictions from being previewed in subtle mode
+    (#51887)
+  - `db7bc734e2` Fix ep preview closing menus (#54194)
+
+  **Files:**
+
+  - Modify: `crates/editor/src/editor.rs`
+  - Modify: `crates/editor/src/edit_prediction_tests.rs`
+  - Modify: `assets/keymaps/default-linux.json`
+  - Modify: `assets/keymaps/default-macos.json`
+  - Modify: `assets/keymaps/default-windows.json`
+  - Modify: `assets/keymaps/vim.json`
+  - Test: `crates/editor/src/edit_prediction_tests.rs`
+
+  **Approach:**
+
+  - Apply or manually adapt the editor fixes in dependency order so preview/keymap behavior is
+    tested against the current editor state.
+  - Preserve current editor action contexts and Superzent keymap behavior while adapting upstream's
+    subtle-preview and accept-keybinding changes.
+  - Treat prediction preview behavior as provider-neutral editor behavior, not hosted-provider
+    behavior.
+  - Add focused coverage for the specific menu and preview regressions rather than broad editor
+    refactors.
+
+  **Patterns to follow:**
+
+  - Existing edit prediction tests in `crates/editor/src/edit_prediction_tests.rs`
+  - GPUI test timer guidance from `AGENTS.md` when async timing or delayed preview behavior is
+    involved
+
+  **Test scenarios:**
+
+  - Happy path: hidden edit predictions no longer open or pollute snippet/completions menus for
+    weak single-word input.
+  - Happy path: strong snippet-prefix matches still open the intended snippet/completions menu.
+  - Edge case: new predictions arriving while subtle-preview modifiers are held become visible.
+  - Edge case: edit prediction preview does not close code-action menus.
+  - Edge case: completions menus may still be superseded where that is the intended editor
+    behavior.
+  - Integration: default keymaps keep accept/preview behavior aligned with eager versus subtle edit
+    prediction modes.
+
+  **Verification:**
+
+  - Focused editor edit-prediction tests cover each imported correctness fix.
+  - Keymap changes compile and do not reintroduce hosted-provider assumptions.
+
+- U4. **Gate hosted/provider-protocol candidates against default-build policy**
+
+  **Goal:** Evaluate nearby upstream provider changes without accidentally importing hosted Zed or
+  broad language model behavior into the default build.
+
+  **Requirements:** R3, R5, R8, R9, R15
+
+  **Dependencies:** U1, U2, U3
+
+  **Candidate order:**
+
+  - Evaluate: `2460a5c5df` ep: Fix moving cursor to a predicted position (#55079)
+  - Defer by default: `57e01b3701` hosted-model copy changes
+  - Defer by default: `f051447a8d` OpenAI Responses API provider migration
+
+  **Files:**
+
+  - Inspect: `crates/cloud_llm_client/src/predict_edits_v3.rs`
+  - Inspect: `crates/edit_prediction/src/zeta.rs`
+  - Inspect: `crates/edit_prediction/src/edit_prediction_tests.rs`
+  - Inspect: `crates/language_models/src/provider/cloud.rs`
+  - Inspect: `crates/language_models/src/provider/open_ai.rs`
+  - Inspect: `crates/open_ai/src/open_ai.rs`
+  - Inspect: `crates/edit_prediction_ui/src/provider_policy.rs`
+  - Inspect: `crates/zed/src/zed/edit_prediction_registry.rs`
+
+  **Approach:**
+
+  - Treat `2460a5c5df` as accepted only if the cursor-position behavior benefits a supported,
+    default-build provider path without exposing hosted Zeta in UI or runtime.
+  - Keep hosted-model copy changes out of scope unless current default-build UI exposes misleading
+    hosted-provider copy.
+  - Keep OpenAI Responses API migration out of scope unless a supported next-edit provider is
+    broken without it.
+  - Record the decision for each candidate in execution notes or the PR body so future sync passes
+    know whether it was skipped, superseded, or intentionally deferred.
+
+  **Patterns to follow:**
+
+  - Provider policy boundary in `crates/edit_prediction_ui/src/provider_policy.rs`
+  - Default-build registry tests in `crates/zed/src/zed/edit_prediction_registry.rs`
+
+  **Test scenarios:**
+
+  - If accepted: cursor placement tests cover the provider-neutral behavior without requiring hosted
+    Zeta in the default build.
+  - If deferred: no new behavior tests are required, but the defer reason is recorded.
+  - Regression: default build still normalizes unsupported hosted provider settings to
+    unconfigured.
+
+  **Verification:**
+
+  - Default-build provider policy remains intact after evaluating hosted/provider-protocol
+    candidates.
+  - No hosted provider surface appears in default-build setup, status, or runtime paths.
+
+- U5. **Backport external-agent environment and cwd correctness**
+
+  **Goal:** Launch external ACP agents with the active project/workspace environment when project
+  context exists.
+
+  **Requirements:** R10, R12, R13
+
+  **Dependencies:** U1
+
+  **Candidate order:**
+
+  - `f7ab907216` Fix agent servers loading environment from home dir instead of project dir (#52763)
+  - Evaluate after core fix: `07e9a2d25a` node runtime/npm registry launch polish
+
+  **Files:**
+
+  - Modify: `crates/project/src/environment.rs`
+  - Modify: `crates/project/src/agent_server_store.rs`
+  - Test: `crates/project/src/environment.rs`
+  - Test: `crates/project/src/agent_server_store.rs` or the nearest existing project integration
+    tests for extension/external agents
+  - Optional: `crates/node_runtime/src/node_runtime.rs` if the npm launch polish is accepted
+
+  **Approach:**
+
+  - Add or adapt a project-default environment lookup that prefers the active visible worktree or
+    equivalent project context.
+  - Replace home-directory environment loading for local registry, archive, custom, and npx ACP
+    agents where project context is available.
+  - Preserve existing environment merge precedence and fallback behavior when no project worktree is
+    available.
+  - Evaluate npm/node runtime polish only after the project-context fix is stable, and defer it if
+    it broadens into unrelated node runtime behavior.
+
+  **Patterns to follow:**
+
+  - Existing `ProjectEnvironment` lookup methods in `crates/project/src/environment.rs`
+  - Existing local registry/custom agent launch paths in `crates/project/src/agent_server_store.rs`
+
+  **Test scenarios:**
+
+  - Happy path: a local registry/custom/npx ACP agent launched from a project uses that project's
+    environment.
+  - Edge case: no visible project worktree falls back to existing safe behavior.
+  - Edge case: extra environment variables and agent-specific settings keep their expected
+    precedence.
+  - Integration: center-pane ACP agent launch observes project environment without requiring Agent
+    Panel.
+
+  **Verification:**
+
+  - External agents no longer load from home-directory environment when project context exists.
+  - ACP launch remains local and does not introduce telemetry or hosted service dependencies.
+
+- U6. **Backport ACP session lifecycle reliability**
+
+  **Goal:** Make ACP session load, replay, retry, and process-death paths reliable in center-pane
+  external-agent tabs.
+
+  **Requirements:** R10, R11, R13, R14
+
+  **Dependencies:** U1, U5
+
+  **Candidate order:**
+
+  - `2ca94a6032` acp: Register ACP sessions before load replay (#54431)
+  - `102805a73f` agent_ui: Preserve session resume state after load errors (#54411)
+  - `a5e78b02de` Fix double borrow panic when ACP process dies (#54135)
+
+  **Files:**
+
+  - Modify: `crates/agent_servers/src/acp.rs`
+  - Modify: `crates/agent_servers/src/agent_servers.rs`
+  - Modify: `crates/agent_servers/Cargo.toml`
+  - Modify: `crates/agent_ui/src/agent_panel.rs`
+  - Modify: `crates/agent_ui/src/conversation_view.rs`
+  - Modify: `crates/agent_ui/Cargo.toml`
+  - Modify: `Cargo.lock`
+  - Test: `crates/agent_servers/src/acp.rs`
+  - Test: `crates/agent_ui/src/conversation_view.rs`
+
+  **Approach:**
+
+  - Adapt upstream's pending-session and replay-order behavior to Superzent's current ACP connection
+    types.
+  - Preserve session resume metadata across load failures so retrying a failed external-agent tab
+    resumes the intended session instead of creating a new one.
+  - Convert ACP process death into visible load/failure state without double-borrow panics.
+  - Keep the UI path aligned with center-pane ACP tabs and avoid making the docked Agent Panel a new
+    default-build dependency.
+  - Review new test dependencies carefully; accept them only when they are limited to test support
+    or necessary fake ACP server coverage.
+
+  **Patterns to follow:**
+
+  - Existing ACP session storage in `crates/agent_servers/src/acp.rs`
+  - Existing center-pane conversation tests in `crates/agent_ui/src/conversation_view.rs`
+  - GPUI entity update rules from `AGENTS.md`, especially avoiding nested updates on the same entity
+
+  **Test scenarios:**
+
+  - Happy path: replay notifications that arrive before load completion are retained and displayed.
+  - Edge case: concurrent load attempts for the same ACP session do not create duplicate sessions or
+    lose replayed updates.
+  - Edge case: closing a tab while load is in flight does not orphan an ACP session.
+  - Edge case: retrying after a load error preserves original session metadata and resumes the
+    intended session.
+  - Edge case: ACP server process exit transitions the view into a visible failure state without a
+    panic.
+
+  **Verification:**
+
+  - ACP session lifecycle tests cover replay, close-during-load, retry-after-load-error, and
+    process-death behavior.
+  - Center-pane ACP tab open/resume/failure flows work without enabling upstream native text
+    threads or docked Agent Panel behavior.
+
+- U7. **Trial ACP debug logging and small registry polish**
+
+  **Goal:** Improve local debugging for external ACP agents and include only low-risk registry polish
+  that fits current Superzent architecture.
+
+  **Requirements:** R10, R11, R13, R14, R15
+
+  **Dependencies:** U1, U5, U6
+
+  **Candidate order:**
+
+  - Trial: `73127da4b7` acp_tools: Always capture ACP transport and stderr into the log ring (#54536)
+  - Evaluate only if needed for the trial: `1c1b03c3d6` ACP debug view modernization
+  - Optional low-risk polish: `3ee2f5b811` registry websites page
+  - Optional low-risk polish: `809e701163` registry new-version notification polish
+  - Superseded/defer: `6e900b43ec`, `c91b917383`, `d1177dc43`, `8f0826f543`
+
+  **Files:**
+
+  - Modify: `crates/acp_tools/src/acp_tools.rs`
+  - Modify: `crates/acp_tools/Cargo.toml`
+  - Modify: `crates/agent_servers/src/acp.rs`
+  - Modify: `crates/agent_servers/src/agent_servers.rs`
+  - Modify: `crates/agent_servers/Cargo.toml`
+  - Optional: `crates/agent_ui/src/agent_connection_store.rs`
+  - Optional: `crates/agent_ui/src/agent_registry_ui.rs`
+  - Optional: `crates/project/src/agent_registry_store.rs`
+  - Optional: `crates/project/src/agent_server_store.rs`
+  - Test: `crates/acp_tools/src/acp_tools.rs`
+  - Test: nearest existing registry/external-agent UI or project integration coverage
+
+  **Approach:**
+
+  - First determine whether transport/stderr capture can be layered onto the current
+    `AcpConnectionRegistry` and debug surface without importing the entire newer debug-view model.
+  - If feasible, capture ACP transport and process stderr into a bounded local log buffer that is
+    available even when the log view is opened after the failure.
+  - Keep logging local to the user's machine and avoid telemetry or remote reporting.
+  - Accept registry website/version polish only if it does not require broader registry store or UI
+    migrations.
+  - Record explicit defer reasons for thread-import, terminal-auth, and broad agent cwd candidates
+    when they do not fit the current tree or phase scope.
+
+  **Patterns to follow:**
+
+  - Current ACP debug surface in `crates/acp_tools/src/acp_tools.rs`
+  - Local-only logging requirement from the brainstorm requirements
+  - Existing registry UI/store patterns in `crates/agent_ui` and `crates/project`
+
+  **Test scenarios:**
+
+  - Happy path: ACP transport messages emitted before opening the logs view are still available.
+  - Happy path: ACP process stderr is captured in local debug logs.
+  - Edge case: the log buffer is bounded and does not grow without limit.
+  - Edge case: opening a new active ACP connection clears or scopes logs so stale logs are not
+    confused with the current connection.
+  - Optional: registry website/version polish is covered only if those candidates are accepted.
+
+  **Verification:**
+
+  - Debug logs help diagnose external-agent startup and transport failures without telemetry.
+  - Any candidate that requires a broad ACP debug-view rewrite is deferred rather than forced into
+    this phase.
+
+- U8. **Final default/full build verification and documentation updates**
+
+  **Goal:** Confirm the accepted backports preserve Superzent's feature split and update user-facing
+  docs only where behavior actually changed.
+
+  **Requirements:** R3, R4, R5, R10, R11, R13, R15
+
+  **Dependencies:** U2, U3, U4, U5, U6, U7
+
+  **Files:**
+
+  - Verify: `crates/zed/Cargo.toml`
+  - Verify: `README.md`
+  - Optional docs: `docs/src/ai/edit-prediction.md`
+  - Optional docs: `docs/src/ai/external-agents.md`
+  - Optional docs: `docs/src/extensions/agent-servers.md`
+  - Optional docs: `docs/src/getting-started.md`
+  - Optional docs: `docs/src/development.md`
+
+  **Approach:**
+
+  - Confirm default and full feature sets still compile after accepted next-edit and ACP changes.
+  - Run focused next-edit, ACP session, external-agent environment, and ACP debug tests that match
+    accepted candidates.
+  - Update docs only if user-visible behavior or setup paths changed. Follow `docs/AGENTS.md` for
+    any `docs/src` edits.
+  - In the PR body, summarize accepted, adapted, already-present, and deferred upstream candidates.
+  - Include release notes that describe user-facing next-edit/provider or external-agent reliability
+    improvements, or `N/A` if the final diff is purely internal.
+
+  **Patterns to follow:**
+
+  - Pull request hygiene from `AGENTS.md`
+  - Existing docs tone and scope under `docs/src`
+
+  **Test scenarios:**
+
+  - Integration: default build includes next-edit and ACP tabs without hosted AI/chat surfaces.
+  - Integration: full build still compiles with hosted/full-only behavior available behind its
+    existing feature gates.
+  - Regression: editor next-edit tests, ACP session tests, and external-agent environment tests pass
+    together.
+  - Documentation: any changed setup path is reflected in docs without describing out-of-scope Zed
+    hosted surfaces as supported defaults.
+
+  **Verification:**
+
+  - Default/full build feature split is unchanged in intent.
+  - Focused tests pass for all accepted candidates.
+  - Documentation and PR notes clearly separate accepted backports from deferred upstream features.
+
+---
+
+## System-Wide Impact
+
+- **Feature gates:** Default build remains `lite + acp_tabs + next_edit`; full remains the place for
+  broader upstream AI/collab behavior.
+- **Provider policy:** `provider_policy.rs` remains the authority for default-build edit prediction
+  provider support.
+- **Editor behavior:** Prediction preview, completions menus, and keymaps change in editor-global
+  code, so focused regression tests are required even though the feature is next-edit-specific.
+- **Project environment:** External-agent launch paths may now observe project environment more
+  accurately, affecting custom, registry, archive, and npx ACP agents.
+- **ACP sessions:** Session load/replay/failure semantics become more explicit and may add test-only
+  fake server support.
+- **Debug logs:** If accepted, ACP logs become buffered locally before the debug view opens; this
+  should improve diagnosis without creating telemetry.
+
+---
+
+## Risks and Mitigations
+
+- **Risk: upstream commits assume newer agent UI or ACP abstractions.**
+  Mitigation: inspect file lists first, adapt behavior to current Superzent center-pane ACP flow, and
+  defer candidates that require broad architecture import.
+- **Risk: hosted-provider changes leak into the default build.**
+  Mitigation: run all provider changes through the existing provider policy and verify default-build
+  provider lists exclude hosted Zed paths.
+- **Risk: keymap changes alter general editor behavior.**
+  Mitigation: keep keymap edits tied to edit prediction mode contexts and cover eager/subtle preview
+  behavior in focused editor tests.
+- **Risk: ACP session lifecycle fixes introduce entity reborrow or nested-update bugs.**
+  Mitigation: follow GPUI entity/window rules, add fake-server tests for process death and load
+  errors, and avoid nested updates on the same entity.
+- **Risk: ACP logging trial expands into a debug-view rewrite.**
+  Mitigation: make `73127da4b7` a gated trial and document a defer decision if a minimal adaptation
+  is not viable.
+- **Risk: project environment changes affect unrelated agent launch flows.**
+  Mitigation: preserve fallback behavior and test project-context, no-project, and extra-env
+  precedence cases.
+
+---
+
+## Verification Strategy
+
+- Focused next-edit provider menu coverage confirms provider setup entry points and provider policy
+  remain aligned.
+- Focused editor edit-prediction tests cover completions-menu pollution, subtle preview, code-action
+  menu preservation, and keymap mode behavior.
+- Focused project/external-agent environment tests cover project-context environment selection and
+  fallback behavior.
+- Focused ACP session tests cover replay-before-load, concurrent load, close-during-load,
+  retry-after-load-error, and ACP process exit.
+- ACP debug tests cover local transport/stderr capture if the log-ring trial is accepted.
+- Default and full build checks confirm feature-gate boundaries still compile.
+- Project clippy verification should use `./script/clippy` rather than raw `cargo clippy`.
+
+---
+
+## Documentation and PR Notes
+
+- Update docs only for user-visible provider setup, external-agent environment, registry, or local
+  ACP debugging behavior that changes.
+- If docs under `docs/src` are edited, follow `docs/AGENTS.md` and format them with the docs
+  Prettier workflow.
+- In the PR body, include a short accepted/deferred candidate table so reviewers can see why hosted
+  Zed Agent, Zeta, provider protocol, or broader ACP architecture commits were not imported.
+- If a non-obvious repeatable rule emerges during execution, propose it under a "Suggested .rules
+  additions" heading in the PR body rather than editing policy files directly.
+
+---
+
+## Sources and References
+
+- Origin requirements:
+  `docs/brainstorms/2026-05-03-zed-1-0-next-edit-acp-registry-sync-requirements.md`
+- Related plan:
+  `docs/plans/2026-04-05-001-feat-default-build-next-edit-plan.md`
+- Related plan:
+  `docs/plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md`
+- Default-build next-edit learning:
+  `docs/solutions/integration-issues/default-build-next-edit-surface-restoration-2026-04-05.md`
+- GPUI/window learning:
+  `docs/solutions/best-practices/gpui-window-reborrow-and-cross-workspace-item-transfer-2026-04-21.md`
+- Product/build context: `README.md`
+- Zed 1.0 announcement: `https://zed.dev/blog/zed-1-0`
+- ACP Registry announcement: `https://zed.dev/blog/acp-registry`
+- Parallel Agents announcement: `https://zed.dev/blog/parallel-agents`

--- a/docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md
+++ b/docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md
@@ -32,7 +32,7 @@ external-agent reliability work that make Superzent's existing default surfaces 
 The current repo already includes:
 
 - default feature split in `crates/zed/Cargo.toml`, with `default = ["lite", "acp_tabs",
-  "next_edit"]`
+"next_edit"]`
 - build-aware edit prediction provider policy in `crates/edit_prediction_ui/src/provider_policy.rs`
 - default-build edit prediction registry tests in `crates/zed/src/zed/edit_prediction_registry.rs`
 - center-pane ACP tab support and external-agent UI under `crates/agent_ui`

--- a/docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md
+++ b/docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md
@@ -14,7 +14,8 @@ severity: medium
 related_components:
   - tooling
   - testing_framework
-tags: [acp, agent-ui, agent-servers, acp-tools, stderr, close-session, lifecycle]
+tags:
+  [acp, agent-ui, agent-servers, acp-tools, stderr, close-session, lifecycle]
 ---
 
 # ACP lifecycle fixes must cover diagnostics and pending-session teardown

--- a/docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md
+++ b/docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md
@@ -1,0 +1,146 @@
+---
+title: ACP lifecycle fixes must cover diagnostics and pending-session teardown
+date: 2026-05-04
+category: integration-issues
+module: ACP agent integration
+problem_type: integration_issue
+component: assistant
+symptoms:
+  - ACP Logs showed transport stream messages but not process stderr emitted by the active agent
+  - Closing a loading ACP tab could leave the remote session open because `close_session` only ran after the view reached Connected
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: medium
+related_components:
+  - tooling
+  - testing_framework
+tags: [acp, agent-ui, agent-servers, acp-tools, stderr, close-session, lifecycle]
+---
+
+# ACP lifecycle fixes must cover diagnostics and pending-session teardown
+
+## Problem
+
+ACP integration work crossed three surfaces: the server process wrapper, the ACP Logs tool, and the conversation view lifecycle. Two workflow steps were easy to miss during the sync: stderr emitted by an active ACP process was only written to the Rust log, and closing a tab while an existing session was still loading did not call `close_session`.
+
+## Symptoms
+
+- The ACP Logs panel could replay ACP stream messages from the registry backlog, but process stderr was invisible there.
+- The stderr task in `crates/agent_servers/src/acp.rs` called `log::warn!` and then discarded the line.
+- `ConversationView::on_release` closed sessions only after the view reached `Connected`.
+- Loading an existing ACP session and immediately closing the tab could leave the provider-side session alive.
+
+## What Didn't Work
+
+- Relying on `log::warn!` for stderr was not enough. The ACP Logs tool subscribes to `AcpConnectionRegistry`, so anything that does not enter that registry is not replayed in the tool backlog.
+- Capturing only `connection.subscribe()` traffic covered protocol stream messages, but stderr is process I/O and has to be explicitly converted into a log entry.
+- Adding pending-session tracking inside `AcpConnection` did not protect the UI release path by itself. If `ConversationView::on_release` never calls `close_session` while the view is still `Loading`, the connection-level cleanup code is never reached.
+- A broad session-history search surfaced upstream context that ACP transport and stderr were intended to be captured into a log ring, but the local branch still had a server-side stderr task that only warned and cleared each line (session history).
+
+## Solution
+
+Route stderr through the same active-connection registry used by ACP stream messages, and make the loading view retain the resolved connection long enough for `on_release` to close a pending session.
+
+For diagnostics, model the registry backlog as log entries instead of only stream messages:
+
+```rust
+#[derive(Clone)]
+enum AcpLogEntry {
+    Stream(acp::StreamMessage),
+    Stderr { line: SharedString },
+}
+```
+
+Then record stderr only when it belongs to the currently active connection:
+
+```rust
+pub fn record_stderr_line(
+    &self,
+    connection: &Weak<acp::ClientSideConnection>,
+    line: impl Into<SharedString>,
+) {
+    let is_active = self
+        .active_connection
+        .borrow()
+        .as_ref()
+        .is_some_and(|active_connection| {
+            Weak::ptr_eq(&active_connection.connection, connection)
+        });
+    if !is_active {
+        return;
+    }
+
+    self.record_stderr_entry(line);
+}
+```
+
+The stderr task now runs on the foreground executor so it can update the GPUI entity, and it passes a weak connection identity into the registry:
+
+```rust
+let stderr_task = cx.spawn({
+    let connection_registry = connection_registry.clone();
+    let connection_weak = Rc::downgrade(&connection);
+    async move |cx| {
+        let mut stderr = BufReader::new(stderr);
+        let mut line = String::new();
+        while let Ok(n) = stderr.read_line(&mut line).await
+            && n > 0
+        {
+            let stderr_line = line.trim().to_string();
+            log::warn!("agent stderr: {}", stderr_line);
+            connection_registry.update(cx, |registry, _| {
+                registry.record_stderr_line(&connection_weak, stderr_line)
+            });
+            line.clear();
+        }
+        Ok(())
+    }
+});
+```
+
+For pending-session teardown, store the resolved connection in `LoadingView`:
+
+```rust
+struct LoadingView {
+    session_id: Option<acp::SessionId>,
+    connection: Rc<RefCell<Option<Rc<dyn AgentConnection>>>>,
+    _load_task: Task<()>,
+}
+```
+
+Then close a loading session from the release hook when the connection has resolved and the agent supports close:
+
+```rust
+} else if let ServerState::Loading(loading) = &this.server_state {
+    loading.update(cx, |loading, cx| {
+        if let Some(session_id) = loading.session_id.as_ref()
+            && let Some(connection) = loading.connection.borrow().clone()
+            && connection.supports_close_session()
+        {
+            connection
+                .close_session(session_id, cx)
+                .detach_and_log_err(cx);
+        }
+    });
+}
+```
+
+## Why This Works
+
+ACP Logs has one source of truth: `AcpConnectionRegistry`. By widening the registry backlog from `StreamMessage` to `AcpLogEntry`, stream traffic and stderr follow the same backlog and subscriber path. The active-connection guard prevents a stale stderr reader from appending lines after another agent connection becomes active.
+
+The loading-session fix closes the missing UI lifecycle step. A session load starts only after the connection resolves, so the loading view stores that connection once it exists. If the user closes the tab before the view transitions to `Connected`, `on_release` can still call `close_session` for the pending `session_id`.
+
+## Prevention
+
+- When adding ACP diagnostics, test the data source that the ACP Logs UI actually subscribes to. `registry_backlog_includes_stderr_lines` guards that stderr is retained in the backlog, not merely written to process logs.
+- When adding connection lifecycle cleanup, test the UI state that triggers cleanup. `test_loading_view_close_closes_pending_session` covers the case where `ConversationView` is released before the session load future completes.
+- Treat provider-side cleanup as a two-part contract: the connection implementation can support `close_session`, but every UI release path that owns a session id still has to call it.
+- For process I/O readers that outlive UI state changes, include an identity check before appending to global or shared diagnostic state.
+
+## Related Issues
+
+- Plan context: [Backport Zed 1.0 Next-Edit and ACP Polish](../../plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md) is the direct planning artifact for this sync.
+- Broader sync context: [Backport Upstream Editor and Search Improvements](../../plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md) explains the selective upstream-sync constraints that make ACP changes require Superzent boundary review.
+- Low-overlap related doc: [Restoring default-build next-edit requires separating it from hosted AI surfaces](./default-build-next-edit-surface-restoration-2026-04-05.md) mentions `acp_tabs`, but covers feature gating rather than ACP lifecycle cleanup.
+- Session history surfaced upstream ACP debug/log work, including `73127da4b7 acp_tools: Always capture ACP transport and stderr into the log ring (#54536)` and `1c1b03c3 acp: Improve ACP debug view (#54769)`. These explain why local stderr and debug-view wiring should be treated as part of one diagnostics path.


### PR DESCRIPTION
## Summary

Backports the Zed 1.0-era next-edit and external ACP agent polish that fits Superzent's existing product boundaries. The default build keeps next-edit separate from hosted AI/chat surfaces, while provider setup, edit prediction acceptance, ACP process context, session loading, and local diagnostics get the reliability fixes needed for the current shell.

This is a selective sync rather than a broad upstream merge. It keeps ACP workflows in center-pane external-agent tabs and avoids importing upstream Agent Panel, Threads Sidebar, hosted Zed Agent, collaboration, calls, DeltaDB, or Zeta telemetry into the default experience.

## What Changed

- Improved edit prediction provider menus and keybindings so configured providers are easier to reach without reopening hosted AI surfaces.
- Fixed edit prediction preview/completion-menu conflicts, including conflict key contexts and regression coverage for preview behavior.
- Runs external ACP agents from the active project/workspace context instead of falling back to an unrelated directory when project context is available.
- Added ACP session load lifecycle handling so loaded sessions stay tracked until their last close, including close calls during in-flight loads.
- Preserves ACP log history before the ACP Logs panel opens, then routes active-process stderr into the same ACP log backlog/subscriber path as protocol traffic.
- Closes pending loading sessions from `ConversationView::on_release` when a tab is released before the view reaches `Connected`.
- Captures the ACP lifecycle learning in `docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md`.

## Verification

- `cargo check -p project --all-targets`
- `cargo check -p agent_servers -p acp_tools -p editor --all-targets`
- `cargo check -p acp_tools -p agent_servers -p agent_ui --all-targets`
- `cargo test -p agent_servers acp::tests`
- `cargo test -p acp_tools registry_backlog_includes_stderr_lines`
- `cargo test -p agent_ui test_loading_view_close_closes_pending_session`
- `cargo test -p editor hidden_edit_prediction`
- `cargo test -p editor edit_prediction_preview`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 /Users/junpark/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.4.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md`

## Suggested .rules additions

When adapting upstream ACP debug or session lifecycle changes, verify both the ACP Logs registry backlog and `ConversationView` release paths for `Loading` and `Connected` session states. ACP process stderr should enter the local ACP Logs path, not only Rust logging.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

Release Notes:

- Improved next-edit provider setup and ACP agent reliability.
