### PR TITLE
superzent_ui: Add history tab to details sidebar

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -6,9 +6,10 @@ use git::{
     Oid, RunHook,
     blame::Blame,
     repository::{
-        AskPassDelegate, Branch, CommitDataReader, CommitDetails, CommitOptions, FetchOptions,
-        GRAPH_CHUNK_SIZE, GitRepository, GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder,
-        LogSource, PushOptions, Remote, RepoPath, ResetMode, Worktree,
+        AskPassDelegate, Branch, CommitDataReader, CommitDetails, CommitOptions, CommitSummary,
+        FetchOptions, GRAPH_CHUNK_SIZE, GitRepository, GitRepositoryCheckpoint,
+        InitialGraphCommitData, LogOrder, LogSource, PushOptions, Remote, RepoPath, ResetMode,
+        Worktree,
     },
     status::{
         DiffTreeType, FileStatus, GitStatus, StatusCode, TrackedStatus, TreeDiff, TreeDiffStatus,
@@ -398,7 +399,15 @@ impl GitRepository for FakeGitRepository {
                     Branch {
                         is_head: Some(branch_name) == current_branch.as_ref(),
                         ref_name,
-                        most_recent_commit: None,
+                        most_recent_commit: state.graph_commits.first().map(|commit| {
+                            CommitSummary {
+                                sha: commit.sha.to_string().into(),
+                                subject: SharedString::default(),
+                                commit_timestamp: 0,
+                                author_name: SharedString::default(),
+                                has_parent: !commit.parents.is_empty(),
+                            }
+                        }),
                         upstream: None,
                     }
                 })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4967,7 +4967,7 @@ impl GitPanel {
                                                     .child(dot_separator())
                                                 })
                                                 .child(
-                                                    Label::new(short_sha.clone())
+                                                    Label::new(short_sha)
                                                         .size(LabelSize::Small)
                                                         .color(Color::Muted),
                                                 ),

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1033,7 +1033,9 @@ impl GitPanel {
             .is_some_and(|focused| self.focus_handle == focused)
         {
             dispatch_context.add("menu");
-            dispatch_context.add("ChangesList");
+            if self.active_tab == GitPanelTab::Changes {
+                dispatch_context.add("ChangesList");
+            }
         }
 
         if self.commit_editor.read(cx).is_focused(window) {
@@ -6925,6 +6927,12 @@ mod tests {
         cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
         handle.await;
 
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_handle.focus(window, cx);
+            let context = panel.dispatch_context(window, cx);
+            assert!(context.contains("ChangesList"));
+        });
+
         panel.read_with(cx, |panel, cx| {
             let repository = panel.active_repository.as_ref().unwrap();
             let branch = repository.read(cx).branch.as_ref().unwrap().name();
@@ -6942,6 +6950,13 @@ mod tests {
 
         panel.update(cx, |panel, cx| panel.show_history_tab(cx));
         cx.executor().run_until_parked();
+
+        panel.update_in(cx, |panel, window, cx| {
+            panel.focus_handle.focus(window, cx);
+            let context = panel.dispatch_context(window, cx);
+            assert!(context.contains("menu"));
+            assert!(!context.contains("ChangesList"));
+        });
 
         panel.read_with(cx, |panel, _| {
             assert_eq!(panel.debug_active_tab(), "history");

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3414,7 +3414,6 @@ impl GitPanel {
     fn schedule_update(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let handle = cx.entity().downgrade();
         self.reopen_commit_buffer(window, cx);
-        self.preload_commit_history(cx);
         if self.active_tab == GitPanelTab::History {
             self.load_commit_history(cx);
         }
@@ -4605,23 +4604,6 @@ impl GitPanel {
             }
         }
         cx.notify();
-    }
-
-    fn preload_commit_history(&mut self, cx: &mut Context<Self>) {
-        let Some(active_repository) = self.active_repository.as_ref() else {
-            return;
-        };
-
-        let Some(branch) = active_repository.read(cx).branch.as_ref() else {
-            return;
-        };
-
-        let log_source = LogSource::Branch(branch.name().to_string().into());
-        let log_order = LogOrder::DateOrder;
-
-        active_repository.update(cx, |repository, cx| {
-            repository.graph_data(log_source, log_order, 0..0, cx);
-        });
     }
 
     fn load_commit_history(&mut self, cx: &mut Context<Self>) {
@@ -6942,6 +6924,21 @@ mod tests {
         });
         cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
         handle.await;
+
+        panel.read_with(cx, |panel, cx| {
+            let repository = panel.active_repository.as_ref().unwrap();
+            let branch = repository.read(cx).branch.as_ref().unwrap().name();
+            assert!(
+                repository
+                    .read(cx)
+                    .get_graph_data(
+                        LogSource::Branch(branch.to_string().into()),
+                        LogOrder::DateOrder
+                    )
+                    .is_none(),
+                "Changes tab should not start the commit history graph job"
+            );
+        });
 
         panel.update(cx, |panel, cx| panel.show_history_tab(cx));
         cx.executor().run_until_parked();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -294,6 +294,12 @@ enum GitPanelTab {
     History,
 }
 
+struct CommitHistorySnapshot {
+    shas: Vec<Oid>,
+    is_loading: bool,
+    error: Option<SharedString>,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 enum Section {
     Conflict,
@@ -683,6 +689,9 @@ pub struct GitPanel {
     stash_entries: GitStash,
     active_tab: GitPanelTab,
     commit_history_key: Option<(LogSource, LogOrder)>,
+    commit_history_load_finished: bool,
+    commit_history_is_loading: bool,
+    commit_history_error: Option<SharedString>,
     commit_history_scroll_handle: UniformListScrollHandle,
     commit_history_shas: Vec<Oid>,
     focused_history_entry: Option<usize>,
@@ -830,11 +839,11 @@ impl GitPanel {
                 &git_store,
                 window,
                 move |this, _git_store, event, window, cx| match event {
-                    GitStoreEvent::RepositoryUpdated(
-                        _,
-                        RepositoryEvent::StatusesChanged | RepositoryEvent::BranchChanged,
-                        true,
-                    )
+                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::BranchChanged, true) => {
+                        this.invalidate_commit_history();
+                        this.schedule_update(window, cx);
+                    }
+                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, true)
                     | GitStoreEvent::RepositoryAdded
                     | GitStoreEvent::RepositoryRemoved(_)
                     | GitStoreEvent::ActiveRepositoryChanged(_) => {
@@ -893,6 +902,9 @@ impl GitPanel {
                 stash_entries: Default::default(),
                 active_tab: GitPanelTab::Changes,
                 commit_history_key: None,
+                commit_history_load_finished: false,
+                commit_history_is_loading: false,
+                commit_history_error: None,
                 commit_history_scroll_handle: UniformListScrollHandle::new(),
                 commit_history_shas: Vec::new(),
                 focused_history_entry: None,
@@ -3490,9 +3502,7 @@ impl GitPanel {
                 .as_ref()
                 .map(|repository| repository.entity_id())
         {
-            self.commit_history_shas.clear();
-            self.focused_history_entry = None;
-            self.history_keyboard_nav = false;
+            self.clear_commit_history();
             self.commit_history_key = None;
             self._repo_subscriptions.clear();
         }
@@ -4597,9 +4607,7 @@ impl GitPanel {
         self.active_tab = tab;
         match tab {
             GitPanelTab::Changes => {
-                self.commit_history_shas.clear();
-                self.focused_history_entry = None;
-                self.history_keyboard_nav = false;
+                self.clear_commit_history();
                 self.commit_history_key = None;
                 self._repo_subscriptions.clear();
             }
@@ -4620,13 +4628,12 @@ impl GitPanel {
         };
         let Some(commit_history_key) = self.commit_history_key(cx) else {
             self.reset_commit_history();
+            self.commit_history_load_finished = true;
             return;
         };
 
         if self.commit_history_key.as_ref() != Some(&commit_history_key) {
-            self.commit_history_shas.clear();
-            self.focused_history_entry = None;
-            self.history_keyboard_nav = false;
+            self.clear_commit_history();
             self.commit_history_key = Some(commit_history_key);
         }
 
@@ -4648,16 +4655,30 @@ impl GitPanel {
                             cx.notify();
                         }
                     }
-                    RepositoryEvent::GraphEvent(
-                        (source, order),
-                        GitGraphEvent::FullyLoaded | GitGraphEvent::LoadingError,
-                    ) if this.active_tab == GitPanelTab::History
-                        && this.commit_history_key.as_ref().is_some_and(
-                            |(current_source, current_order)| {
-                                current_source == source && current_order == order
-                            },
-                        ) =>
+                    RepositoryEvent::GraphEvent((source, order), GitGraphEvent::FullyLoaded)
+                        if this.active_tab == GitPanelTab::History
+                            && this.commit_history_key.as_ref().is_some_and(
+                                |(current_source, current_order)| {
+                                    current_source == source && current_order == order
+                                },
+                            ) =>
                     {
+                        this.replace_commit_history_shas(cx);
+                        this.commit_history_is_loading = false;
+                        this.commit_history_load_finished = true;
+                        cx.notify();
+                    }
+                    RepositoryEvent::GraphEvent((source, order), GitGraphEvent::LoadingError)
+                        if this.active_tab == GitPanelTab::History
+                            && this.commit_history_key.as_ref().is_some_and(
+                                |(current_source, current_order)| {
+                                    current_source == source && current_order == order
+                                },
+                            ) =>
+                    {
+                        this.replace_commit_history_shas(cx);
+                        this.commit_history_is_loading = false;
+                        this.commit_history_load_finished = true;
                         cx.notify();
                     }
                     _ => {}
@@ -4671,16 +4692,27 @@ impl GitPanel {
             ));
         }
 
-        if self.commit_history_shas.is_empty() {
+        if self.commit_history_shas.is_empty() && !self.commit_history_load_finished {
             self.replace_commit_history_shas(cx);
         }
     }
 
-    fn reset_commit_history(&mut self) {
-        self.commit_history_key = None;
+    fn clear_commit_history(&mut self) {
+        self.commit_history_load_finished = false;
+        self.commit_history_is_loading = false;
+        self.commit_history_error = None;
         self.commit_history_shas.clear();
         self.focused_history_entry = None;
         self.history_keyboard_nav = false;
+    }
+
+    fn invalidate_commit_history(&mut self) {
+        self.clear_commit_history();
+        self.commit_history_key = None;
+    }
+
+    fn reset_commit_history(&mut self) {
+        self.invalidate_commit_history();
         self._repo_subscriptions.clear();
     }
 
@@ -4696,27 +4728,31 @@ impl GitPanel {
         Some((LogSource::Branch(branch_name.into()), LogOrder::DateOrder))
     }
 
-    fn load_commit_history_shas(
+    fn load_commit_history_snapshot(
         &self,
         range: Range<usize>,
         cx: &mut Context<Self>,
-    ) -> Option<Vec<Oid>> {
+    ) -> Option<CommitHistorySnapshot> {
         let active_repository = self.active_repository.as_ref()?;
         let (log_source, log_order) = self.commit_history_key.clone()?;
         Some(active_repository.update(cx, |repository, cx| {
-            repository
-                .graph_data(log_source, log_order, range, cx)
-                .commits
-                .iter()
-                .map(|commit| commit.sha)
-                .collect()
+            let graph_data = repository.graph_data(log_source, log_order, range, cx);
+            CommitHistorySnapshot {
+                shas: graph_data.commits.iter().map(|commit| commit.sha).collect(),
+                is_loading: graph_data.is_loading,
+                error: graph_data.error.clone(),
+            }
         }))
     }
 
     fn replace_commit_history_shas(&mut self, cx: &mut Context<Self>) {
-        self.commit_history_shas = self
-            .load_commit_history_shas(0..usize::MAX, cx)
-            .unwrap_or_default();
+        let Some(snapshot) = self.load_commit_history_snapshot(0..usize::MAX, cx) else {
+            self.clear_commit_history();
+            return;
+        };
+
+        self.commit_history_shas = snapshot.shas;
+        self.update_commit_history_load_state(snapshot.is_loading, snapshot.error);
         self.normalize_focused_history_entry();
     }
 
@@ -4726,16 +4762,25 @@ impl GitPanel {
             return false;
         }
 
-        let Some(mut new_shas) = self.load_commit_history_shas(old_len..commit_count, cx) else {
+        let Some(mut snapshot) = self.load_commit_history_snapshot(old_len..commit_count, cx)
+        else {
             return false;
         };
-        if new_shas.is_empty() {
+        self.update_commit_history_load_state(snapshot.is_loading, snapshot.error);
+        if snapshot.shas.is_empty() {
             return false;
         }
 
-        self.commit_history_shas.append(&mut new_shas);
+        self.commit_history_shas.append(&mut snapshot.shas);
         self.normalize_focused_history_entry();
         true
+    }
+
+    fn update_commit_history_load_state(&mut self, is_loading: bool, error: Option<SharedString>) {
+        self.commit_history_is_loading = is_loading;
+        self.commit_history_error = error;
+        self.commit_history_load_finished =
+            !self.commit_history_is_loading || self.commit_history_error.is_some();
     }
 
     fn normalize_focused_history_entry(&mut self) {
@@ -4851,6 +4896,22 @@ impl GitPanel {
                 )
             } else if let Some(history) = self.render_commit_history(window, cx) {
                 this.child(history)
+            } else if self.commit_history_error.is_some() {
+                this.child(
+                    v_flex()
+                        .flex_1()
+                        .items_center()
+                        .justify_center()
+                        .child(Label::new("Unable to load commit history").color(Color::Muted)),
+                )
+            } else if self.commit_history_load_finished {
+                this.child(
+                    v_flex()
+                        .flex_1()
+                        .items_center()
+                        .justify_center()
+                        .child(Label::new("No commits yet").color(Color::Muted)),
+                )
             } else {
                 this.child(
                     v_flex()
@@ -7028,7 +7089,12 @@ mod tests {
         });
 
         panel.update(cx, |panel, cx| panel.show_history_tab(cx));
-        cx.executor().run_until_parked();
+        for _ in 0..10 {
+            cx.executor().run_until_parked();
+            if panel.read_with(cx, |panel, _| panel.commit_history_load_finished) {
+                break;
+            }
+        }
 
         panel.update_in(cx, |panel, window, cx| {
             panel.focus_handle.focus(window, cx);
@@ -7044,6 +7110,87 @@ mod tests {
                 commits.iter().map(|commit| commit.sha).collect::<Vec<_>>()
             );
             assert_eq!(panel.focused_history_entry, Some(0));
+            assert!(panel.commit_history_load_finished);
+            assert!(!panel.commit_history_is_loading);
+            assert!(panel.commit_history_error.is_none());
+        });
+
+        let repository = panel.read_with(cx, |panel, _| panel.active_repository.clone().unwrap());
+        repository.update(cx, |_repository, cx| {
+            cx.emit(RepositoryEvent::BranchChanged);
+        });
+        cx.executor().run_until_parked();
+
+        panel.read_with(cx, |panel, _| {
+            assert!(panel.commit_history_key.is_none());
+            assert!(panel.commit_history_shas.is_empty());
+            assert_eq!(panel.focused_history_entry, None);
+            assert!(!panel.commit_history_load_finished);
+            assert!(!panel.commit_history_is_loading);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_history_tab_finishes_loading_for_empty_history(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/root/project"),
+            json!({
+                ".git": {},
+                "a.txt": "hello",
+            }),
+        )
+        .await;
+
+        fs.set_branch_name(Path::new(path!("/root/project/.git")), Some("main"));
+        fs.set_graph_commits(Path::new(path!("/root/project/.git")), Vec::new());
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        panel.update(cx, |panel, cx| panel.show_history_tab(cx));
+        for _ in 0..10 {
+            cx.executor().run_until_parked();
+            if panel.read_with(cx, |panel, _| panel.commit_history_load_finished) {
+                break;
+            }
+        }
+
+        panel.read_with(cx, |panel, _| {
+            assert_eq!(panel.debug_active_tab(), "history");
+            assert!(panel.commit_history_shas.is_empty());
+            assert!(panel.commit_history_load_finished);
+            assert!(!panel.commit_history_is_loading);
+            assert!(panel.commit_history_error.is_none());
+            assert_eq!(panel.focused_history_entry, None);
         });
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4771,15 +4771,15 @@ impl GitPanel {
     }
 
     fn commit_history_key(&self, cx: &App) -> Option<(LogSource, LogOrder)> {
-        let branch_ref_name = self
+        let branch = self
             .active_repository
             .as_ref()?
             .read(cx)
             .branch
             .as_ref()?
-            .ref_name
-            .as_ref()
-            .to_string();
+            .clone();
+        branch.most_recent_commit.as_ref()?;
+        let branch_ref_name = branch.ref_name.as_ref().to_string();
         Some((
             LogSource::Branch(branch_ref_name.into()),
             LogOrder::DateOrder,
@@ -4789,6 +4789,7 @@ impl GitPanel {
     fn commit_history_unpushed_key(&self, cx: &App) -> Option<(LogSource, LogOrder)> {
         let active_repository = self.active_repository.as_ref()?;
         let branch = active_repository.read(cx).branch.as_ref()?.clone();
+        branch.most_recent_commit.as_ref()?;
         let upstream = branch.upstream.as_ref()?;
         let log_source = format!("{}..{}", upstream.ref_name, branch.ref_name);
         Some((LogSource::Branch(log_source.into()), LogOrder::DateOrder))
@@ -7305,11 +7306,26 @@ mod tests {
 
         panel.read_with(cx, |panel, _| {
             assert_eq!(panel.debug_active_tab(), "history");
+            assert_eq!(panel.commit_history_key, None);
+            assert_eq!(panel.commit_history_unpushed_key, None);
             assert!(panel.commit_history_shas.is_empty());
             assert!(panel.commit_history_load_finished);
             assert!(!panel.commit_history_is_loading);
             assert!(panel.commit_history_error.is_none());
             assert_eq!(panel.focused_history_entry, None);
+        });
+        panel.read_with(cx, |panel, cx| {
+            let repository = panel.active_repository.as_ref().unwrap();
+            assert!(
+                repository
+                    .read(cx)
+                    .get_graph_data(
+                        LogSource::Branch("refs/heads/main".into()),
+                        LogOrder::DateOrder
+                    )
+                    .is_none(),
+                "Unborn branches should not start a commit history graph job"
+            );
         });
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -61,7 +61,8 @@ use panel::{PanelHeader, panel_button, panel_filled_button, panel_icon_button};
 use project::{
     Fs, Project, ProjectPath,
     git_store::{
-        CommitDataState, GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op,
+        CommitDataState, GitGraphEvent, GitStoreEvent, Repository, RepositoryEvent, RepositoryId,
+        pending_op,
     },
     project_settings::{GitPathStyle, ProjectSettings},
 };
@@ -681,6 +682,7 @@ pub struct GitPanel {
     bulk_staging: Option<BulkStaging>,
     stash_entries: GitStash,
     active_tab: GitPanelTab,
+    commit_history_key: Option<(LogSource, LogOrder)>,
     commit_history_scroll_handle: UniformListScrollHandle,
     commit_history_shas: Vec<Oid>,
     focused_history_entry: Option<usize>,
@@ -890,6 +892,7 @@ impl GitPanel {
                 bulk_staging: None,
                 stash_entries: Default::default(),
                 active_tab: GitPanelTab::Changes,
+                commit_history_key: None,
                 commit_history_scroll_handle: UniformListScrollHandle::new(),
                 commit_history_shas: Vec::new(),
                 focused_history_entry: None,
@@ -3416,9 +3419,6 @@ impl GitPanel {
     fn schedule_update(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let handle = cx.entity().downgrade();
         self.reopen_commit_buffer(window, cx);
-        if self.active_tab == GitPanelTab::History {
-            self.load_commit_history(cx);
-        }
         self.update_visible_entries_task = cx.spawn_in(window, async move |_, cx| {
             cx.background_executor().timer(UPDATE_DEBOUNCE).await;
             if let Some(git_panel) = handle.upgrade() {
@@ -3493,7 +3493,11 @@ impl GitPanel {
             self.commit_history_shas.clear();
             self.focused_history_entry = None;
             self.history_keyboard_nav = false;
+            self.commit_history_key = None;
             self._repo_subscriptions.clear();
+        }
+        if self.active_tab == GitPanelTab::History {
+            self.load_commit_history(cx);
         }
         self.entries.clear();
         self.entries_indices.clear();
@@ -4596,6 +4600,7 @@ impl GitPanel {
                 self.commit_history_shas.clear();
                 self.focused_history_entry = None;
                 self.history_keyboard_nav = false;
+                self.commit_history_key = None;
                 self._repo_subscriptions.clear();
             }
             GitPanelTab::History => {
@@ -4609,57 +4614,131 @@ impl GitPanel {
     }
 
     fn load_commit_history(&mut self, cx: &mut Context<Self>) {
-        let Some(active_repository) = self.active_repository.as_ref() else {
+        let Some(active_repository) = self.active_repository.clone() else {
+            self.reset_commit_history();
+            return;
+        };
+        let Some(commit_history_key) = self.commit_history_key(cx) else {
+            self.reset_commit_history();
             return;
         };
 
+        if self.commit_history_key.as_ref() != Some(&commit_history_key) {
+            self.commit_history_shas.clear();
+            self.focused_history_entry = None;
+            self.history_keyboard_nav = false;
+            self.commit_history_key = Some(commit_history_key);
+        }
+
         if self._repo_subscriptions.is_empty() {
             self._repo_subscriptions.push(cx.subscribe(
-                active_repository,
-                |this, _repository, event, cx| {
-                    if let RepositoryEvent::GraphEvent(_, _) = event
-                        && this.active_tab == GitPanelTab::History
+                &active_repository,
+                |this, _repository, event, cx| match event {
+                    RepositoryEvent::GraphEvent(
+                        (source, order),
+                        GitGraphEvent::CountUpdated(commit_count),
+                    ) if this.active_tab == GitPanelTab::History
+                        && this.commit_history_key.as_ref().is_some_and(
+                            |(current_source, current_order)| {
+                                current_source == source && current_order == order
+                            },
+                        ) =>
                     {
-                        this.fetch_commit_history_shas(cx);
+                        if this.append_commit_history_shas(*commit_count, cx) {
+                            cx.notify();
+                        }
                     }
+                    RepositoryEvent::GraphEvent(
+                        (source, order),
+                        GitGraphEvent::FullyLoaded | GitGraphEvent::LoadingError,
+                    ) if this.active_tab == GitPanelTab::History
+                        && this.commit_history_key.as_ref().is_some_and(
+                            |(current_source, current_order)| {
+                                current_source == source && current_order == order
+                            },
+                        ) =>
+                    {
+                        cx.notify();
+                    }
+                    _ => {}
                 },
             ));
             self._repo_subscriptions.push(cx.observe(
-                active_repository,
+                &active_repository,
                 |_this, _repository, cx| {
                     cx.notify();
                 },
             ));
         }
 
-        self.fetch_commit_history_shas(cx);
+        if self.commit_history_shas.is_empty() {
+            self.replace_commit_history_shas(cx);
+        }
     }
 
-    fn fetch_commit_history_shas(&mut self, cx: &mut Context<Self>) {
-        let Some(active_repository) = self.active_repository.as_ref() else {
-            self.commit_history_shas.clear();
-            self.focused_history_entry = None;
-            return;
-        };
+    fn reset_commit_history(&mut self) {
+        self.commit_history_key = None;
+        self.commit_history_shas.clear();
+        self.focused_history_entry = None;
+        self.history_keyboard_nav = false;
+        self._repo_subscriptions.clear();
+    }
 
-        let Some(branch) = active_repository.read(cx).branch.as_ref() else {
-            self.commit_history_shas.clear();
-            self.focused_history_entry = None;
-            return;
-        };
+    fn commit_history_key(&self, cx: &App) -> Option<(LogSource, LogOrder)> {
+        let branch_name = self
+            .active_repository
+            .as_ref()?
+            .read(cx)
+            .branch
+            .as_ref()?
+            .name()
+            .to_string();
+        Some((LogSource::Branch(branch_name.into()), LogOrder::DateOrder))
+    }
 
-        let log_source = LogSource::Branch(branch.name().to_string().into());
-        let log_order = LogOrder::DateOrder;
-
-        self.commit_history_shas = active_repository.update(cx, |repository, cx| {
+    fn load_commit_history_shas(
+        &self,
+        range: Range<usize>,
+        cx: &mut Context<Self>,
+    ) -> Option<Vec<Oid>> {
+        let active_repository = self.active_repository.as_ref()?;
+        let (log_source, log_order) = self.commit_history_key.clone()?;
+        Some(active_repository.update(cx, |repository, cx| {
             repository
-                .graph_data(log_source, log_order, 0..usize::MAX, cx)
+                .graph_data(log_source, log_order, range, cx)
                 .commits
                 .iter()
                 .map(|commit| commit.sha)
                 .collect()
-        });
+        }))
+    }
 
+    fn replace_commit_history_shas(&mut self, cx: &mut Context<Self>) {
+        self.commit_history_shas = self
+            .load_commit_history_shas(0..usize::MAX, cx)
+            .unwrap_or_default();
+        self.normalize_focused_history_entry();
+    }
+
+    fn append_commit_history_shas(&mut self, commit_count: usize, cx: &mut Context<Self>) -> bool {
+        let old_len = self.commit_history_shas.len();
+        if commit_count <= old_len {
+            return false;
+        }
+
+        let Some(mut new_shas) = self.load_commit_history_shas(old_len..commit_count, cx) else {
+            return false;
+        };
+        if new_shas.is_empty() {
+            return false;
+        }
+
+        self.commit_history_shas.append(&mut new_shas);
+        self.normalize_focused_history_entry();
+        true
+    }
+
+    fn normalize_focused_history_entry(&mut self) {
         if self
             .focused_history_entry
             .is_none_or(|index| index >= self.commit_history_shas.len())

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1,6 +1,6 @@
 use crate::askpass_modal::AskPassModal;
 use crate::commit_modal::CommitModal;
-use crate::commit_tooltip::CommitTooltip;
+use crate::commit_tooltip::{CommitAvatar, CommitTooltip};
 use crate::commit_view::CommitView;
 use crate::project_diff::{self, BranchDiff, Diff, ProjectDiff};
 use crate::remote_output::{self, RemoteAction, SuccessMessage};
@@ -25,20 +25,21 @@ use editor::{EditorStyle, RewrapOptions};
 use file_icons::FileIcons;
 #[cfg(feature = "ai")]
 use futures::StreamExt as _;
-use git::commit::ParsedCommitMessage;
 #[cfg(feature = "ai")]
 use git::repository::DiffType;
 use git::repository::{
-    Branch, CommitDetails, CommitOptions, CommitSummary, FetchOptions, PushOptions, Remote,
-    RemoteCommandOutput, ResetMode, Upstream, UpstreamTracking, UpstreamTrackingStatus,
+    Branch, CommitDetails, CommitOptions, CommitSummary, FetchOptions, LogOrder, LogSource,
+    PushOptions, Remote, RemoteCommandOutput, ResetMode, Upstream, UpstreamTracking,
+    UpstreamTrackingStatus,
 };
 use git::stash::GitStash;
 use git::status::{DiffStat, StageStatus};
 use git::{Amend, Signoff, ToggleStaged, repository::RepoPath, status::FileStatus};
 use git::{
-    ExpandCommitEditor, GitHostingProviderRegistry, RestoreTrackedFiles, StageAll, StashAll,
-    StashApply, StashPop, TrashUntrackedFiles, UnstageAll,
+    ExpandCommitEditor, GitHostingProviderRegistry, GitRemote, RestoreTrackedFiles, StageAll,
+    StashAll, StashApply, StashPop, TrashUntrackedFiles, UnstageAll, parse_git_remote_url,
 };
+use git::{Oid, commit::ParsedCommitMessage};
 #[cfg(feature = "ai")]
 use gpui::AsyncApp;
 use gpui::{
@@ -59,7 +60,9 @@ use notifications::status_toast::{StatusToast, ToastIcon};
 use panel::{PanelHeader, panel_button, panel_filled_button, panel_icon_button};
 use project::{
     Fs, Project, ProjectPath,
-    git_store::{GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op},
+    git_store::{
+        CommitDataState, GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op,
+    },
     project_settings::{GitPathStyle, ProjectSettings},
 };
 #[cfg(feature = "ai")]
@@ -282,6 +285,12 @@ struct SerializedGitPanel {
     amend_pending: bool,
     #[serde(default)]
     signoff_enabled: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum GitPanelTab {
+    Changes,
+    History,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -671,6 +680,12 @@ pub struct GitPanel {
     show_placeholders: bool,
     bulk_staging: Option<BulkStaging>,
     stash_entries: GitStash,
+    active_tab: GitPanelTab,
+    commit_history_scroll_handle: UniformListScrollHandle,
+    commit_history_shas: Vec<Oid>,
+    focused_history_entry: Option<usize>,
+    history_keyboard_nav: bool,
+    _repo_subscriptions: Vec<Subscription>,
 
     _settings_subscription: Subscription,
 }
@@ -874,6 +889,12 @@ impl GitPanel {
                 entry_count: 0,
                 bulk_staging: None,
                 stash_entries: Default::default(),
+                active_tab: GitPanelTab::Changes,
+                commit_history_scroll_handle: UniformListScrollHandle::new(),
+                commit_history_shas: Vec::new(),
+                focused_history_entry: None,
+                history_keyboard_nav: false,
+                _repo_subscriptions: Vec::new(),
                 _settings_subscription,
             };
 
@@ -1102,6 +1123,11 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.active_tab == GitPanelTab::History {
+            self.select_first_history_entry(cx);
+            return;
+        }
+
         let first_entry = match &self.view_mode {
             GitPanelViewMode::Flat => self
                 .entries
@@ -1128,6 +1154,11 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.active_tab == GitPanelTab::History {
+            self.select_previous_history_entry(cx);
+            return;
+        }
+
         let item_count = self.entries.len();
         if item_count == 0 {
             return;
@@ -1189,6 +1220,11 @@ impl GitPanel {
     }
 
     fn select_next(&mut self, _: &menu::SelectNext, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.active_tab == GitPanelTab::History {
+            self.select_next_history_entry(cx);
+            return;
+        }
+
         let item_count = self.entries.len();
         if item_count == 0 {
             return;
@@ -1237,6 +1273,11 @@ impl GitPanel {
     }
 
     fn select_last(&mut self, _: &menu::SelectLast, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.active_tab == GitPanelTab::History {
+            self.select_last_history_entry(cx);
+            return;
+        }
+
         if self.entries.last().is_some() {
             self.selected_entry = Some(self.entries.len() - 1);
             self.scroll_to_selected_entry(cx);
@@ -1312,6 +1353,11 @@ impl GitPanel {
     }
 
     fn open_diff(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        if self.active_tab == GitPanelTab::History {
+            self.open_selected_history_commit(window, cx);
+            return;
+        }
+
         maybe!({
             let entry = self.entries.get(self.selected_entry?)?.status_entry()?;
             let workspace = self.workspace.upgrade()?;
@@ -3368,6 +3414,10 @@ impl GitPanel {
     fn schedule_update(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let handle = cx.entity().downgrade();
         self.reopen_commit_buffer(window, cx);
+        self.preload_commit_history(cx);
+        if self.active_tab == GitPanelTab::History {
+            self.load_commit_history(cx);
+        }
         self.update_visible_entries_task = cx.spawn_in(window, async move |_, cx| {
             cx.background_executor().timer(UPDATE_DEBOUNCE).await;
             if let Some(git_panel) = handle.upgrade() {
@@ -3428,7 +3478,22 @@ impl GitPanel {
             .as_ref()
             .and_then(|op| self.entry_by_path(&op.anchor));
 
+        let previous_repository = self
+            .active_repository
+            .as_ref()
+            .map(|repository| repository.entity_id());
         self.active_repository = self.project.read(cx).active_repository(cx);
+        if previous_repository
+            != self
+                .active_repository
+                .as_ref()
+                .map(|repository| repository.entity_id())
+        {
+            self.commit_history_shas.clear();
+            self.focused_history_entry = None;
+            self.history_keyboard_nav = false;
+            self._repo_subscriptions.clear();
+        }
         self.entries.clear();
         self.entries_indices.clear();
         self.single_staged_entry.take();
@@ -4503,6 +4568,455 @@ impl GitPanel {
         )
     }
 
+    pub fn show_changes_tab(&mut self, cx: &mut Context<Self>) {
+        self.set_active_tab(GitPanelTab::Changes, cx);
+    }
+
+    pub fn show_history_tab(&mut self, cx: &mut Context<Self>) {
+        self.set_active_tab(GitPanelTab::History, cx);
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn debug_active_tab(&self) -> &'static str {
+        match self.active_tab {
+            GitPanelTab::Changes => "changes",
+            GitPanelTab::History => "history",
+        }
+    }
+
+    fn set_active_tab(&mut self, tab: GitPanelTab, cx: &mut Context<Self>) {
+        if self.active_tab == tab {
+            return;
+        }
+
+        self.active_tab = tab;
+        match tab {
+            GitPanelTab::Changes => {
+                self.commit_history_shas.clear();
+                self.focused_history_entry = None;
+                self.history_keyboard_nav = false;
+                self._repo_subscriptions.clear();
+            }
+            GitPanelTab::History => {
+                self.load_commit_history(cx);
+                if self.focused_history_entry.is_none() && !self.commit_history_shas.is_empty() {
+                    self.focused_history_entry = Some(0);
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    fn preload_commit_history(&mut self, cx: &mut Context<Self>) {
+        let Some(active_repository) = self.active_repository.as_ref() else {
+            return;
+        };
+
+        let Some(branch) = active_repository.read(cx).branch.as_ref() else {
+            return;
+        };
+
+        let log_source = LogSource::Branch(branch.name().to_string().into());
+        let log_order = LogOrder::DateOrder;
+
+        active_repository.update(cx, |repository, cx| {
+            repository.graph_data(log_source, log_order, 0..0, cx);
+        });
+    }
+
+    fn load_commit_history(&mut self, cx: &mut Context<Self>) {
+        let Some(active_repository) = self.active_repository.as_ref() else {
+            return;
+        };
+
+        if self._repo_subscriptions.is_empty() {
+            self._repo_subscriptions.push(cx.subscribe(
+                active_repository,
+                |this, _repository, event, cx| {
+                    if let RepositoryEvent::GraphEvent(_, _) = event
+                        && this.active_tab == GitPanelTab::History
+                    {
+                        this.fetch_commit_history_shas(cx);
+                    }
+                },
+            ));
+            self._repo_subscriptions.push(cx.observe(
+                active_repository,
+                |_this, _repository, cx| {
+                    cx.notify();
+                },
+            ));
+        }
+
+        self.fetch_commit_history_shas(cx);
+    }
+
+    fn fetch_commit_history_shas(&mut self, cx: &mut Context<Self>) {
+        let Some(active_repository) = self.active_repository.as_ref() else {
+            self.commit_history_shas.clear();
+            self.focused_history_entry = None;
+            return;
+        };
+
+        let Some(branch) = active_repository.read(cx).branch.as_ref() else {
+            self.commit_history_shas.clear();
+            self.focused_history_entry = None;
+            return;
+        };
+
+        let log_source = LogSource::Branch(branch.name().to_string().into());
+        let log_order = LogOrder::DateOrder;
+
+        self.commit_history_shas = active_repository.update(cx, |repository, cx| {
+            repository
+                .graph_data(log_source, log_order, 0..usize::MAX, cx)
+                .commits
+                .iter()
+                .map(|commit| commit.sha)
+                .collect()
+        });
+
+        if self
+            .focused_history_entry
+            .is_none_or(|index| index >= self.commit_history_shas.len())
+        {
+            self.focused_history_entry = (!self.commit_history_shas.is_empty()).then_some(0);
+        }
+    }
+
+    fn git_remote(&self, cx: &mut App) -> Option<GitRemote> {
+        let repository = self.active_repository.as_ref()?;
+        let remote_url = repository.read(cx).default_remote_url()?;
+        let provider_registry = GitHostingProviderRegistry::default_global(cx);
+        let (host, parsed) = parse_git_remote_url(provider_registry, &remote_url)?;
+        Some(GitRemote {
+            host,
+            owner: parsed.owner.into(),
+            repo: parsed.repo.into(),
+        })
+    }
+
+    fn select_first_history_entry(&mut self, cx: &mut Context<Self>) {
+        if self.commit_history_shas.is_empty() {
+            return;
+        }
+
+        self.focused_history_entry = Some(0);
+        self.history_keyboard_nav = true;
+        self.commit_history_scroll_handle
+            .scroll_to_item(0, ScrollStrategy::Top);
+        cx.notify();
+    }
+
+    fn select_last_history_entry(&mut self, cx: &mut Context<Self>) {
+        let Some(index) = self.commit_history_shas.len().checked_sub(1) else {
+            return;
+        };
+
+        self.focused_history_entry = Some(index);
+        self.history_keyboard_nav = true;
+        self.commit_history_scroll_handle
+            .scroll_to_item(index, ScrollStrategy::Top);
+        cx.notify();
+    }
+
+    fn select_next_history_entry(&mut self, cx: &mut Context<Self>) {
+        let count = self.commit_history_shas.len();
+        if count == 0 {
+            return;
+        }
+
+        let index = match self.focused_history_entry {
+            None => 0,
+            Some(index) => (index + 1).min(count - 1),
+        };
+        self.focused_history_entry = Some(index);
+        self.history_keyboard_nav = true;
+        self.commit_history_scroll_handle
+            .scroll_to_item(index, ScrollStrategy::Top);
+        cx.notify();
+    }
+
+    fn select_previous_history_entry(&mut self, cx: &mut Context<Self>) {
+        let count = self.commit_history_shas.len();
+        if count == 0 {
+            return;
+        }
+
+        let index = match self.focused_history_entry {
+            None => 0,
+            Some(index) => index.saturating_sub(1),
+        };
+        self.focused_history_entry = Some(index);
+        self.history_keyboard_nav = true;
+        self.commit_history_scroll_handle
+            .scroll_to_item(index, ScrollStrategy::Top);
+        cx.notify();
+    }
+
+    fn open_selected_history_commit(&self, window: &mut Window, cx: &mut App) {
+        let Some(index) = self.focused_history_entry else {
+            return;
+        };
+        let Some(sha) = self.commit_history_shas.get(index) else {
+            return;
+        };
+        let Some(repository) = self.active_repository.as_ref() else {
+            return;
+        };
+
+        CommitView::open(
+            sha.to_string(),
+            repository.downgrade(),
+            self.workspace.clone(),
+            None,
+            None,
+            window,
+            cx,
+        );
+    }
+
+    fn render_history_tab(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().flex_1().size_full().overflow_hidden().map(|this| {
+            if self.active_repository.is_none() {
+                this.child(
+                    v_flex()
+                        .flex_1()
+                        .items_center()
+                        .justify_center()
+                        .child(Label::new("No Git repositories").color(Color::Muted)),
+                )
+            } else if let Some(history) = self.render_commit_history(window, cx) {
+                this.child(history)
+            } else {
+                this.child(
+                    v_flex()
+                        .flex_1()
+                        .items_center()
+                        .justify_center()
+                        .child(Label::new("Loading Commit History...").color(Color::Muted)),
+                )
+            }
+        })
+    }
+
+    fn render_commit_history(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<impl IntoElement> {
+        if self.commit_history_shas.is_empty() {
+            return None;
+        }
+
+        let active_repository = self.active_repository.as_ref()?;
+        let workspace = self.workspace.clone();
+        let repository = active_repository.downgrade();
+        let shas = self.commit_history_shas.clone();
+        let item_count = shas.len();
+        let scroll_handle = self.commit_history_scroll_handle.clone();
+        let remote = self.git_remote(cx);
+        let focused_history_entry = self.focused_history_entry;
+        let show_focus_border = self.history_keyboard_nav;
+        let is_panel_focused = self.focus_handle.is_focused(window);
+
+        let ahead_count = active_repository
+            .read(cx)
+            .branch
+            .as_ref()
+            .and_then(|branch| branch.upstream.as_ref())
+            .and_then(|upstream| upstream.tracking.status())
+            .map(|status| status.ahead as usize)
+            .unwrap_or(0);
+
+        Some(
+            v_flex()
+                .flex_1()
+                .size_full()
+                .overflow_hidden()
+                .child(
+                    uniform_list("commit_history_list", item_count, {
+                        let workspace = workspace;
+                        let repository = repository;
+                        let git_panel = cx.weak_entity();
+                        move |range, window, cx| {
+                            let local_offset = time::UtcOffset::current_local_offset()
+                                .unwrap_or(time::UtcOffset::UTC);
+                            let now = time::OffsetDateTime::now_utc();
+
+                            let visible_data = repository
+                                .update(cx, |repository, cx| {
+                                    shas[range.clone()]
+                                        .iter()
+                                        .map(|sha| match repository.fetch_commit_data(*sha, cx) {
+                                            CommitDataState::Loaded(data) => Some(data.clone()),
+                                            CommitDataState::Loading => None,
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
+                                .unwrap_or_default();
+
+                            shas[range.clone()]
+                                .iter()
+                                .zip(visible_data)
+                                .enumerate()
+                                .map(|(offset, (sha, data))| {
+                                    let index = range.start + offset;
+                                    let sha_string = sha.to_string();
+                                    let sha_shared: SharedString = sha_string.clone().into();
+                                    let short_sha: SharedString =
+                                        sha_string[..7.min(sha_string.len())].to_string().into();
+
+                                    let (subject, author_name, author_email, timestamp) = match data
+                                    {
+                                        Some(data) => (
+                                            data.subject.clone(),
+                                            data.author_name.clone(),
+                                            Some(data.author_email.clone()),
+                                            Some(data.commit_timestamp),
+                                        ),
+                                        None => ("Loading...".into(), "".into(), None, None),
+                                    };
+
+                                    let relative_time: SharedString = timestamp
+                                        .and_then(|timestamp| {
+                                            time::OffsetDateTime::from_unix_timestamp(timestamp)
+                                                .ok()
+                                        })
+                                        .map(|commit_time| {
+                                            time_format::format_localized_timestamp(
+                                                commit_time,
+                                                now,
+                                                local_offset,
+                                                time_format::TimestampFormat::Relative,
+                                            )
+                                            .into()
+                                        })
+                                        .unwrap_or_else(|| "".into());
+
+                                    let avatar = CommitAvatar::new(
+                                        &sha_shared,
+                                        author_email,
+                                        remote.as_ref(),
+                                    )
+                                    .size(px(14.))
+                                    .render(window, cx);
+
+                                    let is_unpushed = index < ahead_count;
+                                    let is_focused = focused_history_entry == Some(index);
+                                    let workspace = workspace.clone();
+                                    let repository = repository.clone();
+                                    let sha_for_click = sha_string;
+                                    let short_sha_for_tooltip = short_sha.clone();
+
+                                    let dot_separator = || {
+                                        Label::new(".")
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted)
+                                            .alpha(0.5)
+                                    };
+
+                                    v_flex()
+                                        .id(("commit-history-item", index))
+                                        .cursor_pointer()
+                                        .w_full()
+                                        .py_1()
+                                        .px_2()
+                                        .gap_0p5()
+                                        .border_1()
+                                        .border_color(gpui::transparent_black())
+                                        .when(
+                                            is_focused && is_panel_focused && show_focus_border,
+                                            |this| {
+                                                this.border_color(
+                                                    cx.theme().colors().panel_focused_border,
+                                                )
+                                            },
+                                        )
+                                        .hover(|style| style.bg(cx.theme().colors().element_hover))
+                                        .child(
+                                            h_flex()
+                                                .gap_1()
+                                                .w_full()
+                                                .child(Label::new(subject).truncate())
+                                                .when(is_unpushed, |this| {
+                                                    this.child(
+                                                        Icon::new(IconName::ArrowUp)
+                                                            .size(IconSize::XSmall),
+                                                    )
+                                                }),
+                                        )
+                                        .child(
+                                            h_flex()
+                                                .gap_1p5()
+                                                .child(avatar)
+                                                .when(!author_name.is_empty(), |this| {
+                                                    this.child(
+                                                        Label::new(author_name)
+                                                            .size(LabelSize::Small)
+                                                            .color(Color::Muted),
+                                                    )
+                                                    .child(dot_separator())
+                                                })
+                                                .when(!relative_time.is_empty(), |this| {
+                                                    this.child(
+                                                        Label::new(relative_time)
+                                                            .size(LabelSize::Small)
+                                                            .color(Color::Muted),
+                                                    )
+                                                    .child(dot_separator())
+                                                })
+                                                .child(
+                                                    Label::new(short_sha.clone())
+                                                        .size(LabelSize::Small)
+                                                        .color(Color::Muted),
+                                                ),
+                                        )
+                                        .tooltip(move |_window, cx| {
+                                            Tooltip::with_meta(
+                                                "View Commit",
+                                                None,
+                                                short_sha_for_tooltip.clone(),
+                                                cx,
+                                            )
+                                        })
+                                        .on_mouse_down(MouseButton::Left, {
+                                            let git_panel = git_panel.clone();
+                                            move |_, window, cx| {
+                                                git_panel
+                                                    .update(cx, |git_panel, cx| {
+                                                        window.focus(&git_panel.focus_handle, cx);
+                                                        git_panel.focused_history_entry =
+                                                            Some(index);
+                                                        git_panel.history_keyboard_nav = false;
+                                                        cx.notify();
+                                                    })
+                                                    .ok();
+                                            }
+                                        })
+                                        .on_click(move |_, window, cx| {
+                                            CommitView::open(
+                                                sha_for_click.clone(),
+                                                repository.clone(),
+                                                workspace.clone(),
+                                                None,
+                                                None,
+                                                window,
+                                                cx,
+                                            );
+                                        })
+                                        .into_any_element()
+                                })
+                                .collect()
+                        }
+                    })
+                    .size_full()
+                    .track_scroll(&scroll_handle),
+                )
+                .vertical_scrollbar_for(&scroll_handle, window, cx),
+        )
+    }
+
     fn render_empty_state(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let has_repo = self.active_repository.is_some();
         let has_no_repo = self.active_repository.is_none();
@@ -5560,22 +6074,31 @@ impl Render for GitPanel {
             .child(
                 v_flex()
                     .size_full()
-                    .children(self.render_panel_header(window, cx))
-                    .map(|this| {
-                        if let Some(repo) = self.active_repository.clone()
-                            && has_entries
-                        {
-                            this.child(self.render_entries(has_write_access, repo, window, cx))
-                        } else {
-                            this.child(self.render_empty_state(cx).into_any_element())
-                        }
-                    })
-                    .children(self.render_footer(window, cx))
-                    .when(self.amend_pending, |this| {
-                        this.child(self.render_pending_amend(cx))
-                    })
-                    .when(!self.amend_pending, |this| {
-                        this.children(self.render_previous_commit(window, cx))
+                    .map(|this| match self.active_tab {
+                        GitPanelTab::Changes => this
+                            .children(self.render_panel_header(window, cx))
+                            .map(|this| {
+                                if let Some(repo) = self.active_repository.clone()
+                                    && has_entries
+                                {
+                                    this.child(self.render_entries(
+                                        has_write_access,
+                                        repo,
+                                        window,
+                                        cx,
+                                    ))
+                                } else {
+                                    this.child(self.render_empty_state(cx).into_any_element())
+                                }
+                            })
+                            .children(self.render_footer(window, cx))
+                            .when(self.amend_pending, |this| {
+                                this.child(self.render_pending_amend(cx))
+                            })
+                            .when(!self.amend_pending, |this| {
+                                this.children(self.render_previous_commit(window, cx))
+                            }),
+                        GitPanelTab::History => this.child(self.render_history_tab(window, cx)),
                     })
                     .into_any_element(),
             )
@@ -5593,7 +6116,9 @@ impl Render for GitPanel {
 
 impl Focusable for GitPanel {
     fn focus_handle(&self, cx: &App) -> gpui::FocusHandle {
-        if self.entries.is_empty() {
+        if self.active_tab == GitPanelTab::History {
+            self.focus_handle.clone()
+        } else if self.entries.is_empty() {
             self.commit_editor.focus_handle(cx)
         } else {
             self.focus_handle.clone()
@@ -6360,6 +6885,74 @@ mod tests {
             theme::init(LoadThemes::JustBase, cx);
             editor::init(cx);
             crate::init(cx);
+        });
+    }
+
+    fn graph_commit(byte: u8) -> Arc<git::repository::InitialGraphCommitData> {
+        Arc::new(git::repository::InitialGraphCommitData {
+            sha: git::Oid::from_bytes(&[byte; 20]).unwrap(),
+            parents: SmallVec::new(),
+            ref_names: Vec::new(),
+        })
+    }
+
+    #[gpui::test]
+    async fn test_history_tab_loads_branch_commit_history(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/root/project"),
+            json!({
+                ".git": {},
+                "a.txt": "hello",
+            }),
+        )
+        .await;
+
+        let commits = vec![graph_commit(b'1'), graph_commit(b'2')];
+        fs.set_branch_name(Path::new(path!("/root/project/.git")), Some("main"));
+        fs.set_graph_commits(Path::new(path!("/root/project/.git")), commits.clone());
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        panel.update(cx, |panel, cx| panel.show_history_tab(cx));
+        cx.executor().run_until_parked();
+
+        panel.read_with(cx, |panel, _| {
+            assert_eq!(panel.debug_active_tab(), "history");
+            assert_eq!(
+                panel.commit_history_shas,
+                commits.iter().map(|commit| commit.sha).collect::<Vec<_>>()
+            );
+            assert_eq!(panel.focused_history_entry, Some(0));
         });
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4808,7 +4808,7 @@ impl GitPanel {
             CommitHistorySnapshot {
                 shas: graph_data.commits.iter().map(|commit| commit.sha).collect(),
                 is_loading: graph_data.is_loading,
-                error: graph_data.error.clone(),
+                error: graph_data.error,
             }
         }))
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -689,6 +689,8 @@ pub struct GitPanel {
     stash_entries: GitStash,
     active_tab: GitPanelTab,
     commit_history_key: Option<(LogSource, LogOrder)>,
+    commit_history_unpushed_key: Option<(LogSource, LogOrder)>,
+    commit_history_unpushed_shas: HashSet<Oid>,
     commit_history_load_finished: bool,
     commit_history_is_loading: bool,
     commit_history_error: Option<SharedString>,
@@ -902,6 +904,8 @@ impl GitPanel {
                 stash_entries: Default::default(),
                 active_tab: GitPanelTab::Changes,
                 commit_history_key: None,
+                commit_history_unpushed_key: None,
+                commit_history_unpushed_shas: HashSet::default(),
                 commit_history_load_finished: false,
                 commit_history_is_loading: false,
                 commit_history_error: None,
@@ -3504,6 +3508,7 @@ impl GitPanel {
         {
             self.clear_commit_history();
             self.commit_history_key = None;
+            self.commit_history_unpushed_key = None;
             self._repo_subscriptions.clear();
         }
         if self.active_tab == GitPanelTab::History {
@@ -4609,6 +4614,7 @@ impl GitPanel {
             GitPanelTab::Changes => {
                 self.clear_commit_history();
                 self.commit_history_key = None;
+                self.commit_history_unpushed_key = None;
                 self._repo_subscriptions.clear();
             }
             GitPanelTab::History => {
@@ -4636,6 +4642,11 @@ impl GitPanel {
             self.clear_commit_history();
             self.commit_history_key = Some(commit_history_key);
         }
+        let commit_history_unpushed_key = self.commit_history_unpushed_key(cx);
+        if self.commit_history_unpushed_key != commit_history_unpushed_key {
+            self.commit_history_unpushed_shas.clear();
+            self.commit_history_unpushed_key = commit_history_unpushed_key;
+        }
 
         if self._repo_subscriptions.is_empty() {
             self._repo_subscriptions.push(cx.subscribe(
@@ -4655,7 +4666,45 @@ impl GitPanel {
                             cx.notify();
                         }
                     }
+                    RepositoryEvent::GraphEvent(
+                        (source, order),
+                        GitGraphEvent::CountUpdated(commit_count),
+                    ) if this.active_tab == GitPanelTab::History
+                        && this.commit_history_unpushed_key.as_ref().is_some_and(
+                            |(current_source, current_order)| {
+                                current_source == source && current_order == order
+                            },
+                        ) =>
+                    {
+                        if this.append_commit_history_unpushed_shas(*commit_count, cx) {
+                            cx.notify();
+                        }
+                    }
                     RepositoryEvent::GraphEvent((source, order), GitGraphEvent::FullyLoaded)
+                        if this.active_tab == GitPanelTab::History
+                            && this.commit_history_key.as_ref().is_some_and(
+                                |(current_source, current_order)| {
+                                    current_source == source && current_order == order
+                                },
+                            ) =>
+                    {
+                        this.replace_commit_history_shas(cx);
+                        this.commit_history_is_loading = false;
+                        this.commit_history_load_finished = true;
+                        cx.notify();
+                    }
+                    RepositoryEvent::GraphEvent((source, order), GitGraphEvent::FullyLoaded)
+                        if this.active_tab == GitPanelTab::History
+                            && this.commit_history_unpushed_key.as_ref().is_some_and(
+                                |(current_source, current_order)| {
+                                    current_source == source && current_order == order
+                                },
+                            ) =>
+                    {
+                        this.replace_commit_history_unpushed_shas(cx);
+                        cx.notify();
+                    }
+                    RepositoryEvent::GraphEvent((source, order), GitGraphEvent::LoadingError)
                         if this.active_tab == GitPanelTab::History
                             && this.commit_history_key.as_ref().is_some_and(
                                 |(current_source, current_order)| {
@@ -4670,15 +4719,13 @@ impl GitPanel {
                     }
                     RepositoryEvent::GraphEvent((source, order), GitGraphEvent::LoadingError)
                         if this.active_tab == GitPanelTab::History
-                            && this.commit_history_key.as_ref().is_some_and(
+                            && this.commit_history_unpushed_key.as_ref().is_some_and(
                                 |(current_source, current_order)| {
                                     current_source == source && current_order == order
                                 },
                             ) =>
                     {
-                        this.replace_commit_history_shas(cx);
-                        this.commit_history_is_loading = false;
-                        this.commit_history_load_finished = true;
+                        this.commit_history_unpushed_shas.clear();
                         cx.notify();
                     }
                     _ => {}
@@ -4695,6 +4742,11 @@ impl GitPanel {
         if self.commit_history_shas.is_empty() && !self.commit_history_load_finished {
             self.replace_commit_history_shas(cx);
         }
+        if self.commit_history_unpushed_shas.is_empty()
+            && self.commit_history_unpushed_key.is_some()
+        {
+            self.replace_commit_history_unpushed_shas(cx);
+        }
     }
 
     fn clear_commit_history(&mut self) {
@@ -4702,6 +4754,7 @@ impl GitPanel {
         self.commit_history_is_loading = false;
         self.commit_history_error = None;
         self.commit_history_shas.clear();
+        self.commit_history_unpushed_shas.clear();
         self.focused_history_entry = None;
         self.history_keyboard_nav = false;
     }
@@ -4709,6 +4762,7 @@ impl GitPanel {
     fn invalidate_commit_history(&mut self) {
         self.clear_commit_history();
         self.commit_history_key = None;
+        self.commit_history_unpushed_key = None;
     }
 
     fn reset_commit_history(&mut self) {
@@ -4717,24 +4771,37 @@ impl GitPanel {
     }
 
     fn commit_history_key(&self, cx: &App) -> Option<(LogSource, LogOrder)> {
-        let branch_name = self
+        let branch_ref_name = self
             .active_repository
             .as_ref()?
             .read(cx)
             .branch
             .as_ref()?
-            .name()
+            .ref_name
+            .as_ref()
             .to_string();
-        Some((LogSource::Branch(branch_name.into()), LogOrder::DateOrder))
+        Some((
+            LogSource::Branch(branch_ref_name.into()),
+            LogOrder::DateOrder,
+        ))
     }
 
-    fn load_commit_history_snapshot(
+    fn commit_history_unpushed_key(&self, cx: &App) -> Option<(LogSource, LogOrder)> {
+        let active_repository = self.active_repository.as_ref()?;
+        let branch = active_repository.read(cx).branch.as_ref()?.clone();
+        let upstream = branch.upstream.as_ref()?;
+        let log_source = format!("{}..{}", upstream.ref_name, branch.ref_name);
+        Some((LogSource::Branch(log_source.into()), LogOrder::DateOrder))
+    }
+
+    fn load_graph_snapshot(
         &self,
+        key: &(LogSource, LogOrder),
         range: Range<usize>,
         cx: &mut Context<Self>,
     ) -> Option<CommitHistorySnapshot> {
         let active_repository = self.active_repository.as_ref()?;
-        let (log_source, log_order) = self.commit_history_key.clone()?;
+        let (log_source, log_order) = key.clone();
         Some(active_repository.update(cx, |repository, cx| {
             let graph_data = repository.graph_data(log_source, log_order, range, cx);
             CommitHistorySnapshot {
@@ -4746,7 +4813,11 @@ impl GitPanel {
     }
 
     fn replace_commit_history_shas(&mut self, cx: &mut Context<Self>) {
-        let Some(snapshot) = self.load_commit_history_snapshot(0..usize::MAX, cx) else {
+        let Some(commit_history_key) = self.commit_history_key.as_ref() else {
+            self.clear_commit_history();
+            return;
+        };
+        let Some(snapshot) = self.load_graph_snapshot(commit_history_key, 0..usize::MAX, cx) else {
             self.clear_commit_history();
             return;
         };
@@ -4762,7 +4833,11 @@ impl GitPanel {
             return false;
         }
 
-        let Some(mut snapshot) = self.load_commit_history_snapshot(old_len..commit_count, cx)
+        let Some(commit_history_key) = self.commit_history_key.as_ref() else {
+            return false;
+        };
+        let Some(mut snapshot) =
+            self.load_graph_snapshot(commit_history_key, old_len..commit_count, cx)
         else {
             return false;
         };
@@ -4774,6 +4849,48 @@ impl GitPanel {
         self.commit_history_shas.append(&mut snapshot.shas);
         self.normalize_focused_history_entry();
         true
+    }
+
+    fn replace_commit_history_unpushed_shas(&mut self, cx: &mut Context<Self>) {
+        let Some(commit_history_unpushed_key) = self.commit_history_unpushed_key.as_ref() else {
+            self.commit_history_unpushed_shas.clear();
+            return;
+        };
+        let Some(snapshot) =
+            self.load_graph_snapshot(commit_history_unpushed_key, 0..usize::MAX, cx)
+        else {
+            self.commit_history_unpushed_shas.clear();
+            return;
+        };
+
+        self.commit_history_unpushed_shas = snapshot.shas.into_iter().collect();
+    }
+
+    fn append_commit_history_unpushed_shas(
+        &mut self,
+        commit_count: usize,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let old_len = self.commit_history_unpushed_shas.len();
+        if commit_count <= old_len {
+            return false;
+        }
+
+        let Some(commit_history_unpushed_key) = self.commit_history_unpushed_key.as_ref() else {
+            return false;
+        };
+        let Some(snapshot) =
+            self.load_graph_snapshot(commit_history_unpushed_key, old_len..commit_count, cx)
+        else {
+            return false;
+        };
+        if snapshot.shas.is_empty() {
+            return false;
+        }
+
+        let old_len = self.commit_history_unpushed_shas.len();
+        self.commit_history_unpushed_shas.extend(snapshot.shas);
+        self.commit_history_unpushed_shas.len() != old_len
     }
 
     fn update_commit_history_load_state(&mut self, is_loading: bool, error: Option<SharedString>) {
@@ -4943,15 +5060,7 @@ impl GitPanel {
         let focused_history_entry = self.focused_history_entry;
         let show_focus_border = self.history_keyboard_nav;
         let is_panel_focused = self.focus_handle.is_focused(window);
-
-        let ahead_count = active_repository
-            .read(cx)
-            .branch
-            .as_ref()
-            .and_then(|branch| branch.upstream.as_ref())
-            .and_then(|upstream| upstream.tracking.status())
-            .map(|status| status.ahead as usize)
-            .unwrap_or(0);
+        let unpushed_shas = self.commit_history_unpushed_shas.clone();
 
         Some(
             v_flex()
@@ -5026,7 +5135,7 @@ impl GitPanel {
                                     .size(px(14.))
                                     .render(window, cx);
 
-                                    let is_unpushed = index < ahead_count;
+                                    let is_unpushed = unpushed_shas.contains(sha);
                                     let is_focused = focused_history_entry == Some(index);
                                     let workspace = workspace.clone();
                                     let repository = repository.clone();
@@ -7075,7 +7184,13 @@ mod tests {
 
         panel.read_with(cx, |panel, cx| {
             let repository = panel.active_repository.as_ref().unwrap();
-            let branch = repository.read(cx).branch.as_ref().unwrap().name();
+            let branch = repository
+                .read(cx)
+                .branch
+                .as_ref()
+                .unwrap()
+                .ref_name
+                .clone();
             assert!(
                 repository
                     .read(cx)
@@ -7105,6 +7220,10 @@ mod tests {
 
         panel.read_with(cx, |panel, _| {
             assert_eq!(panel.debug_active_tab(), "history");
+            assert_eq!(
+                panel.commit_history_key.as_ref().map(|(source, _)| source),
+                Some(&LogSource::Branch("refs/heads/main".into()))
+            );
             assert_eq!(
                 panel.commit_history_shas,
                 commits.iter().map(|commit| commit.sha).collect::<Vec<_>>()

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4598,22 +4598,28 @@ impl Repository {
                         Err(e) => Err(SharedString::from(e)),
                     };
 
-                    if let Err(fetch_task_error) = result {
-                        repository
-                            .update(cx, |repository, _| {
-                                if let Some(data) = repository
-                                    .initial_graph_data
-                                    .get_mut(&(log_source, log_order))
-                                {
-                                    data.error = Some(fetch_task_error);
-                                } else {
-                                    debug_panic!(
-                                        "This task would be dropped if this entry doesn't exist"
-                                    );
+                    repository
+                        .update(cx, |repository, cx| {
+                            let graph_data_key = (log_source, log_order);
+                            let graph_event = match result {
+                                Ok(()) => GitGraphEvent::FullyLoaded,
+                                Err(fetch_task_error) => {
+                                    if let Some(data) =
+                                        repository.initial_graph_data.get_mut(&graph_data_key)
+                                    {
+                                        data.error = Some(fetch_task_error);
+                                    } else {
+                                        debug_panic!(
+                                            "This task would be dropped if this entry doesn't exist"
+                                        );
+                                    }
+                                    GitGraphEvent::LoadingError
                                 }
-                            })
-                            .ok();
-                    }
+                            };
+
+                            cx.emit(RepositoryEvent::GraphEvent(graph_data_key, graph_event));
+                        })
+                        .ok();
                 });
 
                 InitialGitGraphData {

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4692,17 +4692,18 @@ impl Repository {
 
     pub fn fetch_commit_data(&mut self, sha: Oid, cx: &mut Context<Self>) -> &CommitDataState {
         if !self.commit_data.contains_key(&sha) {
-            match &self.graph_commit_data_handler {
-                GraphCommitHandlerState::Open(handler) => {
-                    if handler.commit_data_request.try_send(sha).is_ok() {
-                        let old_value = self.commit_data.insert(sha, CommitDataState::Loading);
-                        debug_assert!(old_value.is_none(), "We should never overwrite commit data");
-                    }
-                }
-                GraphCommitHandlerState::Closed => {
-                    self.open_graph_commit_data_handler(cx);
-                }
-                GraphCommitHandlerState::Starting => {}
+            if matches!(
+                self.graph_commit_data_handler,
+                GraphCommitHandlerState::Closed
+            ) {
+                self.open_graph_commit_data_handler(cx);
+            }
+
+            if let GraphCommitHandlerState::Open(handler) = &self.graph_commit_data_handler
+                && handler.commit_data_request.try_send(sha).is_ok()
+            {
+                let old_value = self.commit_data.insert(sha, CommitDataState::Loading);
+                debug_assert!(old_value.is_none(), "We should never overwrite commit data");
             }
         }
 
@@ -7178,5 +7179,54 @@ fn tracked_status_to_proto(code: StatusCode) -> i32 {
         StatusCode::TypeChanged => proto::GitStatus::TypeChanged as _,
         StatusCode::Copied => proto::GitStatus::Copied as _,
         StatusCode::Unmodified => proto::GitStatus::Unmodified as _,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[gpui::test]
+    async fn test_fetch_commit_data_enqueues_initial_request(cx: &mut gpui::TestAppContext) {
+        let sha = Oid::from_bytes(&[1; 20]).unwrap();
+        let repository = cx.update(|cx| {
+            cx.new(|cx| {
+                let (job_sender, _jobs_rx) = futures::channel::mpsc::unbounded();
+                Repository {
+                    this: cx.weak_entity(),
+                    snapshot: RepositorySnapshot::empty(
+                        RepositoryId(0),
+                        Arc::from(Path::new("/repo")),
+                        None,
+                        PathStyle::local(),
+                    ),
+                    commit_message_buffer: None,
+                    git_store: WeakEntity::new_invalid(),
+                    paths_needing_status_update: Vec::new(),
+                    job_sender,
+                    active_jobs: HashMap::default(),
+                    pending_ops: SumTree::default(),
+                    job_id: 0,
+                    askpass_delegates: Arc::default(),
+                    latest_askpass_id: 0,
+                    repository_state: Task::ready(Err("repository unavailable".to_string()))
+                        .shared(),
+                    initial_graph_data: HashMap::default(),
+                    graph_commit_data_handler: GraphCommitHandlerState::Closed,
+                    commit_data: HashMap::default(),
+                }
+            })
+        });
+
+        repository.update(cx, |repository, cx| {
+            assert!(matches!(
+                repository.fetch_commit_data(sha, cx),
+                CommitDataState::Loading
+            ));
+            assert!(matches!(
+                repository.commit_data.get(&sha),
+                Some(CommitDataState::Loading)
+            ));
+        });
     }
 }

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -5638,13 +5638,20 @@ impl SuperzentRightSidebar {
         let active = self.tab == tab;
         let compact = self.width.unwrap_or_else(|| px(320.)) < px(250.);
         let tooltip_label = label.clone();
+        let color = if active {
+            Color::Selected
+        } else {
+            Color::Default
+        };
 
         if compact && let Some(icon) = icon {
             return IconButton::new(id, icon)
                 .shape(ui::IconButtonShape::Square)
+                .icon_color(color)
                 .style(ui::ButtonStyle::Subtle)
                 .toggle_state(active)
                 .selected_style(ui::ButtonStyle::Filled)
+                .selected_icon_color(color)
                 .tooltip(move |window, cx| ui::Tooltip::text(tooltip_label.clone())(window, cx))
                 .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
                     this.set_active_tab(tab, cx);
@@ -5653,8 +5660,10 @@ impl SuperzentRightSidebar {
         }
 
         Button::new(id, label)
+            .color(color)
+            .selected_label_color(color)
             .when_some(icon, |button, icon| {
-                button.start_icon(Icon::new(icon).size(IconSize::Small))
+                button.start_icon(Icon::new(icon).size(IconSize::Small).color(color))
             })
             .label_size(LabelSize::Small)
             .style(ui::ButtonStyle::Subtle)

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -5487,8 +5487,21 @@ impl SuperzentRightSidebar {
     }
 
     fn focus_active_tab_content(&self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.tab == RightSidebarTab::History {
-            self.git_panel.focus_handle(cx).focus(window, cx);
+        match self.tab {
+            RightSidebarTab::Changes | RightSidebarTab::History => {
+                self.git_panel.focus_handle(cx).focus(window, cx);
+            }
+            RightSidebarTab::Files => {
+                self.project_panel.focus_handle(cx).focus(window, cx);
+            }
+            RightSidebarTab::Panel(panel_id) => {
+                let panel = self.right_dock.read(cx).panel_for_id(panel_id).cloned();
+                if let Some(panel) = panel {
+                    panel.panel_focus_handle(cx).focus(window, cx);
+                } else {
+                    self.focus_handle.focus(window, cx);
+                }
+            }
         }
     }
 

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -112,6 +112,7 @@ actions!(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RightSidebarTab {
     Changes,
+    History,
     Files,
     Panel(EntityId),
 }
@@ -157,6 +158,15 @@ pub fn show_superzent_changes_sidebar(
     show_superzent_right_sidebar(workspace, Some(RightSidebarTab::Changes), focus, window, cx);
 }
 
+pub fn show_superzent_history_sidebar(
+    workspace: &mut Workspace,
+    focus: bool,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    show_superzent_right_sidebar(workspace, Some(RightSidebarTab::History), focus, window, cx);
+}
+
 pub fn toggle_superzent_files_sidebar(
     workspace: &mut Workspace,
     window: &mut Window,
@@ -171,6 +181,14 @@ pub fn toggle_superzent_changes_sidebar(
     cx: &mut Context<Workspace>,
 ) {
     toggle_superzent_right_sidebar(workspace, RightSidebarTab::Changes, window, cx);
+}
+
+pub fn toggle_superzent_history_sidebar(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    toggle_superzent_right_sidebar(workspace, RightSidebarTab::History, window, cx);
 }
 
 fn toggle_superzent_right_sidebar(
@@ -866,7 +884,9 @@ pub fn init(cx: &mut App) {
                     };
 
                     match panel.read(cx).tab {
-                        RightSidebarTab::Changes | RightSidebarTab::Files => {
+                        RightSidebarTab::Changes
+                        | RightSidebarTab::History
+                        | RightSidebarTab::Files => {
                             if workspace.active_pane().read(cx).items_len() > 0 {
                                 window.dispatch_action(Box::new(CloseCenterPaneItem), cx);
                             }
@@ -885,7 +905,9 @@ pub fn init(cx: &mut App) {
                     };
 
                     match panel.read(cx).tab {
-                        RightSidebarTab::Changes | RightSidebarTab::Files => {
+                        RightSidebarTab::Changes
+                        | RightSidebarTab::History
+                        | RightSidebarTab::Files => {
                             let active_pane = workspace.active_pane().clone();
                             if active_pane.read(cx).items_len() > 0 {
                                 active_pane.update(cx, |pane, cx| {
@@ -5451,6 +5473,7 @@ impl SuperzentRightSidebar {
 
     fn set_active_tab(&mut self, tab: RightSidebarTab, cx: &mut Context<Self>) {
         self.tab = tab;
+        self.sync_git_panel_tab(cx);
         cx.notify();
     }
 
@@ -5461,6 +5484,7 @@ impl SuperzentRightSidebar {
     pub fn debug_active_tab(&self, cx: &App) -> String {
         match self.tab {
             RightSidebarTab::Changes => "changes".to_string(),
+            RightSidebarTab::History => "history".to_string(),
             RightSidebarTab::Files => "files".to_string(),
             RightSidebarTab::Panel(panel_id) => self
                 .right_dock
@@ -5468,6 +5492,20 @@ impl SuperzentRightSidebar {
                 .panel_for_id(panel_id)
                 .map(|panel| panel.persistent_name().to_string())
                 .unwrap_or_default(),
+        }
+    }
+
+    fn sync_git_panel_tab(&self, cx: &mut Context<Self>) {
+        match self.tab {
+            RightSidebarTab::Changes => {
+                self.git_panel
+                    .update(cx, |git_panel, cx| git_panel.show_changes_tab(cx));
+            }
+            RightSidebarTab::History => {
+                self.git_panel
+                    .update(cx, |git_panel, cx| git_panel.show_history_tab(cx));
+            }
+            RightSidebarTab::Files | RightSidebarTab::Panel(_) => {}
         }
     }
 
@@ -5494,6 +5532,7 @@ impl SuperzentRightSidebar {
     fn sync_active_tab(&mut self, active_panel_exists: bool, cx: &mut Context<Self>) {
         if matches!(self.tab, RightSidebarTab::Panel(_)) && !active_panel_exists {
             self.tab = RightSidebarTab::Changes;
+            self.sync_git_panel_tab(cx);
             cx.notify();
         }
     }
@@ -5535,6 +5574,7 @@ impl SuperzentRightSidebar {
         self.external_panel_tabs.retain(|id| *id != panel_id);
         if self.tab == RightSidebarTab::Panel(panel_id) {
             self.tab = RightSidebarTab::Changes;
+            self.sync_git_panel_tab(cx);
         }
         if previous_len != self.external_panel_tabs.len() {
             cx.notify();
@@ -5555,7 +5595,7 @@ impl SuperzentRightSidebar {
 
         let active_tab_exists = match self.tab {
             RightSidebarTab::Panel(panel_id) => dock.read(cx).panel_for_id(panel_id).is_some(),
-            RightSidebarTab::Changes | RightSidebarTab::Files => true,
+            RightSidebarTab::Changes | RightSidebarTab::History | RightSidebarTab::Files => true,
         };
         self.sync_external_tabs(cx);
         self.sync_active_tab(active_tab_exists, cx);
@@ -5681,6 +5721,7 @@ impl Render for SuperzentRightSidebar {
         let external_tabs = self.visible_external_tabs(window, cx);
         let content = match self.tab {
             RightSidebarTab::Changes => self.git_panel.clone().into_any_element(),
+            RightSidebarTab::History => self.git_panel.clone().into_any_element(),
             RightSidebarTab::Files => self.project_panel.clone().into_any_element(),
             RightSidebarTab::Panel(panel_id) => self
                 .right_dock
@@ -5692,6 +5733,13 @@ impl Render for SuperzentRightSidebar {
 
         v_flex()
             .size_full()
+            .track_focus(&self.focus_handle)
+            .on_action(
+                cx.listener(|this, _: &git_ui::git_panel::ToggleFocus, window, cx| {
+                    this.set_active_tab(RightSidebarTab::Changes, cx);
+                    window.focus(&this.focus_handle, cx);
+                }),
+            )
             .child(
                 v_flex()
                     .border_b_1()
@@ -5708,6 +5756,13 @@ impl Render for SuperzentRightSidebar {
                                 "Changes".into(),
                                 Some(IconName::GitBranchAlt),
                                 RightSidebarTab::Changes,
+                                cx,
+                            ))
+                            .child(self.render_tab_button(
+                                "superzent-right-tab-history",
+                                "History".into(),
+                                Some(IconName::HistoryRerun),
+                                RightSidebarTab::History,
                                 cx,
                             ))
                             .child(self.render_tab_button(

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -132,7 +132,7 @@ fn show_superzent_right_sidebar(
     if let Some(panel) = workspace.panel::<SuperzentRightSidebar>(cx) {
         panel.update(cx, |panel, cx| {
             if let Some(tab) = tab {
-                panel.set_active_tab(tab, cx);
+                panel.set_active_tab(tab, focus, window, cx);
             } else {
                 cx.notify();
             }
@@ -5471,10 +5471,25 @@ impl SuperzentRightSidebar {
         }
     }
 
-    fn set_active_tab(&mut self, tab: RightSidebarTab, cx: &mut Context<Self>) {
+    fn set_active_tab(
+        &mut self,
+        tab: RightSidebarTab,
+        focus_content: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.tab = tab;
         self.sync_git_panel_tab(cx);
+        if focus_content {
+            self.focus_active_tab_content(window, cx);
+        }
         cx.notify();
+    }
+
+    fn focus_active_tab_content(&self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.tab == RightSidebarTab::History {
+            self.git_panel.focus_handle(cx).focus(window, cx);
+        }
     }
 
     fn is_tab_active(&self, tab: RightSidebarTab) -> bool {
@@ -5653,8 +5668,8 @@ impl SuperzentRightSidebar {
                 .selected_style(ui::ButtonStyle::Filled)
                 .selected_icon_color(color)
                 .tooltip(move |window, cx| ui::Tooltip::text(tooltip_label.clone())(window, cx))
-                .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
-                    this.set_active_tab(tab, cx);
+                .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                    this.set_active_tab(tab, true, window, cx);
                 }))
                 .into_any_element();
         }
@@ -5669,8 +5684,8 @@ impl SuperzentRightSidebar {
             .style(ui::ButtonStyle::Subtle)
             .toggle_state(active)
             .selected_style(ui::ButtonStyle::Filled)
-            .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
-                this.set_active_tab(tab, cx);
+            .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                this.set_active_tab(tab, true, window, cx);
             }))
             .into_any_element()
     }
@@ -5745,7 +5760,7 @@ impl Render for SuperzentRightSidebar {
             .track_focus(&self.focus_handle)
             .on_action(
                 cx.listener(|this, _: &git_ui::git_panel::ToggleFocus, window, cx| {
-                    this.set_active_tab(RightSidebarTab::Changes, cx);
+                    this.set_active_tab(RightSidebarTab::Changes, false, window, cx);
                     window.focus(&this.focus_handle, cx);
                 }),
             )

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -5773,8 +5773,7 @@ impl Render for SuperzentRightSidebar {
             .track_focus(&self.focus_handle)
             .on_action(
                 cx.listener(|this, _: &git_ui::git_panel::ToggleFocus, window, cx| {
-                    this.set_active_tab(RightSidebarTab::Changes, false, window, cx);
-                    window.focus(&this.focus_handle, cx);
+                    this.set_active_tab(RightSidebarTab::Changes, true, window, cx);
                 }),
             )
             .child(

--- a/crates/ui/src/components/button/icon_button.rs
+++ b/crates/ui/src/components/button/icon_button.rs
@@ -203,10 +203,10 @@ impl RenderOnce for IconButton {
 
         let icon_color = if is_disabled {
             Color::Disabled
-        } else if self.selected_style.is_some() && is_selected {
-            self.selected_style.unwrap().into()
         } else if is_selected {
-            self.selected_icon_color.unwrap_or(Color::Selected)
+            self.selected_icon_color
+                .or_else(|| self.selected_style.map(Into::into))
+                .unwrap_or(Color::Selected)
         } else {
             let base_color = self.icon_color.color(cx);
             Color::Custom(base_color.opacity(self.alpha.unwrap_or(1.0)))

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -5364,6 +5364,42 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_superzent_history_sidebar_switches_to_history_tab(cx: &mut TestAppContext) {
+        let app_state = init_superzent_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/root"), json!({ "a.txt": "" }))
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/root"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let window = cx.windows()[0].downcast::<MultiWorkspace>().unwrap();
+        window
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    superzent_ui::show_superzent_history_sidebar(workspace, true, window, cx);
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(right_dock_panel_name(window, cx), "Superzent Right Sidebar");
+        assert_eq!(right_sidebar_tab(window, cx), "history");
+        assert!(!left_dock_open(window, cx));
+    }
+
+    #[gpui::test]
     async fn test_superzent_git_panel_toggle_opens_changes_tab(cx: &mut TestAppContext) {
         let app_state = init_superzent_test(cx);
         app_state
@@ -5385,6 +5421,17 @@ mod tests {
         cx.run_until_parked();
 
         let window = cx.windows()[0].downcast::<MultiWorkspace>().unwrap();
+        window
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    superzent_ui::show_superzent_history_sidebar(workspace, true, window, cx);
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(right_sidebar_tab(window, cx), "history");
+
         cx.dispatch_action(window.into(), git_ui::git_panel::ToggleFocus);
         cx.run_until_parked();
 
@@ -5512,6 +5559,71 @@ mod tests {
         assert!(right_dock_open(window, cx));
         assert_eq!(right_dock_panel_name(window, cx), "Superzent Right Sidebar");
         assert_eq!(right_sidebar_tab(window, cx), "files");
+        assert_eq!(cx.update(|cx| cx.windows().len()), 1);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    async fn test_superzent_history_cmd_w_closes_center_item_before_sidebar(
+        cx: &mut TestAppContext,
+    ) {
+        let app_state = init_superzent_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/root"), json!({ "a.txt": "", "b.txt": "" }))
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/root"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        cx.update(|cx| {
+            open_paths(
+                &[
+                    PathBuf::from(path!("/root/a.txt")),
+                    PathBuf::from(path!("/root/b.txt")),
+                ],
+                app_state.clone(),
+                workspace::OpenOptions {
+                    open_new_workspace: Some(false),
+                    ..Default::default()
+                },
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let window = cx.windows()[0].downcast::<MultiWorkspace>().unwrap();
+        window
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    superzent_ui::show_superzent_history_sidebar(workspace, true, window, cx);
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(active_center_pane_item_count(window, cx), 2);
+        assert!(right_dock_open(window, cx));
+        assert_eq!(right_sidebar_tab(window, cx), "history");
+
+        dispatch_right_sidebar_close(window, cx);
+        cx.run_until_parked();
+
+        assert_eq!(active_center_pane_item_count(window, cx), 1);
+        assert!(right_dock_open(window, cx));
+        assert_eq!(right_dock_panel_name(window, cx), "Superzent Right Sidebar");
+        assert_eq!(right_sidebar_tab(window, cx), "history");
         assert_eq!(cx.update(|cx| cx.windows().len()), 1);
     }
 

--- a/docs/solutions/architecture-patterns/superzent-right-sidebar-history-tab-reuses-git-panel-2026-05-17.md
+++ b/docs/solutions/architecture-patterns/superzent-right-sidebar-history-tab-reuses-git-panel-2026-05-17.md
@@ -1,0 +1,163 @@
+---
+title: "Reuse GitPanel modes for Superzent sidebar tabs"
+date: "2026-05-17"
+category: architecture-patterns
+module: superzent_ui
+problem_type: architecture_pattern
+component: tooling
+severity: low
+related_components:
+  - "git_ui"
+  - "ui"
+applies_when:
+  - "Adding a Superzent right details sidebar tab backed by an existing Zed panel"
+  - "Surfacing branch commit history without building a separate Git history view"
+  - "Keeping full and compact right sidebar tab icons visually aligned with selected label color"
+tags:
+  - superzent-ui
+  - right-sidebar
+  - git-panel
+  - history-tab
+  - commit-history
+  - icon-button
+  - selected-state
+---
+
+# Reuse GitPanel modes for Superzent sidebar tabs
+
+## Context
+
+Superzent needed a right details sidebar `History` tab next to `Changes` and `Files`, in the user-facing order `Changes / History / Files`. The goal was branch commit history in the details sidebar, not a full Git Graph lane view or GitLens-style CodeLens feature.
+
+The existing `git_ui::GitPanel` already had the right ownership boundary for changes and history data. The durable pattern is to treat `History` as another mode of the shared Git panel while letting `SuperzentRightSidebar` own the outer sidebar tab state.
+
+## Guidance
+
+When a new top-level Superzent sidebar tab is another mode of an existing panel, reuse the existing panel entity and synchronize sidebar tab state into that panel. Avoid creating a parallel view that duplicates repository subscriptions, keyboard handling, commit opening, or scroll state.
+
+For the history sidebar work, `SuperzentRightSidebar` owns `RightSidebarTab::History`, while `GitPanel` owns `GitPanelTab::History` and the commit-history rendering. The bridge is intentionally small:
+
+```rust
+fn set_active_tab(&mut self, tab: RightSidebarTab, cx: &mut Context<Self>) {
+    self.tab = tab;
+    self.sync_git_panel_tab(cx);
+    cx.notify();
+}
+
+fn sync_git_panel_tab(&self, cx: &mut Context<Self>) {
+    match self.tab {
+        RightSidebarTab::Changes => {
+            self.git_panel
+                .update(cx, |git_panel, cx| git_panel.show_changes_tab(cx));
+        }
+        RightSidebarTab::History => {
+            self.git_panel
+                .update(cx, |git_panel, cx| git_panel.show_history_tab(cx));
+        }
+        RightSidebarTab::Files | RightSidebarTab::Panel(_) => {}
+    }
+}
+```
+
+Keep legacy actions predictable. In Superzent, the Git panel toggle/focus action should still land on `Changes`, even when `History` exists:
+
+```rust
+.on_action(
+    cx.listener(|this, _: &git_ui::git_panel::ToggleFocus, window, cx| {
+        this.set_active_tab(RightSidebarTab::Changes, cx);
+        window.focus(&this.focus_handle, cx);
+    }),
+)
+```
+
+Keep `GitPanel` responsible for history internals. The panel should expose mode setters such as `show_changes_tab` and `show_history_tab`, and it should clear history-specific state when leaving history mode:
+
+```rust
+pub fn show_changes_tab(&mut self, cx: &mut Context<Self>) {
+    self.set_active_tab(GitPanelTab::Changes, cx);
+}
+
+pub fn show_history_tab(&mut self, cx: &mut Context<Self>) {
+    self.set_active_tab(GitPanelTab::History, cx);
+}
+```
+
+For selected tab icon polish in GPUI, label and icon color do not automatically stay in sync. Set both the label color and the icon color from the same selected-state token:
+
+```rust
+let color = if active {
+    Color::Selected
+} else {
+    Color::Default
+};
+
+Button::new(id, label)
+    .color(color)
+    .selected_label_color(color)
+    .when_some(icon, |button, icon| {
+        button.start_icon(Icon::new(icon).size(IconSize::Small).color(color))
+    })
+    .toggle_state(active)
+    .selected_style(ui::ButtonStyle::Filled);
+```
+
+For compact icon-only tabs, `IconButton` needs the same selected color contract. `selected_icon_color` should take precedence over the color implied by `selected_style`:
+
+```rust
+self.selected_icon_color
+    .or_else(|| self.selected_style.map(Into::into))
+    .unwrap_or(Color::Selected)
+```
+
+## Why This Matters
+
+Reusing `GitPanel` keeps one source of truth for branch history, commit details, repository updates, keyboard navigation, and commit opening. A separate Superzent-only history view would have copied behavior from `git_ui`, increasing the chance that history rows, shortcuts, or repository refreshes drift from the standard Git panel.
+
+Separating outer tab state from inner panel mode also keeps product behavior clear. Users get `Changes / History / Files` as first-class Superzent tabs, while existing Git actions continue to mean "show changes" unless the action itself is intentionally redesigned.
+
+The selected icon color fix prevents a common GPUI polish issue: selected labels can use `Color::Selected` while icons silently inherit a filled or tinted button-style color. Keeping both on the same token makes full-width and compact sidebar tabs render consistently.
+
+## When to Apply
+
+- Adding a first-class Superzent sidebar tab that is really a mode of an existing panel.
+- Backporting or adapting an upstream panel feature without importing a broader layout architecture.
+- Preserving existing shortcuts while adding a secondary tab under the same panel namespace.
+- Styling GPUI `Button` or `IconButton` instances where selected icon color must match selected text color.
+
+## Examples
+
+Prefer this structure:
+
+- `SuperzentRightSidebar` owns the product-level tab order and close/focus behavior.
+- `GitPanel` owns Git-specific data loading, repository subscriptions, list rendering, and row interaction.
+- Sidebar actions switch `RightSidebarTab`; the sidebar then calls the panel's public mode setters.
+- Shared UI components such as `IconButton` encode selected-state precedence once, then callers pass selected colors directly.
+
+Avoid this structure:
+
+- A separate Superzent history component that independently queries branch history.
+- A top-level `History` tab that bypasses `GitPanel` keyboard navigation or commit opening behavior.
+- Treating `History` like an external dock panel when close behavior should match built-in sidebar tabs.
+- Relying on `selected_style` to color icons when a specific selected label color is required.
+
+## Verification
+
+The history sidebar change was verified with:
+
+- `cargo test -p git_ui test_history_tab_loads_branch_commit_history -- --nocapture`
+- `cargo test -p superzent test_superzent_history -- --nocapture`
+- `cargo test -p superzent test_superzent_git_panel_toggle_opens_changes_tab -- --nocapture`
+- `cargo fmt --check`
+- `cargo check -p git_ui -p superzent_ui -p superzent`
+
+The selected icon color polish was verified with:
+
+- `cargo fmt --check`
+- `cargo check -p superzent_ui`
+
+## Related
+
+- Related local pattern: [Backport markdown preview search against the current renderer](../best-practices/markdown-preview-search-backport-current-renderer-2026-05-05.md)
+- Related local GPUI pattern: [GPUI window re-borrow and cross-workspace item transfer patterns](../best-practices/gpui-window-reborrow-and-cross-workspace-item-transfer-2026-04-21.md)
+- Upstream source feature: [zed-industries/zed#56500](https://github.com/zed-industries/zed/pull/56500)
+- Upstream keyboard/tab behavior: [zed-industries/zed#56743](https://github.com/zed-industries/zed/pull/56743)


### PR DESCRIPTION
## Summary

Superzent now exposes branch commit history as a first-class right details sidebar tab between Changes and Files. The tab reuses `GitPanel` history mode, so commit rows, keyboard navigation, commit opening, and repository refresh behavior stay owned by `git_ui` while Superzent controls the outer details sidebar tab order.

This keeps existing behavior predictable: the Git panel toggle still returns to Changes, Cmd+W treats History like the built-in details tabs, and selected tab icons now follow the same color as their labels. The implementation pattern is also captured in `docs/solutions/architecture-patterns/` for future sidebar work.

## Testing

- `cargo test -p git_ui test_history_tab_loads_branch_commit_history -- --nocapture`
- `cargo test -p superzent test_superzent_history -- --nocapture`
- `cargo test -p superzent test_superzent_git_panel_toggle_opens_changes_tab -- --nocapture`
- `cargo fmt --check`
- `cargo check -p git_ui -p superzent_ui -p superzent`
- `cargo check -p superzent_ui`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)

Release Notes:

- Added a History tab to the Superzent details sidebar for branch commit history.
