### PR TITLE
Support stringified edit tool inputs

### DIFF
--- a/crates/agent/src/tools/streaming_edit_file_tool.rs
+++ b/crates/agent/src/tools/streaming_edit_file_tool.rs
@@ -22,7 +22,10 @@ use language_model::LanguageModelToolResultContent;
 use project::lsp_store::{FormatTrigger, LspFormatTarget};
 use project::{AgentLocation, Project, ProjectPath};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{DeserializeOwned, Error as _},
+};
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -80,6 +83,7 @@ pub struct StreamingEditFileToolInput {
     /// - 'edit': Make granular edits to an existing file. Requires 'edits' field.
     ///
     /// When a file already exists or you just created it, prefer editing it as opposed to recreating it from scratch.
+    #[serde(deserialize_with = "deserialize_maybe_stringified")]
     pub mode: StreamingEditFileMode,
 
     /// The complete content for the new file (required for 'write' mode).
@@ -89,7 +93,11 @@ pub struct StreamingEditFileToolInput {
 
     /// List of edit operations to apply sequentially (required for 'edit' mode).
     /// Each edit finds `old_text` in the file and replaces it with `new_text`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_maybe_stringified"
+    )]
     pub edits: Option<Vec<Edit>>,
 }
 
@@ -124,11 +132,11 @@ struct StreamingEditFileToolPartialInput {
     display_description: Option<String>,
     #[serde(default)]
     path: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_maybe_stringified")]
     mode: Option<StreamingEditFileMode>,
     #[serde(default)]
     content: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_maybe_stringified")]
     edits: Option<Vec<PartialEdit>>,
 }
 
