### PR TITLE
Add markdown preview search

### DIFF
--- a/.rules
+++ b/.rules
@@ -139,6 +139,10 @@ Other entities can then register a callback to handle these events by doing `cx.
 
 - Use `./script/clippy` instead of `cargo clippy`
 
+## Markdown formatting
+
+- If a commit includes Markdown files under `docs/`, run `cd docs && pnpm dlx prettier@3.5.0 . --write && cd ..` before committing.
+
 # Superzent window behavior
 
 * Superzent uses a single-window model. `workspace::CloseWindow` (Cmd+W) is intentionally intercepted so it never closes the OS window — users quit with Cmd+Q instead. When there are no tabs in the center pane, Cmd+W does nothing. When the right sidebar is focused, Cmd+W closes the active sidebar item rather than the window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10258,6 +10258,7 @@ dependencies = [
  "markup5ever_rcdom",
  "mermaid-rs-renderer",
  "pretty_assertions",
+ "project",
  "pulldown-cmark 0.13.0",
  "settings",
  "stacksafe",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1245,6 +1245,8 @@
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
       "alt-down": "markdown::ScrollDownByItem",
+      "find": "buffer_search::Deploy",
+      "ctrl-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1361,6 +1361,7 @@
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
       "alt-down": "markdown::ScrollDownByItem",
+      "cmd-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1274,6 +1274,8 @@
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
       "alt-down": "markdown::ScrollDownByItem",
+      "find": "buffer_search::Deploy",
+      "ctrl-f": "buffer_search::Deploy",
     },
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1110,6 +1110,7 @@
       "ctrl-e": "markdown::ScrollDown",
       "g g": "markdown::ScrollToTop",
       "shift-g": "markdown::ScrollToBottom",
+      "/": "buffer_search::Deploy",
     },
   },
   {

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 markdown.workspace = true
 markup5ever_rcdom.workspace = true
 pretty_assertions.workspace = true
+project.workspace = true
 pulldown-cmark.workspace = true
 settings.workspace = true
 stacksafe.workspace = true

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -989,8 +989,11 @@ impl SearchableItem for MarkdownPreviewView {
 mod tests {
     use super::*;
     use crate::markdown_elements::{
-        HeadingLevel, ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownHeading,
-        ParsedMarkdownListItem, ParsedMarkdownListItemType, ParsedMarkdownText,
+        HeadingLevel, Image, Link, ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock,
+        ParsedMarkdownHeading, ParsedMarkdownListItem, ParsedMarkdownListItemType,
+        ParsedMarkdownMermaidDiagram, ParsedMarkdownMermaidDiagramContents, ParsedMarkdownTable,
+        ParsedMarkdownTableAlignment, ParsedMarkdownTableColumn, ParsedMarkdownTableRow,
+        ParsedMarkdownText,
     };
     use ui::SharedString;
 
@@ -1001,6 +1004,16 @@ mod tests {
             highlights: Vec::new(),
             regions: Vec::new(),
         })
+    }
+
+    fn table_column(contents: &str, source_range: Range<usize>) -> ParsedMarkdownTableColumn {
+        ParsedMarkdownTableColumn {
+            col_span: 1,
+            row_span: 1,
+            is_header: false,
+            children: vec![text(contents, source_range)],
+            alignment: ParsedMarkdownTableAlignment::None,
+        }
     }
 
     #[test]
@@ -1036,6 +1049,33 @@ mod tests {
                         54..59,
                     )])],
                 }),
+                ParsedMarkdownElement::Table(ParsedMarkdownTable {
+                    source_range: 63..92,
+                    header: vec![ParsedMarkdownTableRow {
+                        columns: vec![table_column("header", 63..69)],
+                    }],
+                    body: vec![ParsedMarkdownTableRow {
+                        columns: vec![table_column("cell", 73..77)],
+                    }],
+                    caption: Some(vec![text("caption", 85..92)]),
+                }),
+                ParsedMarkdownElement::HorizontalRule(94..97),
+                ParsedMarkdownElement::Image(Image {
+                    link: Link::Web {
+                        url: "https://example.com/image.png".to_string(),
+                    },
+                    source_range: 99..112,
+                    alt_text: Some(SharedString::new("image alt")),
+                    width: None,
+                    height: None,
+                }),
+                ParsedMarkdownElement::MermaidDiagram(ParsedMarkdownMermaidDiagram {
+                    source_range: 114..135,
+                    contents: ParsedMarkdownMermaidDiagramContents {
+                        contents: SharedString::new("graph TD"),
+                        scale: 1,
+                    },
+                }),
             ],
         };
 
@@ -1052,6 +1092,9 @@ mod tests {
                 (2, 16..35, "code alpha".to_string()),
                 (3, 39..45, "nested".to_string()),
                 (4, 54..59, "quote".to_string()),
+                (5, 63..69, "header".to_string()),
+                (5, 73..77, "cell".to_string()),
+                (5, 85..92, "caption".to_string()),
             ]
         );
     }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -12,17 +12,23 @@ use gpui::{
     Subscription, Task, WeakEntity, Window, list,
 };
 use language::LanguageRegistry;
+use project::search::SearchQuery;
 use settings::Settings;
 use theme::ThemeSettings;
 use ui::{WithScrollbar, prelude::*};
-use workspace::item::{Item, ItemHandle};
+use workspace::item::{Item, ItemBufferKind, ItemHandle};
+use workspace::searchable::{
+    Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
+};
 use workspace::{Pane, Workspace};
 
-use crate::markdown_elements::ParsedMarkdownElement;
+use crate::markdown_elements::{
+    MarkdownParagraph, MarkdownParagraphChunk, ParsedMarkdown, ParsedMarkdownElement,
+    ParsedMarkdownTableRow,
+};
 use crate::markdown_renderer::{CheckboxClickedEvent, MermaidState};
 use crate::{
     OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
-    markdown_elements::ParsedMarkdown,
     markdown_parser::parse_markdown,
     markdown_renderer::{RenderContext, render_markdown_block},
 };
@@ -42,6 +48,8 @@ pub struct MarkdownPreviewView {
     mermaid_state: MermaidState,
     parsing_markdown_task: Option<Task<Result<()>>>,
     mode: MarkdownPreviewMode,
+    search_matches: Vec<MarkdownSearchMatch>,
+    active_search_match_index: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -55,6 +63,19 @@ pub enum MarkdownPreviewMode {
 struct EditorState {
     editor: Entity<Editor>,
     _subscription: Subscription,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarkdownSearchMatch {
+    pub(crate) block_index: usize,
+    pub(crate) text_source_range: Range<usize>,
+    pub(crate) text_range: Range<usize>,
+}
+
+struct MarkdownSearchSegment {
+    block_index: usize,
+    text_source_range: Range<usize>,
+    text: String,
 }
 
 impl MarkdownPreviewView {
@@ -219,6 +240,8 @@ impl MarkdownPreviewView {
                 parsing_markdown_task: None,
                 image_cache: RetainAllImageCache::new(cx),
                 mode,
+                search_matches: Vec::new(),
+                active_search_match_index: None,
             };
 
             this.set_editor(active_editor, window, cx);
@@ -361,6 +384,7 @@ impl MarkdownPreviewView {
                 view.list_state.reset(markdown_blocks_count);
                 view.list_state.scroll_to(scroll_top);
                 view.parsing_markdown_task = None;
+                cx.emit(SearchEvent::MatchesInvalidated);
                 cx.notify();
             })
         })
@@ -435,6 +459,91 @@ impl MarkdownPreviewView {
         next_block: Option<&ParsedMarkdownElement>,
     ) -> bool {
         !(current_block.is_list_item() && next_block.map(|b| b.is_list_item()).unwrap_or(false))
+    }
+
+    fn search_segments(contents: &ParsedMarkdown) -> Vec<MarkdownSearchSegment> {
+        let mut segments = Vec::new();
+        for (block_index, block) in contents.children.iter().enumerate() {
+            Self::search_segments_for_element(block, block_index, &mut segments);
+        }
+        segments
+    }
+
+    fn search_segments_for_element(
+        element: &ParsedMarkdownElement,
+        block_index: usize,
+        segments: &mut Vec<MarkdownSearchSegment>,
+    ) {
+        match element {
+            ParsedMarkdownElement::Heading(heading) => {
+                Self::search_segments_for_paragraph(&heading.contents, block_index, segments);
+            }
+            ParsedMarkdownElement::ListItem(list_item) => {
+                for child in &list_item.content {
+                    Self::search_segments_for_element(child, block_index, segments);
+                }
+            }
+            ParsedMarkdownElement::Table(table) => {
+                for row in table.header.iter().chain(table.body.iter()) {
+                    Self::search_segments_for_table_row(row, block_index, segments);
+                }
+                if let Some(caption) = &table.caption {
+                    Self::search_segments_for_paragraph(caption, block_index, segments);
+                }
+            }
+            ParsedMarkdownElement::BlockQuote(block_quote) => {
+                for child in &block_quote.children {
+                    Self::search_segments_for_element(child, block_index, segments);
+                }
+            }
+            ParsedMarkdownElement::CodeBlock(code_block) => {
+                segments.push(MarkdownSearchSegment {
+                    block_index,
+                    text_source_range: code_block.source_range.clone(),
+                    text: code_block.contents.to_string(),
+                });
+            }
+            ParsedMarkdownElement::Paragraph(paragraph) => {
+                Self::search_segments_for_paragraph(paragraph, block_index, segments);
+            }
+            ParsedMarkdownElement::MermaidDiagram(_)
+            | ParsedMarkdownElement::HorizontalRule(_)
+            | ParsedMarkdownElement::Image(_) => {}
+        }
+    }
+
+    fn search_segments_for_table_row(
+        row: &ParsedMarkdownTableRow,
+        block_index: usize,
+        segments: &mut Vec<MarkdownSearchSegment>,
+    ) {
+        for column in &row.columns {
+            Self::search_segments_for_paragraph(&column.children, block_index, segments);
+        }
+    }
+
+    fn search_segments_for_paragraph(
+        paragraph: &MarkdownParagraph,
+        block_index: usize,
+        segments: &mut Vec<MarkdownSearchSegment>,
+    ) {
+        for chunk in paragraph {
+            if let MarkdownParagraphChunk::Text(text) = chunk {
+                segments.push(MarkdownSearchSegment {
+                    block_index,
+                    text_source_range: text.source_range.clone(),
+                    text: text.contents.to_string(),
+                });
+            }
+        }
+    }
+
+    fn search_match_position(search_match: &MarkdownSearchMatch) -> (usize, usize, usize) {
+        (
+            search_match.block_index,
+            search_match.text_source_range.start,
+            search_match.text_range.start,
+        )
     }
 
     fn scroll_page_up(&mut self, _: &ScrollPageUp, _window: &mut Window, cx: &mut Context<Self>) {
@@ -544,6 +653,7 @@ impl Focusable for MarkdownPreviewView {
 }
 
 impl EventEmitter<()> for MarkdownPreviewView {}
+impl EventEmitter<SearchEvent> for MarkdownPreviewView {}
 
 impl Item for MarkdownPreviewView {
     type Event = ();
@@ -568,6 +678,18 @@ impl Item for MarkdownPreviewView {
     }
 
     fn to_item_events(_event: &Self::Event, _f: &mut dyn FnMut(workspace::item::ItemEvent)) {}
+
+    fn buffer_kind(&self, _cx: &App) -> ItemBufferKind {
+        ItemBufferKind::Singleton
+    }
+
+    fn as_searchable(
+        &self,
+        handle: &Entity<Self>,
+        _: &App,
+    ) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(handle.clone()))
+    }
 }
 
 impl Render for MarkdownPreviewView {
@@ -605,6 +727,8 @@ impl Render for MarkdownPreviewView {
                             let mut render_cx = RenderContext::new(
                                 Some(this.workspace.clone()),
                                 &this.mermaid_state,
+                                &this.search_matches,
+                                this.active_search_match_index,
                                 window,
                                 cx,
                             )
@@ -698,5 +822,237 @@ impl Render for MarkdownPreviewView {
                 )
             }))
             .vertical_scrollbar_for(&self.list_state, window, cx)
+    }
+}
+
+impl SearchableItem for MarkdownPreviewView {
+    type Match = MarkdownSearchMatch;
+
+    fn supported_options(&self) -> SearchOptions {
+        SearchOptions {
+            case: true,
+            word: true,
+            regex: true,
+            replacement: false,
+            selection: false,
+            find_in_results: false,
+        }
+    }
+
+    fn get_matches(&self, _window: &mut Window, _cx: &mut App) -> (Vec<Self::Match>, SearchToken) {
+        (self.search_matches.clone(), SearchToken::default())
+    }
+
+    fn clear_matches(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let had_matches = !self.search_matches.is_empty();
+        let had_active_match = self.active_search_match_index.is_some();
+        self.search_matches.clear();
+        self.active_search_match_index = None;
+
+        if had_matches {
+            cx.emit(SearchEvent::MatchesInvalidated);
+        }
+        if had_matches || had_active_match {
+            cx.notify();
+        }
+    }
+
+    fn update_matches(
+        &mut self,
+        matches: &[Self::Match],
+        active_match_index: Option<usize>,
+        _token: SearchToken,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let matches_changed = self.search_matches != matches;
+        let active_match_changed = self.active_search_match_index != active_match_index;
+        self.search_matches = matches.to_vec();
+        self.active_search_match_index = active_match_index;
+        if matches_changed {
+            cx.emit(SearchEvent::MatchesInvalidated);
+        }
+        if matches_changed || active_match_changed {
+            cx.notify();
+        }
+    }
+
+    fn query_suggestion(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> String {
+        String::new()
+    }
+
+    fn activate_match(
+        &mut self,
+        index: usize,
+        matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(search_match) = matches.get(index) else {
+            return;
+        };
+
+        self.active_search_match_index = Some(index);
+        self.selected_block = search_match.block_index;
+        self.list_state
+            .scroll_to_reveal_item(search_match.block_index);
+        cx.emit(SearchEvent::ActiveMatchChanged);
+        cx.notify();
+    }
+
+    fn select_matches(
+        &mut self,
+        _matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn replace(
+        &mut self,
+        _: &Self::Match,
+        _: &SearchQuery,
+        _token: SearchToken,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+    }
+
+    fn find_matches(
+        &mut self,
+        query: Arc<SearchQuery>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Vec<Self::Match>> {
+        let segments = self
+            .contents
+            .as_ref()
+            .map(Self::search_segments)
+            .unwrap_or_default();
+
+        cx.background_spawn(async move {
+            let mut matches = Vec::new();
+            for segment in segments {
+                matches.extend(
+                    query
+                        .search_str(&segment.text)
+                        .into_iter()
+                        .map(|text_range| MarkdownSearchMatch {
+                            block_index: segment.block_index,
+                            text_source_range: segment.text_source_range.clone(),
+                            text_range,
+                        }),
+                );
+            }
+            matches
+        })
+    }
+
+    fn active_match_index(
+        &mut self,
+        direction: Direction,
+        matches: &[Self::Match],
+        _token: SearchToken,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        if matches.is_empty() {
+            return None;
+        }
+
+        let current_position = self
+            .active_search_match_index
+            .and_then(|index| self.search_matches.get(index))
+            .map(Self::search_match_position)
+            .unwrap_or((self.selected_block, 0, 0));
+
+        match direction {
+            Direction::Next => matches
+                .iter()
+                .position(|search_match| {
+                    Self::search_match_position(search_match) >= current_position
+                })
+                .or(Some(0)),
+            Direction::Prev => matches
+                .iter()
+                .rposition(|search_match| {
+                    Self::search_match_position(search_match) <= current_position
+                })
+                .or(Some(matches.len().saturating_sub(1))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::markdown_elements::{
+        HeadingLevel, ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownHeading,
+        ParsedMarkdownListItem, ParsedMarkdownListItemType, ParsedMarkdownText,
+    };
+    use ui::SharedString;
+
+    fn text(contents: &str, source_range: Range<usize>) -> MarkdownParagraphChunk {
+        MarkdownParagraphChunk::Text(ParsedMarkdownText {
+            source_range,
+            contents: SharedString::new(contents),
+            highlights: Vec::new(),
+            regions: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn search_segments_include_rendered_text_and_code_blocks() {
+        let markdown = ParsedMarkdown {
+            children: vec![
+                ParsedMarkdownElement::Heading(ParsedMarkdownHeading {
+                    source_range: 0..8,
+                    level: HeadingLevel::H1,
+                    contents: vec![text("Title", 2..7)],
+                }),
+                ParsedMarkdownElement::Paragraph(vec![text("alpha", 9..14)]),
+                ParsedMarkdownElement::CodeBlock(ParsedMarkdownCodeBlock {
+                    source_range: 16..35,
+                    language: None,
+                    contents: SharedString::new("code alpha"),
+                    highlights: None,
+                }),
+                ParsedMarkdownElement::ListItem(ParsedMarkdownListItem {
+                    source_range: 37..50,
+                    depth: 1,
+                    item_type: ParsedMarkdownListItemType::Unordered,
+                    content: vec![ParsedMarkdownElement::Paragraph(vec![text(
+                        "nested",
+                        39..45,
+                    )])],
+                    nested: false,
+                }),
+                ParsedMarkdownElement::BlockQuote(ParsedMarkdownBlockQuote {
+                    source_range: 52..61,
+                    children: vec![ParsedMarkdownElement::Paragraph(vec![text(
+                        "quote",
+                        54..59,
+                    )])],
+                }),
+            ],
+        };
+
+        let segments = MarkdownPreviewView::search_segments(&markdown)
+            .into_iter()
+            .map(|segment| (segment.block_index, segment.text_source_range, segment.text))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            segments,
+            vec![
+                (0, 2..7, "Title".to_string()),
+                (1, 9..14, "alpha".to_string()),
+                (2, 16..35, "code alpha".to_string()),
+                (3, 39..45, "nested".to_string()),
+                (4, 54..59, "quote".to_string()),
+            ]
+        );
     }
 }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -6,7 +6,7 @@ use crate::{
         ParsedMarkdownMermaidDiagram, ParsedMarkdownMermaidDiagramContents, ParsedMarkdownTable,
         ParsedMarkdownTableAlignment, ParsedMarkdownTableRow,
     },
-    markdown_preview_view::MarkdownPreviewView,
+    markdown_preview_view::{MarkdownPreviewView, MarkdownSearchMatch},
 };
 use collections::HashMap;
 use fs::normalize_path;
@@ -191,12 +191,18 @@ pub struct RenderContext<'a> {
     checkbox_clicked_callback: Option<CheckboxClickedCallback>,
     is_last_child: bool,
     mermaid_state: &'a MermaidState,
+    search_matches: &'a [MarkdownSearchMatch],
+    active_search_match_index: Option<usize>,
+    search_match_background_color: Hsla,
+    search_active_match_background_color: Hsla,
 }
 
 impl<'a> RenderContext<'a> {
     pub(crate) fn new(
         workspace: Option<WeakEntity<Workspace>>,
         mermaid_state: &'a MermaidState,
+        search_matches: &'a [MarkdownSearchMatch],
+        active_search_match_index: Option<usize>,
         window: &mut Window,
         cx: &mut App,
     ) -> Self {
@@ -230,6 +236,10 @@ impl<'a> RenderContext<'a> {
             checkbox_clicked_callback: None,
             is_last_child: false,
             mermaid_state,
+            search_matches,
+            active_search_match_index,
+            search_match_background_color: theme.colors().search_match_background,
+            search_active_match_background_color: theme.colors().search_active_match_background,
         }
     }
 
@@ -245,6 +255,32 @@ impl<'a> RenderContext<'a> {
         let id = format!("markdown-{}-{}-{}", self.next_id, span.start, span.end);
         self.next_id += 1;
         ElementId::from(SharedString::from(id))
+    }
+
+    fn search_highlights_for(
+        &self,
+        source_range: &Range<usize>,
+    ) -> Vec<(Range<usize>, HighlightStyle)> {
+        self.search_matches
+            .iter()
+            .enumerate()
+            .filter_map(|(index, search_match)| {
+                (search_match.text_source_range == *source_range).then(|| {
+                    let background_color = if Some(index) == self.active_search_match_index {
+                        self.search_active_match_background_color
+                    } else {
+                        self.search_match_background_color
+                    };
+                    (
+                        search_match.text_range.clone(),
+                        HighlightStyle {
+                            background_color: Some(background_color),
+                            ..Default::default()
+                        },
+                    )
+                })
+            })
+            .collect()
     }
 
     /// HACK: used to have rems relative to buffer font size, so that things scale appropriately as
@@ -299,7 +335,7 @@ pub fn render_parsed_markdown(
     cx: &mut App,
 ) -> Div {
     let cache = Default::default();
-    let mut cx = RenderContext::new(workspace, &cache, window, cx);
+    let mut cx = RenderContext::new(workspace, &cache, &[], None, window, cx);
 
     v_flex().gap_3().children(
         parsed
@@ -747,15 +783,20 @@ fn render_markdown_code_block(
     parsed: &ParsedMarkdownCodeBlock,
     cx: &mut RenderContext,
 ) -> AnyElement {
+    let search_highlights = cx.search_highlights_for(&parsed.source_range);
     let body = if let Some(highlights) = parsed.highlights.as_ref() {
+        let syntax_highlights = highlights.iter().filter_map(|(range, highlight_id)| {
+            highlight_id
+                .style(cx.syntax_theme.as_ref())
+                .map(|style| (range.clone(), style))
+        });
         StyledText::new(parsed.contents.clone()).with_default_highlights(
             &cx.buffer_text_style,
-            highlights.iter().filter_map(|(range, highlight_id)| {
-                highlight_id
-                    .style(cx.syntax_theme.as_ref())
-                    .map(|style| (range.clone(), style))
-            }),
+            gpui::combine_highlights(syntax_highlights, search_highlights),
         )
+    } else if !search_highlights.is_empty() {
+        StyledText::new(parsed.contents.clone())
+            .with_default_highlights(&cx.buffer_text_style, search_highlights)
     } else {
         StyledText::new(parsed.contents.clone())
     };
@@ -892,34 +933,38 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
         match parsed_region {
             MarkdownParagraphChunk::Text(parsed) => {
                 let element_id = cx.next_id(&parsed.source_range);
+                let search_highlights = cx.search_highlights_for(&parsed.source_range);
 
                 let highlights = gpui::combine_highlights(
-                    parsed.highlights.iter().filter_map(|(range, highlight)| {
-                        highlight
-                            .to_highlight_style(&syntax_theme)
-                            .map(|style| (range.clone(), style))
-                    }),
-                    parsed.regions.iter().filter_map(|(range, region)| {
-                        if region.code {
-                            Some((
-                                range.clone(),
-                                HighlightStyle {
-                                    background_color: Some(code_span_bg_color),
-                                    ..Default::default()
-                                },
-                            ))
-                        } else if region.link.is_some() {
-                            Some((
-                                range.clone(),
-                                HighlightStyle {
-                                    color: Some(link_color),
-                                    ..Default::default()
-                                },
-                            ))
-                        } else {
-                            None
-                        }
-                    }),
+                    gpui::combine_highlights(
+                        parsed.highlights.iter().filter_map(|(range, highlight)| {
+                            highlight
+                                .to_highlight_style(&syntax_theme)
+                                .map(|style| (range.clone(), style))
+                        }),
+                        parsed.regions.iter().filter_map(|(range, region)| {
+                            if region.code {
+                                Some((
+                                    range.clone(),
+                                    HighlightStyle {
+                                        background_color: Some(code_span_bg_color),
+                                        ..Default::default()
+                                    },
+                                ))
+                            } else if region.link.is_some() {
+                                Some((
+                                    range.clone(),
+                                    HighlightStyle {
+                                        color: Some(link_color),
+                                        ..Default::default()
+                                    },
+                                ))
+                            } else {
+                                None
+                            }
+                        }),
+                    ),
+                    search_highlights,
                 );
                 let mut links = Vec::new();
                 let mut link_ranges = Vec::new();

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -668,4 +668,96 @@ impl SearchQuery {
             Self::Text { .. } => None,
         }
     }
+
+    pub fn search_str(&self, text: &str) -> Vec<Range<usize>> {
+        if self.as_str().is_empty() {
+            return Vec::new();
+        }
+
+        let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+        let mut matches = Vec::new();
+        match self {
+            Self::Text {
+                search, whole_word, ..
+            } => {
+                for mat in search.find_iter(text.as_bytes()) {
+                    if *whole_word {
+                        let prev_char = text[..mat.start()].chars().last();
+                        let next_char = text[mat.end()..].chars().next();
+                        if prev_char.is_some_and(is_word_char)
+                            || next_char.is_some_and(is_word_char)
+                        {
+                            continue;
+                        }
+                    }
+                    matches.push(mat.start()..mat.end());
+                }
+            }
+            Self::Regex {
+                regex,
+                multiline,
+                one_match_per_line,
+                ..
+            } => {
+                if *multiline {
+                    for mat in regex.find_iter(text).flatten() {
+                        matches.push(mat.start()..mat.end());
+                    }
+                } else {
+                    let mut line_offset = 0;
+                    for line in text.split('\n') {
+                        for mat in regex.find_iter(line).flatten() {
+                            matches.push((line_offset + mat.start())..(line_offset + mat.end()));
+                            if *one_match_per_line {
+                                break;
+                            }
+                        }
+                        line_offset += line.len() + 1;
+                    }
+                }
+            }
+        }
+        matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::paths::PathMatcher;
+
+    #[test]
+    fn search_str_supports_text_and_word_boundaries() {
+        let query = SearchQuery::text(
+            "cat",
+            true,
+            true,
+            false,
+            PathMatcher::default(),
+            PathMatcher::default(),
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(query.search_str("cat scatter cat"), vec![0..3, 12..15]);
+    }
+
+    #[test]
+    fn search_str_supports_regex_per_line_matching() {
+        let query = SearchQuery::regex(
+            r"\d+",
+            false,
+            true,
+            false,
+            true,
+            PathMatcher::default(),
+            PathMatcher::default(),
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(query.search_str("a1 b2\nc3 d4"), vec![1..2, 7..8]);
+    }
 }

--- a/docs/plans/2026-05-05-001-feat-markdown-preview-search-plan.md
+++ b/docs/plans/2026-05-05-001-feat-markdown-preview-search-plan.md
@@ -1,0 +1,207 @@
+---
+title: "Add markdown preview search support"
+type: feat
+status: active
+date: 2026-05-05
+origin: docs/brainstorms/2026-04-23-upstream-sync-editor-search-requirements.md
+---
+
+# Add Markdown Preview Search Support
+
+## Overview
+
+Backport the useful behavior from upstream Zed commit `fd4d8444cf` (`markdown_preview: Add search support to markdown preview (#52502)`) onto Superzent's current markdown preview renderer. The upstream patch targets Zed's newer `Markdown` entity rendering path; this branch still renders parsed markdown blocks through `crates/markdown_preview/src/markdown_renderer.rs`, so the implementation needs to preserve the current renderer and add only the thin search integration layer.
+
+## Problem Frame
+
+Markdown preview currently behaves like a focused item but not a searchable item: Cmd/Ctrl-F does not give users in-preview search over rendered markdown. The broader upstream sync plan deferred this commit because a direct cherry-pick would pull in a renderer refactor. This follow-up implements the same user-facing search behavior against the existing parsed-block/list renderer instead of changing the preview architecture.
+
+## Requirements Trace
+
+- R1. Cmd/Ctrl-F in `MarkdownPreview` opens the existing buffer search UI.
+- R2. Markdown preview implements `SearchableItem` so the existing search bar can find, count, and navigate matches.
+- R3. Search candidates include rendered text chunks and code block contents.
+- R4. Search highlights render in inline markdown text and code blocks without corrupting syntax, link, or inline-code styling.
+- R5. Next/previous search navigation scrolls the matching preview block into view and marks the active result distinctly.
+- R6. Search uses existing `SearchQuery` semantics for plain text, case handling, whole-word matching, and regex matching.
+- R7. The backport remains scoped to search/highlight/navigation and does not add markdown preview text selection or drag interactions.
+
+## Scope Boundaries
+
+- Do not refactor markdown preview to upstream's newer `Markdown` entity rendering model.
+- Do not implement preview text drag selection, actual selection ranges, copy selection, or drag-and-drop interactions.
+- Do not implement replacement in markdown preview.
+- Do not make `SearchableItem::select_matches` behave like editor selection in this phase.
+- Do not change general editor or project-search behavior beyond a reusable string-search helper.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/markdown_preview/src/markdown_preview_view.rs` owns the preview item, focus handle, parsed markdown contents, list state, selected block, and `Item` integration.
+- `crates/markdown_preview/src/markdown_renderer.rs` renders parsed markdown blocks into GPUI elements and already combines syntax, link, and inline-code styles for `InteractiveText`.
+- `crates/project/src/search.rs` owns `SearchQuery`, which already represents text and regex search options for buffer/project search.
+- `assets/keymaps/default-macos.json`, `assets/keymaps/default-linux.json`, `assets/keymaps/default-windows.json`, and `assets/keymaps/vim.json` define the `MarkdownPreview` key context bindings.
+- Existing `SearchableItem` implementations in `crates/terminal_view/src/terminal_view.rs`, `crates/language_tools/src/lsp_log_view.rs`, and `crates/debugger_tools/src/dap_log.rs` show the search-bar integration contract.
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md` deferred `fd4d8444cf` because the direct upstream patch assumed a different markdown rendering path.
+- Repo guidance requires focused changes, no drive-by `.rules` edits, and `./script/clippy` instead of raw `cargo clippy`.
+
+### External References
+
+- Upstream commit: `fd4d8444cf markdown_preview: Add search support to markdown preview (#52502)`.
+
+## Key Technical Decisions
+
+- **Adapt the behavior, not the upstream renderer:** Preserve Superzent's current parsed markdown renderer and carry only the search contract, matching logic, keymaps, and highlighting behavior that fit the current code.
+- **Search rendered segments rather than source markdown:** Extract searchable segments from headings, paragraphs, lists, block quotes, tables, and code blocks so users search what they see instead of markdown formatting syntax.
+- **Track matches by block and source-backed text segment:** Store `block_index`, `text_source_range`, and in-segment `text_range` so navigation can reveal the right virtual list row and rendering can apply highlights to the correct `InteractiveText` or code block.
+- **Keep selection explicitly out of scope:** `select_matches` remains a no-op and `supported_options().selection` remains false because preview selection requires separate state and mouse handling.
+- **Centralize plain-string search in `SearchQuery`:** Add `SearchQuery::search_str` so markdown preview can reuse existing search semantics without creating a markdown-specific query engine.
+
+## Implementation Units
+
+- [ ] **U1: Add reusable `SearchQuery::search_str` helper**
+
+  **Goal:** Let non-buffer surfaces search plain strings with the same query semantics as existing search UI options.
+
+  **Requirements:** R2, R6
+
+  **Files:**
+
+  - Modify: `crates/project/src/search.rs`
+
+  **Approach:**
+
+  Add a synchronous helper that returns byte ranges in an input `&str` for both text and regex queries. Preserve whole-word filtering for text queries and line-by-line behavior for non-multiline regex queries.
+
+  **Patterns to follow:**
+
+  - Existing `SearchQuery` enum behavior in `crates/project/src/search.rs`.
+
+  **Test scenarios:**
+
+  - Text search finds multiple matches and excludes embedded whole-word false positives.
+  - Regex search respects one-match-per-line behavior.
+  - Empty queries return no ranges.
+
+  **Verification:**
+
+  - `cargo test -p project search_str`
+
+- [ ] **U2: Make markdown preview searchable**
+
+  **Goal:** Integrate `MarkdownPreviewView` with the workspace search bar and maintain match state for counts and navigation.
+
+  **Requirements:** R1, R2, R3, R5, R7
+
+  **Files:**
+
+  - Modify: `crates/markdown_preview/Cargo.toml`
+  - Modify: `crates/markdown_preview/src/markdown_preview_view.rs`
+  - Modify: `Cargo.lock`
+
+  **Approach:**
+
+  Implement `SearchableItem` for `MarkdownPreviewView`, expose the item via `Item::as_searchable`, store matches on the view, invalidate matches after markdown reparses, and scroll the virtual list to the active match block during navigation.
+
+  **Patterns to follow:**
+
+  - Existing `SearchableItem` behavior in `crates/terminal_view/src/terminal_view.rs`.
+  - Existing markdown preview `ListState` row navigation in `crates/markdown_preview/src/markdown_preview_view.rs`.
+
+  **Test scenarios:**
+
+  - Search segments include headings, paragraphs, list item text, block quote text, table text, and code block contents.
+  - Images, horizontal rules, and mermaid diagrams do not produce searchable text segments.
+  - `select_matches` and replacement remain no-ops.
+
+  **Verification:**
+
+  - `cargo test -p markdown_preview search_segments_include_rendered_text_and_code_blocks`
+
+- [ ] **U3: Render search highlights in markdown text and code blocks**
+
+  **Goal:** Show all matches and the active match with existing theme colors while preserving current rendered markdown styling.
+
+  **Requirements:** R4, R5
+
+  **Files:**
+
+  - Modify: `crates/markdown_preview/src/markdown_renderer.rs`
+
+  **Approach:**
+
+  Pass search state through `RenderContext`, map each match to highlights for its source-backed text segment, and combine those highlights with syntax, inline-code, and link styling.
+
+  **Patterns to follow:**
+
+  - Current `gpui::combine_highlights` usage in markdown text rendering.
+  - Theme search colors from `theme.colors().search_match_background` and `search_active_match_background`.
+
+  **Test scenarios:**
+
+  - Inline markdown text still renders syntax/link/inline-code styles with search backgrounds layered in.
+  - Code blocks preserve syntax highlights while adding search backgrounds.
+  - Active match uses a distinct background from inactive matches.
+
+  **Verification:**
+
+  - Focused compile/test of `markdown_preview`.
+  - Manual preview smoke test if a local UI run is available.
+
+- [ ] **U4: Wire markdown preview keymaps and finish verification**
+
+  **Goal:** Ensure normal platform search shortcuts deploy the search bar while preview has focus.
+
+  **Requirements:** R1
+
+  **Files:**
+
+  - Modify: `assets/keymaps/default-macos.json`
+  - Modify: `assets/keymaps/default-linux.json`
+  - Modify: `assets/keymaps/default-windows.json`
+  - Modify: `assets/keymaps/vim.json`
+
+  **Approach:**
+
+  Add `buffer_search::Deploy` bindings under the existing `MarkdownPreview` key context for macOS, Linux, Windows, and Vim modes.
+
+  **Patterns to follow:**
+
+  - Existing `MarkdownPreview` scroll bindings in the same keymap sections.
+
+  **Test scenarios:**
+
+  - Cmd-F works in macOS preview context.
+  - Ctrl-F/find works in Linux and Windows preview contexts.
+  - Vim `/` deploys search while preview is focused.
+
+  **Verification:**
+
+  - Keymap JSON remains valid.
+  - Final local checks include focused unit tests and `./script/clippy` if feasible.
+
+## System-Wide Impact
+
+- **Search UI:** Reuses the existing buffer search bar and search event model instead of adding a separate preview search UI.
+- **Preview rendering:** Adds highlight state to rendering context but does not change markdown parsing or block layout.
+- **Performance:** Search runs on extracted text segments in a background task. Large markdown files still avoid blocking the foreground thread during query execution.
+- **Error handling:** Search helper returns empty results for empty queries and does not introduce fallible operations.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Direct upstream patch diverges from current renderer | Adapt only the behavior to current `ParsedMarkdown` and `RenderContext` structures |
+| Highlight byte ranges drift from rendered text | Store ranges relative to each extracted text segment and render highlights only when the segment source range matches |
+| Users expect text selection from search | Keep `selection: false`, document `select_matches` as out of scope, and do not present selection UI |
+| Search helper subtly diverges from buffer search semantics | Keep tests around text whole-word and regex per-line behavior |
+
+## Sources & References
+
+- Origin requirements: `docs/brainstorms/2026-04-23-upstream-sync-editor-search-requirements.md`
+- Prior plan deferral: `docs/plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md`
+- Upstream source commit: `fd4d8444cf markdown_preview: Add search support to markdown preview (#52502)`

--- a/docs/plans/2026-05-05-001-feat-markdown-preview-search-plan.md
+++ b/docs/plans/2026-05-05-001-feat-markdown-preview-search-plan.md
@@ -193,12 +193,12 @@ Markdown preview currently behaves like a focused item but not a searchable item
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-| --- | --- |
-| Direct upstream patch diverges from current renderer | Adapt only the behavior to current `ParsedMarkdown` and `RenderContext` structures |
-| Highlight byte ranges drift from rendered text | Store ranges relative to each extracted text segment and render highlights only when the segment source range matches |
-| Users expect text selection from search | Keep `selection: false`, document `select_matches` as out of scope, and do not present selection UI |
-| Search helper subtly diverges from buffer search semantics | Keep tests around text whole-word and regex per-line behavior |
+| Risk                                                       | Mitigation                                                                                                            |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Direct upstream patch diverges from current renderer       | Adapt only the behavior to current `ParsedMarkdown` and `RenderContext` structures                                    |
+| Highlight byte ranges drift from rendered text             | Store ranges relative to each extracted text segment and render highlights only when the segment source range matches |
+| Users expect text selection from search                    | Keep `selection: false`, document `select_matches` as out of scope, and do not present selection UI                   |
+| Search helper subtly diverges from buffer search semantics | Keep tests around text whole-word and regex per-line behavior                                                         |
 
 ## Sources & References
 

--- a/docs/solutions/best-practices/markdown-preview-search-backport-current-renderer-2026-05-05.md
+++ b/docs/solutions/best-practices/markdown-preview-search-backport-current-renderer-2026-05-05.md
@@ -1,0 +1,112 @@
+---
+title: "Backport markdown preview search against the current renderer"
+date: "2026-05-05"
+category: best-practices
+module: markdown_preview
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - "Backporting an upstream feature whose implementation assumes a newer renderer or entity model"
+  - "Adding search support to a non-editor GPUI item through SearchableItem"
+  - "Searching rendered markdown without implementing preview text selection"
+tags:
+  - markdown-preview
+  - search
+  - upstream-backport
+  - searchable-item
+  - gpui
+  - renderer-boundary
+---
+
+# Backport markdown preview search against the current renderer
+
+## Context
+
+Upstream Zed commit `fd4d8444cf` added markdown preview search, but its patch assumed the newer `Markdown` entity rendering path. Superzent's markdown preview still renders parsed markdown blocks through `MarkdownPreviewView` and `RenderContext`, so a direct cherry-pick would have turned a scoped search feature into a renderer migration.
+
+Session history for the `markdown-preview-search` worktree confirmed this started from the upstream-sync plan's deferred markdown-preview-search item. The useful pattern was to preserve the current renderer and adapt only the search behavior: `SearchableItem` integration, rendered-text match extraction, highlight composition, active-match scrolling, and keymap wiring.
+
+## Guidance
+
+When backporting a feature from upstream into an older or intentionally different rendering path, separate the user-facing contract from the upstream internal architecture.
+
+For markdown preview search, the contract was:
+
+- Cmd/Ctrl-F deploys the existing buffer search bar while preview is focused.
+- The preview implements `SearchableItem`.
+- Search candidates are rendered text and code block contents, not raw markdown syntax.
+- Matches are highlighted in rendered inline text and code blocks.
+- Next/previous navigation scrolls the matching preview block into view.
+- Replacement, text drag selection, and `select_matches` remain out of scope.
+
+The implementation that fit Superzent's current renderer used three local boundaries:
+
+- `crates/project/src/search.rs`: add `SearchQuery::search_str` so non-buffer surfaces can reuse existing query semantics.
+- `crates/markdown_preview/src/markdown_preview_view.rs`: extract rendered search segments and implement `SearchableItem` on the preview item.
+- `crates/markdown_preview/src/markdown_renderer.rs`: pass search matches through `RenderContext` and combine search backgrounds with existing syntax, link, and inline-code highlights.
+
+The important detail is that matches are stored with both a preview block and a source-backed rendered segment:
+
+```rust
+pub struct MarkdownSearchMatch {
+    pub(crate) block_index: usize,
+    pub(crate) text_source_range: Range<usize>,
+    pub(crate) text_range: Range<usize>,
+}
+```
+
+That lets navigation reveal the right virtual-list row while rendering applies highlights only to the `InteractiveText` or code block whose source range produced the match.
+
+## Why This Matters
+
+Directly importing upstream code across a renderer boundary tends to pull in unrelated architecture. In this case, the upstream behavior was small, but the upstream implementation depended on a different markdown rendering model. Adapting the contract preserved the current Superzent renderer, kept the PR reviewable, and avoided accidental work on text selection or drag handling.
+
+It also made the non-goals explicit. Markdown preview search can support highlighting and navigation without pretending it supports editor-like selection. Keeping `selection: false`, `replacement: false`, and a no-op `select_matches` prevents the search UI from advertising behavior the preview cannot perform safely yet.
+
+## When to Apply
+
+- An upstream PR is valuable but assumes a newer component architecture than the current branch has.
+- A GPUI item should integrate with existing search UI without becoming an editor.
+- The rendered surface differs from source text and search should match what users see.
+- Implementing selection, copy, or drag behavior would require new state and input handling beyond the intended scope.
+
+## Examples
+
+Prefer rendered-segment extraction over searching raw markdown source:
+
+```rust
+fn search_segments_for_paragraph(
+    paragraph: &MarkdownParagraph,
+    block_index: usize,
+    segments: &mut Vec<MarkdownSearchSegment>,
+) {
+    for chunk in paragraph {
+        if let MarkdownParagraphChunk::Text(text) = chunk {
+            segments.push(MarkdownSearchSegment {
+                block_index,
+                text_source_range: text.source_range.clone(),
+                text: text.contents.to_string(),
+            });
+        }
+    }
+}
+```
+
+Prefer highlight composition over replacing existing text styling:
+
+```rust
+let highlights = gpui::combine_highlights(
+    gpui::combine_highlights(syntax_highlights, region_highlights),
+    search_highlights,
+);
+```
+
+Cover the renderer boundary in tests. The search segment test should include text-bearing nested structures such as lists, block quotes, tables, and code blocks, and it should also assert that non-text blocks such as images, horizontal rules, and mermaid diagrams do not create search candidates.
+
+## Related
+
+- Plan: `docs/plans/2026-05-05-001-feat-markdown-preview-search-plan.md`
+- Origin requirements: `docs/brainstorms/2026-04-23-upstream-sync-editor-search-requirements.md`
+- Prior deferred item: `docs/plans/2026-04-23-001-feat-upstream-editor-search-sync-plan.md`
+- Upstream commit: `fd4d8444cf markdown_preview: Add search support to markdown preview (#52502)`


### PR DESCRIPTION
## Summary

Adds search support to the markdown preview without adopting upstream Zed's newer markdown renderer. The preview now exposes `SearchableItem`, searches rendered text/code segments, highlights matches in inline text and code blocks, and scrolls next/previous navigation to the matching preview block.

This also adds `SearchQuery::search_str` for plain string search surfaces, wires MarkdownPreview Cmd/Ctrl-F and Vim `/` keymaps, and records the renderer-boundary backport pattern in `docs/solutions/`.

## Verification

- `cargo fmt --check`
- `cargo check -p markdown_preview`
- `cargo check -p project`
- `cargo test -p markdown_preview`
- `cargo test -p project search_str`
- `./script/clippy -p markdown_preview -p project`
- Browser test skipped: `agent-browser` is not installed, and this is a native GPUI/Rust surface rather than a browser route.

## Review

- Autofix review found a missing coverage edge and added table/non-text-block search segment coverage.
- Residual actionable work: none.

## Compound

- Added `docs/solutions/best-practices/markdown-preview-search-backport-current-renderer-2026-05-05.md` documenting how to adapt upstream markdown preview behavior to Superzent's current renderer boundary.

## Suggested .rules additions

- When backporting upstream `markdown_preview` changes, first check whether the patch targets upstream's newer `Markdown` entity renderer. If the current branch still uses the parsed-block/list renderer, adapt behavior at the `SearchableItem` and `RenderContext` boundary instead of importing a renderer refactor.

Release Notes:

- Added search support to markdown preview.
