### PR TITLE
Port upstream GPUI and editor stability fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16601,6 +16601,7 @@ checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 name = "streaming_diff"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "ordered-float 2.10.1",
  "rand 0.9.2",
  "rope",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13028,7 +13028,6 @@ impl Editor {
 
         let mut new_selections = Vec::new();
         let mut edits = Vec::new();
-        let mut selection_adjustment = 0isize;
 
         for selection in self.selections.all_adjusted(&self.display_snapshot(cx)) {
             let selection_is_empty = selection.is_empty();
@@ -13043,23 +13042,24 @@ impl Editor {
                 )
             };
 
-            let text = buffer.text_for_range(start..end).collect::<String>();
-            let old_length = text.len() as isize;
-            let text = callback(&text);
+            let old_text = buffer.text_for_range(start..end).collect::<String>();
+            let new_text = callback(&old_text);
 
             new_selections.push(Selection {
-                start: MultiBufferOffset((start.0 as isize - selection_adjustment) as usize),
-                end: MultiBufferOffset(
-                    ((start.0 + text.len()) as isize - selection_adjustment) as usize,
-                ),
+                start: buffer.anchor_before(start),
+                end: buffer.anchor_after(end),
                 goal: SelectionGoal::None,
                 id: selection.id,
                 reversed: selection.reversed,
             });
 
-            selection_adjustment += old_length - text.len() as isize;
+            if new_text != old_text {
+                edits.push((start..end, new_text));
+            }
+        }
 