@@ -138,6 +146,26 @@ pub struct PartialEdit {
     pub old_text: Option<String>,
     #[serde(default)]
     pub new_text: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ValueOrJsonString<T> {
+    Value(T),
+    String(String),
+}
+
+fn deserialize_maybe_stringified<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    match ValueOrJsonString::<T>::deserialize(deserializer)? {
+        ValueOrJsonString::Value(value) => Ok(value),
+        ValueOrJsonString::String(string) => serde_json::from_str::<T>(&string).map_err(|error| {
+            D::Error::custom(format!("failed to parse stringified value: {error}"))
+        }),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1120,6 +1148,90 @@ mod tests {
     use settings::SettingsStore;
     use util::path;
     use util::rel_path::rel_path;
+
+    #[test]
+    fn test_input_deserializes_native_and_double_encoded_fields() {
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "edit",
+            "edits": [{"old_text": "hello\nworld", "new_text": "HELLO\nWORLD"}]
+        }))
+        .expect("native input should deserialize");
+
+        assert!(matches!(input.mode, StreamingEditFileMode::Edit));
+        let edits = input.edits.expect("edits should deserialize");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].old_text, "hello\nworld");
+        assert_eq!(edits[0].new_text, "HELLO\nWORLD");
+
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": "[{\"old_text\": \"hello\\nworld\", \"new_text\": \"HELLO\\nWORLD\"}]"
+        }))
+        .expect("double encoded input should deserialize");
+
+        assert!(matches!(input.mode, StreamingEditFileMode::Edit));
+        let edits = input.edits.expect("edits should deserialize");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].old_text, "hello\nworld");
+        assert_eq!(edits[0].new_text, "HELLO\nWORLD");
+
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\""
+        }))
+        .expect("input without edits should deserialize");
+        assert!(matches!(input.mode, StreamingEditFileMode::Edit));
+        assert!(input.edits.is_none());
+
+        let input = serde_json::from_value::<StreamingEditFileToolInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": null
+        }))
+        .expect("input with null edits should deserialize");
+        assert!(input.edits.is_none());
+    }
+
+    #[test]
+    fn test_partial_input_deserializes_double_encoded_fields() {
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": "\"edit\"",
+            "edits": "[{\"old_text\": \"hello\\nworld\", \"new_text\": \"HELLO\\nWORLD\"}]"
+        }))
+        .expect("partial input should deserialize");
+
+        assert!(matches!(input.mode, Some(StreamingEditFileMode::Edit)));
+        let edits = input.edits.expect("edits should deserialize");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].old_text.as_deref(), Some("hello\nworld"));
+        assert_eq!(edits[0].new_text.as_deref(), Some("HELLO\nWORLD"));
+
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt"
+        }))
+        .expect("partial input without optional fields should deserialize");
+        assert!(input.mode.is_none());
+        assert!(input.edits.is_none());
+
+        let input = serde_json::from_value::<StreamingEditFileToolPartialInput>(json!({
+            "display_description": "Edit",
+            "path": "root/file.txt",
+            "mode": null,
+            "edits": null
+        }))
+        .expect("partial input with null optional fields should deserialize");
+        assert!(input.mode.is_none());
+        assert!(input.edits.is_none());
+    }
 
     #[gpui::test]
     async fn test_streaming_edit_create_file(cx: &mut TestAppContext) {

--- a/docs/plans/2026-05-05-001-fix-edit-tool-stringified-mode-plan.md
+++ b/docs/plans/2026-05-05-001-fix-edit-tool-stringified-mode-plan.md
@@ -1,0 +1,212 @@
+---
+title: "fix: Support stringified edit-tool mode input"
+type: fix
+status: active
+date: 2026-05-05
+---
+
+# Support Stringified Edit-Tool Mode Input
+
+## Summary
+
+Backport the upstream Zed edit-tool input robustness fix so Superzent accepts double-encoded JSON fields from agent tool calls. The change should keep normal edit-tool inputs unchanged while allowing stringified `mode` and `edits` values on both final and streaming partial inputs.
+
+---
+
+## Problem Frame
+
+Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures caused by models sending the edit tool's `mode` parameter as a JSON string containing a JSON string. Superzent carries the same `streaming_edit_file_tool` shape but currently only accepts native enum/array values for `mode` and `edits`.
+
+---
+
+## Assumptions
+
+*This plan was authored without synchronous user confirmation. The items below are agent inferences that fill gaps in the input -- un-validated bets that should be reviewed before implementation proceeds.*
+
+- The requested comparison is specifically about whether Zed PR #55500's edit-tool deserialization fix applies to Superzent.
+- Superzent should accept the same stringified `mode` and `edits` inputs upstream now accepts, without broadening scope to unrelated agent tool changes.
+- Directly adapting the upstream helper is preferable to introducing a new compatibility layer elsewhere in the agent stack because the malformed data reaches serde at this boundary.
+
+---
+
+## Requirements
+
+- R1. Confirm whether Zed PR #55500 applies to Superzent's current code.
+- R2. Accept normal native JSON `mode` and `edits` values exactly as before.
+- R3. Accept double-encoded string JSON for final `StreamingEditFileToolInput.mode`.
+- R4. Accept double-encoded string JSON for final `StreamingEditFileToolInput.edits`.
+- R5. Accept double-encoded string JSON for streaming partial `mode` and `edits`.
+- R6. Preserve absent and `null` optional partial fields as `None`.
+- R7. Add focused tests for the compatibility behavior.
+
+---
+
+## Scope Boundaries
+
+- Do not change edit matching, diff rendering, authorization, or file-write behavior.
+- Do not alter agent tool schemas beyond serde input tolerance.
+- Do not import unrelated upstream agent panel or ACP changes from nearby Zed commits.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/agent/src/tools/streaming_edit_file_tool.rs` defines `StreamingEditFileToolInput`, `StreamingEditFileToolPartialInput`, `StreamingEditFileMode`, and the tests for streaming edit behavior.
+- Current final input serde accepts `mode: "edit"` and `edits: [...]`, but not `mode: "\"edit\""` or `edits: "[...]"`.
+- Current partial input serde uses default `Option` fields and feeds successful partial parses into the streaming edit session startup path.
+- Existing tests in `crates/agent/src/tools/streaming_edit_file_tool.rs` already use direct `serde_json::from_value` and `ToolInput` helpers, so this fix should add coverage in the same module.
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/acp-stderr-logs-and-loading-session-close-2026-05-04.md` reinforces keeping upstream sync work scoped to the local Superzent boundary and adding focused tests for the actual integration path.
+- `docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md` establishes the current selective-upstream-sync posture: accept targeted reliability fixes without drifting into unrelated upstream surfaces.
+
+### External References
+
+- Zed PR #55500: `https://github.com/zed-industries/zed/pull/55500`
+- Upstream source PR #55498 diff: `crates/agent/src/tools/streaming_edit_file_tool.rs` adds a generic stringified-value deserializer for `mode` and `edits`.
+
+---
+
+## Key Technical Decisions
+
+- Apply the compatibility at serde boundaries: this catches malformed final inputs and partial snapshots before business logic sees them.
+- Use one generic helper for enum, vector, and option-shaped values: the upstream approach keeps behavior consistent and avoids another single-purpose `edits` parser.
+- Keep the helper local to `streaming_edit_file_tool.rs`: no other local tool currently shows the same pattern, and a shared utility would be premature.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does the upstream fix apply? Yes. Superzent has the same `StreamingEditFileToolInput`/partial input structures but lacks the new `deserialize_maybe_stringified` annotations.
+
+### Deferred to Implementation
+
+- Exact test placement among the existing large test module: choose the nearby serde/input parsing section during implementation so the test remains discoverable.
+
+---
+
+## Implementation Units
+
+- U1. **Add stringified-value serde support**
+
+**Goal:** Allow edit-tool final and partial inputs to deserialize values that arrive as JSON strings containing JSON.
+
+**Requirements:** R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+
+**Approach:**
+- Add a local untagged enum representing either a native value or a JSON string.
+- Add a generic deserializer that first accepts native values, then parses string contents with `serde_json`.
+- Annotate final `mode`, final `edits`, partial `mode`, and partial `edits` with that helper while preserving existing `default` and `skip_serializing_if` behavior.
+
+**Patterns to follow:**
+- The upstream Zed PR #55498 helper shape.
+- Existing local serde field annotations in `StreamingEditFileToolInput` and `StreamingEditFileToolPartialInput`.
+
+**Test scenarios:**
+- Covered by U2 and U3.
+
+**Verification:**
+- Native `mode`/`edits` inputs still deserialize.
+- Stringified `mode`/`edits` inputs deserialize to the same Rust values as native inputs.
+- Missing and `null` optional partial values remain `None`.
+
+- U2. **Cover final input deserialization**
+
+**Goal:** Prove `StreamingEditFileToolInput` accepts double-encoded final fields without changing optional-field semantics.
+
+**Requirements:** R2, R3, R4, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+- Test: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+
+**Approach:**
+- Add direct `serde_json::from_value` tests for final edit-tool inputs.
+- Cover double-encoded `mode`, double-encoded `edits`, omitted `edits`, and explicit `edits: null`.
+
+**Patterns to follow:**
+- Existing direct serde assertions and `json!` fixtures in the module's test block.
+
+**Test scenarios:**
+- Happy path: final input with `mode: "\"edit\""` and stringified `edits` deserializes to `Edit` mode with one edit.
+- Edge case: final edit input with double-encoded `mode` and omitted `edits` deserializes with `edits == None`.
+- Edge case: final edit input with double-encoded `mode` and `edits: null` deserializes with `edits == None`.
+
+**Verification:**
+- The new tests fail before U1 and pass after U1.
+
+- U3. **Cover streaming partial deserialization**
+
+**Goal:** Prove streaming partial snapshots can carry stringified `mode` and `edits`, which is necessary for the progressive edit session path.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+- Test: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+
+**Approach:**
+- Add direct `serde_json::from_value` tests for `StreamingEditFileToolPartialInput`.
+- Cover double-encoded `mode`, stringified partial `edits`, omitted optionals, and explicit `null` optionals.
+
+**Patterns to follow:**
+- Existing partial-input startup behavior in `StreamingEditFileTool::run`.
+
+**Test scenarios:**
+- Happy path: partial input with `mode: "\"edit\""` and stringified partial edits deserializes with `Some(Edit)` and partial edit text.
+- Edge case: partial input with only path/description and no `mode` or `edits` keeps both fields `None`.
+- Edge case: partial input with `mode: null` and `edits: null` keeps both fields `None`.
+
+**Verification:**
+- The partial parser accepts malformed-but-recoverable snapshots instead of falling back to `DEFAULT_UI_TEXT`/ignored partial behavior.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Only serde input parsing for the streaming edit file tool changes; downstream edit session logic should receive the same enum and edit vector values it already expects.
+- **Error propagation:** Invalid stringified JSON should continue to produce a serde error with context instead of silently accepting bad data.
+- **State lifecycle risks:** None expected; no edit application state is changed.
+- **API surface parity:** This improves compatibility with upstream Zed's current agent edit-tool contract.
+- **Integration coverage:** Direct deserialization tests cover the contract boundary where the failure occurs.
+- **Unchanged invariants:** Authorization, path resolution, diff generation, file mutation, and rejection behavior are intentionally unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The generic helper accidentally changes native deserialization behavior | Include native and stringified cases in focused tests, and preserve existing field defaults |
+| Optional `null` handling regresses for partial inputs | Cover omitted and explicit `null` optionals in tests |
+| Error messages become less specific than the old edits-only helper | Use a clear generic parse failure message because the helper now applies to multiple fields |
+
+---
+
+## Documentation / Operational Notes
+
+- No user-facing documentation changes are required.
+- PR release notes should be user-facing because this can fix agent edit failures.
+
+---
+
+## Sources & References
+
+- Related upstream PR: `https://github.com/zed-industries/zed/pull/55500`
+- Related upstream source PR: `https://github.com/zed-industries/zed/pull/55498`
+- Related code: `crates/agent/src/tools/streaming_edit_file_tool.rs`
+- Related local plan: `docs/plans/2026-05-03-001-feat-zed-1-0-next-edit-acp-sync-plan.md`

--- a/docs/plans/2026-05-05-001-fix-edit-tool-stringified-mode-plan.md
+++ b/docs/plans/2026-05-05-001-fix-edit-tool-stringified-mode-plan.md
@@ -21,7 +21,7 @@ Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures c
 
 ## Assumptions
 
-*This plan was authored without synchronous user confirmation. The items below are agent inferences that fill gaps in the input -- un-validated bets that should be reviewed before implementation proceeds.*
+_This plan was authored without synchronous user confirmation. The items below are agent inferences that fill gaps in the input -- un-validated bets that should be reviewed before implementation proceeds._
 
 - The requested comparison is specifically about whether Zed PR #55500's edit-tool deserialization fix applies to Superzent.
 - Superzent should accept the same stringified `mode` and `edits` inputs upstream now accepts, without broadening scope to unrelated agent tool changes.
@@ -101,21 +101,26 @@ Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures c
 **Dependencies:** None
 
 **Files:**
+
 - Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
 
 **Approach:**
+
 - Add a local untagged enum representing either a native value or a JSON string.
 - Add a generic deserializer that first accepts native values, then parses string contents with `serde_json`.
 - Annotate final `mode`, final `edits`, partial `mode`, and partial `edits` with that helper while preserving existing `default` and `skip_serializing_if` behavior.
 
 **Patterns to follow:**
+
 - The upstream Zed PR #55498 helper shape.
 - Existing local serde field annotations in `StreamingEditFileToolInput` and `StreamingEditFileToolPartialInput`.
 
 **Test scenarios:**
+
 - Covered by U2 and U3.
 
 **Verification:**
+
 - Native `mode`/`edits` inputs still deserialize.
 - Stringified `mode`/`edits` inputs deserialize to the same Rust values as native inputs.
 - Missing and `null` optional partial values remain `None`.
@@ -129,22 +134,27 @@ Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures c
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
 - Test: `crates/agent/src/tools/streaming_edit_file_tool.rs`
 
 **Approach:**
+
 - Add direct `serde_json::from_value` tests for final edit-tool inputs.
 - Cover double-encoded `mode`, double-encoded `edits`, omitted `edits`, and explicit `edits: null`.
 
 **Patterns to follow:**
+
 - Existing direct serde assertions and `json!` fixtures in the module's test block.
 
 **Test scenarios:**
+
 - Happy path: final input with `mode: "\"edit\""` and stringified `edits` deserializes to `Edit` mode with one edit.
 - Edge case: final edit input with double-encoded `mode` and omitted `edits` deserializes with `edits == None`.
 - Edge case: final edit input with double-encoded `mode` and `edits: null` deserializes with `edits == None`.
 
 **Verification:**
+
 - The new tests fail before U1 and pass after U1.
 
 - U3. **Cover streaming partial deserialization**
@@ -156,22 +166,27 @@ Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures c
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `crates/agent/src/tools/streaming_edit_file_tool.rs`
 - Test: `crates/agent/src/tools/streaming_edit_file_tool.rs`
 
 **Approach:**
+
 - Add direct `serde_json::from_value` tests for `StreamingEditFileToolPartialInput`.
 - Cover double-encoded `mode`, stringified partial `edits`, omitted optionals, and explicit `null` optionals.
 
 **Patterns to follow:**
+
 - Existing partial-input startup behavior in `StreamingEditFileTool::run`.
 
 **Test scenarios:**
+
 - Happy path: partial input with `mode: "\"edit\""` and stringified partial edits deserializes with `Some(Edit)` and partial edit text.
 - Edge case: partial input with only path/description and no `mode` or `edits` keeps both fields `None`.
 - Edge case: partial input with `mode: null` and `edits: null` keeps both fields `None`.
 
 **Verification:**
+
 - The partial parser accepts malformed-but-recoverable snapshots instead of falling back to `DEFAULT_UI_TEXT`/ignored partial behavior.
 
 ---
@@ -189,11 +204,11 @@ Zed PR #55500 cherry-picks upstream PR #55498, which fixed agent edit failures c
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
+| Risk                                                                    | Mitigation                                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | The generic helper accidentally changes native deserialization behavior | Include native and stringified cases in focused tests, and preserve existing field defaults |
-| Optional `null` handling regresses for partial inputs | Cover omitted and explicit `null` optionals in tests |
-| Error messages become less specific than the old edits-only helper | Use a clear generic parse failure message because the helper now applies to multiple fields |
+| Optional `null` handling regresses for partial inputs                   | Cover omitted and explicit `null` optionals in tests                                        |
+| Error messages become less specific than the old edits-only helper      | Use a clear generic parse failure message because the helper now applies to multiple fields |
 
 ---
 


### PR DESCRIPTION
## Summary

Agent edit tool calls that double-encode `mode` or `edits` now deserialize successfully instead of failing before an edit session starts. This backports the relevant behavior from zed-industries/zed#55500 while keeping the change scoped to Superzent's streaming edit file tool.

- Adds a local serde helper that accepts either native JSON values or JSON strings containing those values.
- Applies the helper to final edit-tool input and streaming partial input for `mode` and `edits`.
- Adds focused coverage for native values, double-encoded values, omitted optionals, and explicit `null` optionals.

## Testing

- `cargo test -p agent deserializes --lib`
- `cargo test -p agent test_streaming_edit_file_tool_fields_out_of_order_in_edit_mode --lib`
- `./script/clippy -p agent`

## Notes

- Browser testing was not applicable to this Rust agent-tool parsing change. The pipeline browser step could not run because `agent-browser` is not installed locally.
- Related upstream PRs: https://github.com/zed-industries/zed/pull/55500 and https://github.com/zed-industries/zed/pull/55498

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

Release Notes:

- Fixed agent edit failures when edit-tool input fields are sent as stringified JSON.
