### PR TITLE
Fix hidden Superzent startup window

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1741,12 +1741,10 @@ async fn restore_superzent_startup_workspace(
     }
 
     match cx
-        .update(|cx| {
-            workspace::Workspace::new_local(vec![], app_state.clone(), None, None, None, true, cx)
-        })
+        .update(|cx| workspace::open_new(Default::default(), app_state.clone(), cx, |_, _, _| {}))
         .await
     {
-        Ok(_) => Ok(true),
+        Ok(()) => Ok(true),
         Err(error) => {
             log::error!("Failed to open empty startup workspace: {error:#}");
             Ok(false)
@@ -1785,7 +1783,13 @@ async fn restore_local_superzent_startup_workspace(
         })
         .await
     {
-        Ok(_) => {
+        Ok((window, _)) => {
+            window
+                .update(cx, |_, window, _cx| {
+                    window.activate_window();
+                })
+                .context("Failed to activate restored Superzent startup workspace window")
+                .log_err();
             cx.update(|cx| {
                 store.update(cx, |store: &mut superzent_model::SuperzentStore, cx| {
                     store.record_workspace_opened(&workspace_id, cx);


### PR DESCRIPTION
## Summary

- Use the standard empty workspace open path for Superzent startup fallback so the window is activated.
- Activate restored local Superzent startup windows after creation.

## Verification

- cargo fmt --check
- cargo test -p superzent test_superzent_startup_restores_only_startup_workspace
- cargo test -p superzent test_superzent_startup_falls_back_to_latest_local_workspace
- cargo check -p superzent

Release Notes:

- Fixed Superzent startup opening without a visible application window.