-            edits.push((start..end, text));
+        if edits.is_empty() {
+            return;
         }
 
         self.transact(window, cx, |this, window, cx| {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6522,6 +6522,61 @@ async fn test_convert_to_sentence_case(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_manipulate_text_handles_cross_excerpt_edit_that_applies_differently(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let buffer_1 = cx.new(|cx| {
+        let mut buffer = Buffer::local("ab", cx);
+        // The selected multibuffer range starts in this excerpt, but edits to
+        // it are skipped because the underlying buffer is read-only.
+        buffer.set_capability(language::Capability::ReadOnly, cx);
+        buffer
+    });
+    let buffer_2 = cx.new(|cx| Buffer::local("cd", cx));
+    let multibuffer = cx.new(|cx| {
+        let mut multibuffer = MultiBuffer::new(ReadWrite);
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            buffer_1.clone(),
+            [Point::new(0, 0)..Point::new(0, 2)],
+            0,
+            cx,
+        );
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(1),
+            buffer_2.clone(),
+            [Point::new(0, 0)..Point::new(0, 2)],
+            0,
+            cx,
+        );
+        multibuffer
+    });
+
+    cx.add_window(|window, cx| {
+        let mut editor = build_editor(multibuffer, window, cx);
+        let len = editor.buffer().read(cx).len(cx);
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+            selections.select_ranges([MultiBufferOffset(0)..len])
+        });
+
+        // No-op transformations should not be sent through `MultiBuffer::edit`.
+        editor.manipulate_text(window, cx, |text| text.to_string());
+        assert_eq!(buffer_1.read(cx).text(), "ab");
+        assert_eq!(buffer_2.read(cx).text(), "cd");
+
+        // A real replacement can apply differently than requested; selection
+        // remapping should follow the actual edit instead of predicted offsets.
+        editor.manipulate_text(window, cx, |_| "replacement".to_string());
+        assert_eq!(buffer_1.read(cx).text(), "ab");
+        assert_eq!(buffer_2.read(cx).text(), "");
+
+        editor
+    });
+}
+
+#[gpui::test]
 async fn test_manipulate_text(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12096,9 +12096,9 @@ impl PositionMap {
         let x = position.x + (scroll_position.x as f32 * self.em_layout_width);
         let row = ((y / self.line_height) as f64 + scroll_position.y) as u32;
 
-        let (column, x_overshoot_after_line_end) = if let Some(line) = self
-            .line_layouts
-            .get(row as usize - scroll_position.y as usize)
+        let (column, x_overshoot_after_line_end) = if let Some(line_index) =
+            row.checked_sub(self.visible_row_range.start.0)
+            && let Some(line) = self.line_layouts.get(line_index as usize)
         {
             let alignment_offset = line.alignment_offset(self.text_align, self.content_width);
             let x_relative_to_text = x - alignment_offset;
@@ -12768,6 +12768,47 @@ mod tests {
                 "Soft wrapped editor should have no horizontal scrolling!"
             );
         }
+    }
+
+    #[gpui::test]
+    async fn test_point_for_position_clipped_rows(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let text = "aaa\nbbb";
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(text, cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = editor.update(cx, |editor, cx| editor.style(cx).clone());
+        let line_height = window
+            .update(cx, |_, window, _| {
+                style.text.line_height_in_pixels(window.rem_size())
+            })
+            .unwrap();
+
+        // the first line is clipped
+        let (_, state) = cx.draw(
+            point(Pixels::ZERO, Pixels::ZERO - line_height * 1.5),
+            size(px(500.), px(500.)),
+            |_, _| EditorElement::new(&editor, style),
+        );
+
+        // click at the end of the second line
+        let target_point = DisplayPoint::new(DisplayRow(1), 3);
+        let click_x = state.content_origin.x
+            + editor.update_in(cx, |editor, window, cx| {
+                editor
+                    .snapshot(window, cx)
+                    .x_for_display_point(target_point, &editor.text_layout_details(window, cx))
+            });
+
+        let point = state
+            .position_map
+            .point_for_position(point(click_x, px(0.)));
+        assert_eq!(point.nearest_valid, target_point);
     }
 
     #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12808,7 +12808,7 @@ mod tests {
         let point = state
             .position_map
             .point_for_position(point(click_x, px(0.)));
-        assert_eq!(point.nearest_valid, target_point);
+        assert_eq!(point.next_valid, target_point);
     }
 
     #[gpui::test]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2228,8 +2228,21 @@ impl Window {
         self.requested_autoscroll = None;
 
         // Restore the previously-used input handler.
+        // Place it back into a None slot (left by a previous .take()) so that
+        // cached paint_range indices in reuse_paint find the handler at the
+        // expected position.
         if let Some(input_handler) = self.platform_window.take_input_handler() {
-            self.rendered_frame.input_handlers.push(Some(input_handler));
+            if let Some(slot) = self
+                .rendered_frame
+                .input_handlers
+                .iter_mut()
+                .rev()
+                .find(|h| h.is_none())
+            {
+                *slot = Some(input_handler);
+            } else {
+                self.rendered_frame.input_handlers.push(Some(input_handler));
+            }
         }
         if !cx.mode.skip_drawing() {
             self.draw_roots(cx);
@@ -2238,9 +2251,18 @@ impl Window {
         self.next_frame.window_active = self.active.get();
 
         // Register requested input handler with the platform window.
-        if let Some(input_handler) = self.next_frame.input_handlers.pop() {
-            self.platform_window
-                .set_input_handler(input_handler.unwrap());
+        // Use .take() instead of .pop() to preserve Vec length, so that cached
+        // paint_range indices remain valid for reuse_paint on the next frame.
+        // Search backwards to find the last Some entry, since reuse_paint may
+        // have copied None slots from the previous frame. (Fixes #50456)
+        if let Some(input_handler) = self
+            .next_frame
+            .input_handlers
+            .iter_mut()
+            .rev()
+            .find_map(|h| h.take())
+        {
+            self.platform_window.set_input_handler(input_handler);
         }
 
         self.layout_engine.as_mut().unwrap().clear();

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -8513,7 +8513,11 @@ impl<'a> Iterator for MultiBufferChunks<'a> {
         if self.range.start >= self.range.end {
             return None;
         }
-        if self.range.start == self.diff_transforms.end().0 {
+        while self
+            .diff_transforms
+            .item()
+            .is_some_and(|_| self.range.start >= self.diff_transforms.end().0)
+        {
             self.diff_transforms.next();
         }
 
@@ -8540,10 +8544,17 @@ impl<'a> Iterator for MultiBufferChunks<'a> {
                 let chunk_end = self.range.start + chunk.text.len();
                 let diff_transform_end = diff_transform_end.min(self.range.end);
 
-                if diff_transform_end < chunk_end {
-                    let split_idx = diff_transform_end - self.range.start;
+                let split_idx = if diff_transform_end < chunk_end {
+                    chunk
+                        .text
+                        .ceil_char_boundary(diff_transform_end - self.range.start)
+                } else {
+                    chunk.text.len()
+                };
+
+                if split_idx < chunk.text.len() {
                     let (before, after) = chunk.text.split_at(split_idx);
-                    self.range.start = diff_transform_end;
+                    self.range.start += split_idx;
                     let mask = 1u128.unbounded_shl(split_idx as u32).wrapping_sub(1);
                     let chars = chunk.chars & mask;
                     let tabs = chunk.tabs & mask;

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1664,6 +1664,42 @@ async fn test_basic_diff_hunks(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_text_for_range_with_diff_transform_boundary_inside_multibyte_character(cx: &mut App) {
+    let buffer = cx.new(|cx| Buffer::local("タx", cx));
+    let multibuffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let mut snapshot = multibuffer.read(cx).snapshot(cx);
+
+    fn ascii_summary_with_byte_len(byte_len: usize) -> MBTextSummary {
+        let text = "x".repeat(byte_len);
+        MBTextSummary::from(TextSummary::from(text.as_str()))
+    }
+
+    // FR-16 shown a diff transform boundary two bytes into the leading 'タ'.
+    // Build that transform tree directly so this test stays focused on chunk iteration.
+    let mut diff_transforms = SumTree::default();
+    diff_transforms.push(
+        DiffTransform::BufferContent {
+            summary: ascii_summary_with_byte_len(2),
+            inserted_hunk_info: None,
+        },
+        (),
+    );
+    diff_transforms.push(
+        DiffTransform::BufferContent {
+            summary: ascii_summary_with_byte_len("タx".len() - 2),
+            inserted_hunk_info: None,
+        },
+        (),
+    );
+    snapshot.diff_transforms = diff_transforms;
+
+    let text = snapshot
+        .text_for_range(MultiBufferOffset(0)..snapshot.len())
+        .collect::<String>();
+    assert_eq!(text, "タx");
+}
+
+#[gpui::test]
 async fn test_repeatedly_expand_a_diff_hunk(cx: &mut TestAppContext) {
     let text = indoc!(
         "

--- a/crates/scheduler/src/executor.rs
+++ b/crates/scheduler/src/executor.rs
@@ -343,9 +343,10 @@ where
                 "local task dropped by a thread that didn't spawn it. Task spawned at {}",
                 self.location
             );
-            unsafe {
-                ManuallyDrop::drop(&mut self.inner);
-            }
+            // SAFETY: `inner` is wrapped in `ManuallyDrop`, so this is the only
+            // place it is dropped. The thread check above ensures local futures
+            // are dropped on the thread that created them.
+            unsafe { ManuallyDrop::drop(&mut self.inner) };
         }
     }
 
@@ -353,27 +354,34 @@ where
         type Output = F::Output;
 
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: We don't move any fields out of `self`; this mutable
+            // reference is only used to check metadata and to project the pin to
+            // `inner` below.
+            let this = unsafe { self.get_unchecked_mut() };
             assert!(
-                self.id == thread_id(),
+                this.id == thread_id(),
                 "local task polled by a thread that didn't spawn it. Task spawned at {}",
-                self.location
+                this.location
             );
-            unsafe { self.map_unchecked_mut(|c| &mut *c.inner).poll(cx) }
+            // SAFETY: `inner` is structurally pinned by `Checked`; after
+            // `Checked` is pinned, `inner` is never moved. The thread check
+            // above ensures the local future is only polled by its spawning
+            // thread.
+            unsafe { Pin::new_unchecked(&mut *this.inner).poll(cx) }
         }
     }
 
     let location = metadata.location;
 
-    unsafe {
-        async_task::Builder::new()
-            .metadata(metadata)
-            .spawn_unchecked(
-                move |_| Checked {
-                    id: thread_id(),
-                    inner: ManuallyDrop::new(future),
-                    location,
-                },
-                schedule,
-            )
-    }
+    let future = move |_| Checked {
+        id: thread_id(),
+        inner: ManuallyDrop::new(future),
+        location,
+    };
+
+    let builder = async_task::Builder::new().metadata(metadata);
+    // SAFETY: `Checked` enforces the invariants required by `spawn_unchecked`:
+    // the non-`Send` future is only polled and dropped on the thread that
+    // spawned it.
+    unsafe { builder.spawn_unchecked(future, schedule) }
 }

--- a/crates/scheduler/src/test_scheduler.rs
+++ b/crates/scheduler/src/test_scheduler.rs
@@ -108,7 +108,12 @@ impl TestScheduler {
     pub fn end_test(&self) {
         let mut state = self.state.lock();
         if let Some((message, backtrace)) = &state.non_determinism_error {
-            panic!("{}\n{:?}", message, backtrace)
+            if cfg!(miri) {
+                // miri cannot debug print backtraces with `miri-disable-isolation` enabled
+                panic!("{}", message)
+            } else {
+                panic!("{}\n{:?}", message, backtrace)
+            }
         }
         state.finished = true;
     }
@@ -458,6 +463,9 @@ impl TestScheduler {
             }
         } else if deadline.is_some() {
             false
+        } else if cfg!(miri) {
+            // miri cannot debug print backtraces with `miri-disable-isolation` enabled
+            panic!("Parking forbidden.");
         } else if self.state.lock().capture_pending_traces {
             let mut pending_traces = String::new();
             for (_, trace) in mem::take(&mut self.state.lock().pending_traces) {

--- a/crates/scheduler/src/tests.rs
+++ b/crates/scheduler/src/tests.rs
@@ -38,7 +38,7 @@ fn test_background_executor_spawn() {
 fn test_foreground_ordering() {
     let mut traces = HashSet::new();
 
-    TestScheduler::many(100, async |scheduler| {
+    TestScheduler::many(if cfg!(miri) { 5 } else { 100 }, async |scheduler| {
         #[derive(Hash, PartialEq, Eq)]
         struct TraceEntry {
             session: usize,
@@ -125,6 +125,24 @@ fn test_timer_ordering() {
             .boxed(),
         );
         assert_eq!(futures.collect::<Vec<_>>().await, vec![1, 2, 3]);
+    });
+}
+
+#[test]
+fn test_foreground_task_can_hold_mut_borrow_across_await() {
+    TestScheduler::once(async |scheduler| {
+        let foreground = scheduler.foreground();
+        let (sender, mut receiver) = mpsc::unbounded::<()>();
+
+        foreground
+            .spawn(async move {
+                receiver.next().await;
+            })
+            .detach();
+
+        scheduler.run();
+        sender.unbounded_send(()).unwrap();
+        scheduler.run();
     });
 }
 
@@ -238,7 +256,7 @@ fn test_block() {
 }
 
 #[test]
-#[should_panic(expected = "Parking forbidden. Pending traces:")]
+#[should_panic(expected = "Parking forbidden.")]
 fn test_parking_panics() {
     let config = TestSchedulerConfig {
         capture_pending_traces: true,
@@ -340,7 +358,7 @@ fn test_block_with_timeout() {
 
     // Test case: future makes progress via timer but still times out
     let mut results = BTreeSet::new();
-    TestScheduler::many(100, async |scheduler| {
+    TestScheduler::many(if cfg!(miri) { 5 } else { 100 }, async |scheduler| {
         // Keep the existing probabilistic behavior here (do not force 0 ticks), since this subtest
         // is explicitly checking that some seeds/timeouts can complete while others can time out.
         let task = scheduler.background().spawn(async move {
@@ -354,7 +372,11 @@ fn test_block_with_timeout() {
     });
     assert_eq!(
         results.into_iter().collect::<Vec<_>>(),
-        vec![None, Some(42)]
+        if cfg!(miri) {
+            vec![Some(42)]
+        } else {
+            vec![None, Some(42)]
+        }
     );
 
     // Regression test:
@@ -400,7 +422,7 @@ fn test_block_with_timeout() {
 #[test]
 fn test_block_does_not_progress_same_session_foreground() {
     let mut task2_made_progress_once = false;
-    TestScheduler::many(1000, async |scheduler| {
+    TestScheduler::many(if cfg!(miri) { 5 } else { 1000 }, async |scheduler| {
         let foreground1 = scheduler.foreground();
         let foreground2 = scheduler.foreground();
 
@@ -614,7 +636,7 @@ fn test_background_priority_scheduling() {
 
     // Run many iterations to get statistical significance
     let mut high_before_low_count = 0;
-    let iterations = 100;
+    let iterations = if cfg!(miri) { 5 } else { 100 };
 
     for seed in 0..iterations {
         let config = TestSchedulerConfig::with_seed(seed);

--- a/crates/streaming_diff/Cargo.toml
+++ b/crates/streaming_diff/Cargo.toml
@@ -16,5 +16,10 @@ ordered-float.workspace = true
 rope.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 rand.workspace = true
 util = { workspace = true, features = ["test-support"] }
+
+[[bench]]
+name = "streaming_diff"
+harness = false

--- a/crates/streaming_diff/benches/streaming_diff.rs
+++ b/crates/streaming_diff/benches/streaming_diff.rs
@@ -1,0 +1,321 @@
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
+use streaming_diff::StreamingDiff;
+
+const SEED: u64 = 0x5EED_5EED;
+const CHUNK_SIZE: usize = 512;
+
+#[derive(Clone)]
+struct EditFixture {
+    name: &'static str,
+    old_text: String,
+    new_text: String,
+}
+
+fn streaming_diff_push_new(criterion: &mut Criterion) {
+    let fixtures = fixtures();
+    let mut group = criterion.benchmark_group("streaming_diff_push_new");
+    group.sample_size(10);
+
+    for fixture in fixtures {
+        group.throughput(Throughput::Bytes(fixture.new_text.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new(fixture.name, fixture.old_text.len()),
+            &fixture,
+            |bench, fixture| {
+                bench.iter_batched(
+                    || StreamingDiff::new(fixture.old_text.clone()),
+                    |mut diff| {
+                        let mut operation_count = 0;
+                        for chunk in chunk_text(&fixture.new_text, CHUNK_SIZE) {
+                            operation_count += black_box(diff.push_new(chunk)).len();
+                        }
+                        black_box(operation_count);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn streaming_diff_finish(criterion: &mut Criterion) {
+    let fixtures = fixtures();
+    let mut group = criterion.benchmark_group("streaming_diff_finish");
+    group.sample_size(10);
+
+    for fixture in fixtures {
+        group.throughput(Throughput::Bytes(fixture.new_text.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new(fixture.name, fixture.old_text.len()),
+            &fixture,
+            |bench, fixture| {
+                bench.iter_batched(
+                    || {
+                        let mut diff = StreamingDiff::new(fixture.old_text.clone());
+                        for chunk in chunk_text(&fixture.new_text, CHUNK_SIZE) {
+                            black_box(diff.push_new(chunk));
+                        }
+                        diff
+                    },
+                    |diff| {
+                        black_box(diff.finish());
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn fixtures() -> Vec<EditFixture> {
+    // Keep fixtures modest because `StreamingDiff` is intentionally stressed here and
+    // can become very slow on tens of kilobytes of replacement text. These sizes still
+    // represent realistic `edit_file` old/new text blocks and are large enough to cross
+    // frame-budget-sized CPU work.
+    vec![
+        make_fixture(
+            "tiny_function_rewrite",
+            2,
+            EditPattern::LocalizedRewrite {
+                start_line: 12,
+                line_count: 6,
+            },
+            SEED,
+        ),
+        make_fixture(
+            "small_function_rewrite",
+            5,
+            EditPattern::LocalizedRewrite {
+                start_line: 22,
+                line_count: 12,
+            },
+            SEED + 1,
+        ),
+        make_fixture(
+            "medium_many_small_changes",
+            8,
+            EditPattern::ManySmallChanges { every_nth_line: 7 },
+            SEED + 2,
+        ),
+        make_fixture(
+            "medium_insertions",
+            8,
+            EditPattern::InsertHelperBlocks { every_nth_line: 9 },
+            SEED + 3,
+        ),
+    ]
+}
+
+enum EditPattern {
+    LocalizedRewrite {
+        start_line: usize,
+        line_count: usize,
+    },
+    ManySmallChanges {
+        every_nth_line: usize,
+    },
+    InsertHelperBlocks {
+        every_nth_line: usize,
+    },
+}
+
+fn make_fixture(
+    name: &'static str,
+    function_count: usize,
+    pattern: EditPattern,
+    seed: u64,
+) -> EditFixture {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut lines = random_rust_module(&mut rng, function_count);
+    let old_text = lines.join("\n");
+
+    match pattern {
+        EditPattern::LocalizedRewrite {
+            start_line,
+            line_count,
+        } => rewrite_local_block(&mut lines, start_line, line_count, &mut rng),
+        EditPattern::ManySmallChanges { every_nth_line } => {
+            rewrite_many_small_lines(&mut lines, every_nth_line, &mut rng)
+        }
+        EditPattern::InsertHelperBlocks { every_nth_line } => {
+            insert_helper_blocks(&mut lines, every_nth_line, &mut rng)
+        }
+    }
+
+    EditFixture {
+        name,
+        old_text,
+        new_text: lines.join("\n"),
+    }
+}
+
+fn random_rust_module(rng: &mut StdRng, function_count: usize) -> Vec<String> {
+    let mut lines = vec![
+        "use anyhow::{Context as _, Result};".to_string(),
+        "use collections::HashMap;".to_string(),
+        "".to_string(),
+        "#[derive(Clone, Debug)]".to_string(),
+        "pub struct WorkspaceSnapshot {".to_string(),
+        "    buffers: HashMap<String, usize>,".to_string(),
+        "    version: usize,".to_string(),
+        "}".to_string(),
+        "".to_string(),
+        "impl WorkspaceSnapshot {".to_string(),
+    ];
+
+    for function_index in 0..function_count {
+        let function_name = identifier(rng, function_index);
+        let argument_name = identifier(rng, function_index + 1_000);
+        let local_name = identifier(rng, function_index + 2_000);
+        let branch_name = identifier(rng, function_index + 3_000);
+        let multiplier = rng.random_range(2..17);
+        let offset = rng.random_range(1..128);
+
+        lines.extend([
+            format!(
+                "    pub fn {function_name}(&mut self, {argument_name}: usize) -> Result<usize> {{"
+            ),
+            format!("        let mut {local_name} = {argument_name}.saturating_mul({multiplier});"),
+            format!("        if {local_name} % 2 == 0 {{"),
+            format!(
+                "            {local_name} = {local_name}.saturating_add(self.version + {offset});"
+            ),
+            "        } else {".to_string(),
+            format!("            {local_name} = {local_name}.saturating_sub({offset});"),
+            "        }".to_string(),
+            format!("        let {branch_name} = self.buffers.len().saturating_add({local_name});"),
+            format!("        self.version = self.version.saturating_add({branch_name});"),
+            format!("        Ok({branch_name})"),
+            "    }".to_string(),
+            "".to_string(),
+        ]);
+    }
+
+    lines.push("}".to_string());
+    lines.push("".to_string());
+    lines.push("pub fn normalize_path(path: &str) -> String {".to_string());
+    lines.push("    path.replace('\\\\', \"/\")".to_string());
+    lines.push("}".to_string());
+    lines
+}
+
+fn rewrite_local_block(
+    lines: &mut [String],
+    start_line: usize,
+    line_count: usize,
+    rng: &mut StdRng,
+) {
+    let end_line = (start_line + line_count).min(lines.len());
+    for (relative_index, line) in lines[start_line..end_line].iter_mut().enumerate() {
+        let suffix = identifier(rng, relative_index + 10_000);
+        if line.contains("saturating_add") {
+            *line = format!(
+                "        let {suffix} = self.version.checked_add({relative_index}).context(\"version overflow\")?;"
+            );
+        } else if line.contains("saturating_sub") {
+            *line = format!(
+                "            {suffix}.saturating_sub({});",
+                rng.random_range(8..256)
+            );
+        } else if line.trim().is_empty() {
+            *line = format!(
+                "        tracing::trace!(target: \"agent_bench\", value = {relative_index});"
+            );
+        } else {
+            *line = format!("{line} // updated {suffix}");
+        }
+    }
+}
+
+fn rewrite_many_small_lines(lines: &mut [String], every_nth_line: usize, rng: &mut StdRng) {
+    for (line_index, line) in lines.iter_mut().enumerate() {
+        if line_index % every_nth_line != 0 || line.trim().is_empty() {
+            continue;
+        }
+
+        if line.contains("let mut") {
+            *line = line.replace("let mut", "let mut updated");
+        } else if line.contains("Ok(") {
+            *line = line.replace("Ok(", "Ok(black_box_value(");
+        } else if line.ends_with('{') {
+            *line = format!("{line} // scenario {}", identifier(rng, line_index));
+        } else {
+            *line = format!("{line} // touched {}", identifier(rng, line_index));
+        }
+    }
+}
+
+fn insert_helper_blocks(lines: &mut Vec<String>, every_nth_line: usize, rng: &mut StdRng) {
+    let mut line_index = every_nth_line;
+    while line_index < lines.len() {
+        if lines[line_index].trim() == "}" {
+            let helper_name = identifier(rng, line_index + 20_000);
+            lines.splice(
+                line_index..line_index,
+                [
+                    format!("        let {helper_name} = self.buffers.len();"),
+                    format!("        tracing::trace!(target: \"agent_bench\", {helper_name});"),
+                ],
+            );
+            line_index += 2;
+        }
+        line_index += every_nth_line;
+    }
+}
+
+fn identifier(rng: &mut StdRng, salt: usize) -> String {
+    const WORDS: &[&str] = &[
+        "buffer",
+        "workspace",
+        "snapshot",
+        "version",
+        "project",
+        "entry",
+        "path",
+        "cursor",
+        "anchor",
+        "edit",
+        "thread",
+        "message",
+        "context",
+        "store",
+        "diff",
+        "range",
+        "token",
+        "parser",
+        "semantic",
+        "format",
+        "completion",
+        "diagnostic",
+        "terminal",
+        "channel",
+    ];
+
+    let first = WORDS[(rng.random_range(0..WORDS.len()) + salt) % WORDS.len()];
+    let second = WORDS[(rng.random_range(0..WORDS.len()) + salt / 3) % WORDS.len()];
+    format!("{first}_{second}_{salt}")
+}
+
+fn chunk_text(text: &str, max_chunk_size: usize) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = (start + max_chunk_size).min(text.len());
+        while end < text.len() && !text.is_char_boundary(end) {
+            end += 1;
+        }
+        chunks.push(&text[start..end]);
+        start = end;
+    }
+    chunks
+}
+
+criterion_group!(benches, streaming_diff_push_new, streaming_diff_finish);
+criterion_main!(benches);

--- a/crates/streaming_diff/src/streaming_diff.rs
+++ b/crates/streaming_diff/src/streaming_diff.rs
@@ -1,6 +1,6 @@
 use ordered_float::OrderedFloat;
 use rope::{Point, Rope, TextSummary};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::{
     cmp,
     fmt::{self, Debug},
@@ -103,7 +103,8 @@ pub struct StreamingDiff {
     scores: Matrix,
     old_text_ix: usize,
     new_text_ix: usize,
-    equal_runs: HashMap<(usize, usize), u32>,
+    previous_equal_runs: Vec<u32>,
+    current_equal_runs: Vec<u32>,
 }
 
 impl StreamingDiff {
@@ -114,9 +115,10 @@ impl StreamingDiff {
 
     pub fn new(old: String) -> Self {
         let old = old.chars().collect::<Vec<_>>();
+        let old_len = old.len();
         let mut scores = Matrix::new();
-        scores.resize(old.len() + 1, 1);
-        for i in 0..=old.len() {
+        scores.resize(old_len + 1, 1);
+        for i in 0..=old_len {
             scores.set(i, 0, i as f64 * Self::DELETION_SCORE);
         }
         Self {
@@ -125,7 +127,8 @@ impl StreamingDiff {
             scores,
             old_text_ix: 0,
             new_text_ix: 0,
-            equal_runs: Default::default(),
+            previous_equal_runs: vec![0; old_len + 1],
+            current_equal_runs: vec![0; old_len + 1],
         }
     }
 
@@ -134,9 +137,9 @@ impl StreamingDiff {
         self.scores.swap_columns(0, self.scores.cols - 1);
         self.scores
             .resize(self.old.len() + 1, self.new.len() - self.new_text_ix + 1);
-        self.equal_runs.retain(|(_i, j), _| *j == self.new_text_ix);
 
         for j in self.new_text_ix + 1..=self.new.len() {
+            self.current_equal_runs.fill(0);
             let relative_j = j - self.new_text_ix;
 
             self.scores
@@ -145,9 +148,8 @@ impl StreamingDiff {
                 let insertion_score = self.scores.get(i, relative_j - 1) + Self::INSERTION_SCORE;
                 let deletion_score = self.scores.get(i - 1, relative_j) + Self::DELETION_SCORE;
                 let equality_score = if self.old[i - 1] == self.new[j - 1] {
-                    let mut equal_run = self.equal_runs.get(&(i - 1, j - 1)).copied().unwrap_or(0);
-                    equal_run += 1;
-                    self.equal_runs.insert((i, j), equal_run);
+                    let equal_run = self.previous_equal_runs[i - 1] + 1;
+                    self.current_equal_runs[i] = equal_run;
 
                     let exponent = cmp::min(equal_run as i32 / 4, Self::MAX_EQUALITY_EXPONENT);
                     self.scores.get(i - 1, relative_j - 1) + Self::EQUALITY_BASE.powi(exponent)
@@ -158,6 +160,8 @@ impl StreamingDiff {
                 let score = insertion_score.max(deletion_score).max(equality_score);
                 self.scores.set(i, relative_j, score);
             }
+
+            std::mem::swap(&mut self.previous_equal_runs, &mut self.current_equal_runs);
         }
 
         let mut max_score = f64::NEG_INFINITY;


### PR DESCRIPTION
## Summary

Cherry-picks (and adapts) six upstream crash, memory-safety, and performance
fixes into independent core crates (`gpui`, `editor`, `multi_buffer`,
`scheduler`, `streaming_diff`). No overlap with #33; branched fresh from `main`.
All are pure stability/perf gains with no behavioral or UX change.

## Changes

- **Fix GPUI crash when using cached view with Input** (zed #50665) — out-of-bounds panic in `gpui/window.rs` affecting any input-bearing panel.
- **Fix crash in `manipulate_text` on multibuffers** (zed #57165) — cross-excerpt edits that apply differently than predicted. Ported the regression test; dropped the unrelated `test_convert_to_base64` since superzent has no base64-convert feature.
- **Fix multibuffer chunk splitting at UTF-8 boundaries** (zed #57641) — with regression test.
- **Fix editor hit testing when the editor is clipped** (zed #56861) — wrong positions for markdown blocks in the agent panel. The test is adapted to superzent's `PointForPosition` (upstream's separately-added `nearest_valid` field is absent → uses `next_valid`).
- **Speed up `StreamingDiff::push_new` by 30-36%** (zed #57772) — agent edit streaming.
- **Fix stacked-borrows violation in scheduler** (zed #56850) — memory-safety fix under Miri. Only the `crates/scheduler` changes are ported; the upstream PR's CI workflow edits are omitted.

## Test plan

- [x] `cargo test -p editor -- test_manipulate_text_handles_cross_excerpt_edit_that_applies_differently test_point_for_position_clipped_rows` — pass
- [x] `cargo test -p multi_buffer -- test_text_for_range_with_diff_transform_boundary_inside_multibyte_character` — pass
- [x] `cargo test -p scheduler -p streaming_diff` — pass
- [x] `./script/clippy -p gpui -p editor -p multi_buffer -p scheduler -p streaming_diff` — no warnings
- [ ] `#50665` has no upstream test (fix-only); compile-verified.

Release Notes:

- Fixed several crashes (cached-view text input, `manipulate_text` on multibuffers, UTF-8 multibuffer boundaries, clipped-editor hit testing), a scheduler memory-safety issue, and sped up agent edit streaming
