### PR TITLE
Port upstream out-of-bounds panic fixes for GIFs and inline rewrites

### DIFF
--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -1851,7 +1851,7 @@ mod tests {
             .unbounded_send(rewrite_tool_use("tool_1", &text[..chunk_len], false))
             .unwrap();
         events_tx
-            .unbounded_send(rewrite_tool_use("tool_2", &text, true))
+            .unbounded_send(rewrite_tool_use("tool_1", &text, true))
             .unwrap();
         events_tx
             .unbounded_send(LanguageModelCompletionEvent::Stop(StopReason::EndTurn))

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -4,7 +4,7 @@ use anyhow::{Context as _, Result};
 use uuid::Uuid;
 
 use cloud_llm_client::CompletionIntent;
-use collections::HashSet;
+use collections::{HashMap, HashSet};
 use editor::{Anchor, AnchorRangeExt, MultiBuffer, MultiBufferSnapshot, ToOffset as _, ToPoint};
 use futures::{
     SinkExt, Stream, StreamExt, TryStreamExt as _,
@@ -19,7 +19,7 @@ use language_model::{
     LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage,
     LanguageModelRequestTool, LanguageModelTextStream, LanguageModelToolChoice,
-    LanguageModelToolUse, Role, TokenUsage,
+    LanguageModelToolUse, LanguageModelToolUseId, Role, TokenUsage,
 };
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
@@ -1168,9 +1168,10 @@ impl CodegenAlternative {
                 Failure(String),
             }
 
-            let chars_read_so_far = Arc::new(Mutex::new(0usize));
+            let chars_read_by_tool_id: Arc<Mutex<HashMap<LanguageModelToolUseId, usize>>> =
+                Arc::new(Mutex::new(HashMap::default()));
             let process_tool_use = move |tool_use: LanguageModelToolUse| -> Option<ToolUseOutput> {
-                let mut chars_read_so_far = chars_read_so_far.lock();
+                let mut chars_read_by_tool_id = chars_read_by_tool_id.lock();
                 match tool_use.name.as_ref() {
                     REWRITE_SECTION_TOOL_NAME => {
                         let Ok(input) =
@@ -1178,7 +1179,13 @@ impl CodegenAlternative {
                         else {
                             return None;
                         };
-                        let text = input.replacement_text[*chars_read_so_far..].to_string();
+                        let chars_read_so_far =
+                            chars_read_by_tool_id.entry(tool_use.id).or_insert(0);
+                        let Some(text_slice) = input.replacement_text.get(*chars_read_so_far..)
+                        else {
+                            return None;
+                        };
+                        let text = text_slice.to_string();
                         *chars_read_so_far = input.replacement_text.len();
                         Some(ToolUseOutput::Rewrite {
                             text,
@@ -1896,6 +1903,53 @@ mod tests {
                     .collect::<Vec<_>>(),
             )
         }
+    }
+
+    // Regression test: a second rewrite tool use with a *shorter* replacement_text
+    // than the first must not panic. The character counter used to be shared
+    // across all tool use ids, so slicing the shorter text at the first tool's
+    // offset indexed out of bounds.
+    #[gpui::test]
+    async fn test_separate_tool_uses_have_independent_char_counters(cx: &mut TestAppContext) {
+        init_test(cx);
+        let buffer = cx.new(|cx| Buffer::local("", cx));
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+        let range = buffer.read_with(cx, |buffer, cx| {
+            let snapshot = buffer.snapshot(cx);
+            snapshot.anchor_before(Point::new(0, 0))..snapshot.anchor_after(Point::new(0, 0))
+        });
+        let prompt_builder = Arc::new(PromptBuilder::new(None).unwrap());
+        let codegen = cx.new(|cx| {
+            CodegenAlternative::new(
+                buffer.clone(),
+                range.clone(),
+                true,
+                prompt_builder,
+                Uuid::new_v4(),
+                cx,
+            )
+        });
+
+        let events_tx = simulate_tool_based_completion(&codegen, cx);
+        // tool_1 has longer text; tool_2 has shorter text. With the old shared
+        // counter, processing tool_2 would attempt replacement_text[N..] where
+        // N > replacement_text.len(), panicking with index out of bounds.
+        events_tx
+            .unbounded_send(rewrite_tool_use("tool_1", "longer replacement text", true))
+            .unwrap();
+        events_tx
+            .unbounded_send(rewrite_tool_use("tool_2", "short", true))
+            .unwrap();
+        events_tx
+            .unbounded_send(LanguageModelCompletionEvent::Stop(StopReason::EndTurn))
+            .unwrap();
+        drop(events_tx);
+        cx.run_until_parked();
+
+        assert_eq!(
+            buffer.read_with(cx, |buffer, cx| buffer.snapshot(cx).text()),
+            "longer replacement textshort"
+        );
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -294,7 +294,7 @@ impl Element for Img {
                 })
             });
 
-            let frame_index = state.as_ref().map(|state| state.frame_index).unwrap_or(0);
+            let mut frame_index = state.as_ref().map(|state| state.frame_index).unwrap_or(0);
 
             let layout_id = self.interactivity.request_layout(
                 global_id,
@@ -314,6 +314,11 @@ impl Element for Img {
                         Some(Ok(data)) => {
                             if let Some(state) = &mut state {
                                 let frame_count = data.frame_count();
+                                // Clamp a frame_index carried over from a previously
+                                // rendered, longer animation so it cannot index out of
+                                // bounds when the underlying image is replaced.
+                                state.frame_index =
+                                    state.frame_index.min(frame_count.saturating_sub(1));
                                 if frame_count > 1 {
                                     let current_time = Instant::now();
                                     if let Some(last_frame_time) = state.last_frame_time {
@@ -330,8 +335,11 @@ impl Element for Img {
                                     } else {
                                         state.last_frame_time = Some(current_time);
                                     }
+                                } else {
+                                    state.last_frame_time = None;
                                 }
                                 state.started_loading = None;
+                                frame_index = state.frame_index;
                             }
 
                             let image_size = data.render_size(frame_index);


### PR DESCRIPTION
Ports two upstream out-of-bounds panic fixes that also affect superzent. Both target files were frozen at the March-18 fork point, so a verbatim `git cherry-pick` conflicts on upstream's intervening refactors; each fix was therefore adapted by hand to superzent's current code and credited to the upstream commit.

## gpui: out-of-bounds panic rendering GIFs (upstream 749fcfdfd, #54701)

When an `img` element's underlying image is replaced with one that has fewer frames, the cached `frame_index` from the previous, longer animation can index out of bounds, panicking on the next render (e.g. a GIF swapped in Markdown Preview). The fix clamps the cached `frame_index` to the new image's frame count before it is used, resets the animation timer for single-frame images, and propagates the clamped value to the index actually used for sizing and painting.

superzent's `img` element predates upstream's `window.is_window_active()` refactor, so the change is the minimal adaptation rather than a verbatim cherry-pick. No regression test was added: superzent's `img.rs` has no test module and the upstream test depends on `canvas`/element-state seeding scaffolding not present here; the clamp is verified by inspection and a clean clippy build.

## agent_ui: out-of-bounds panic on multiple inline rewrites (upstream 064a17fd1, #52458)

The inline assistant's streaming-tool handler (`CodegenAlternative::handle_completion`) tracked how many characters of `replacement_text` had already been emitted with a single counter shared across every rewrite tool use. When one completion produced more than one rewrite and a later one had a shorter `replacement_text`, slicing `replacement_text[counter..]` panicked with an out-of-bounds index. The counter is now keyed by tool use id and the slice is read defensively with `get(..)`, so a shorter follow-up rewrite degrades instead of crashing. This handler ships by default (`acp_tabs` feature), so the panic is user-reachable.

A regression test (`test_separate_tool_uses_have_independent_char_counters`) is included, adapted to superzent's `CodegenAlternative::new` signature and existing test helpers.

## Verification

- `./script/clippy -p gpui -p agent_ui` — clean.
- `cargo test -p agent_ui test_separate_tool_uses_have_independent_char_counters` — passes (and panics without the fix).

## Suggested .rules additions

When porting an upstream fix, simulate the cherry-pick with `git merge-tree --write-tree --merge-base <sha>^ HEAD <sha>` (commit parent as base), not the fork merge-base — superzent files frozen at the fork point conflict on upstream's intervening refactors, so "clean against the fork base" does not mean "clean cherry-pick".

Release Notes:

- Fixed two out-of-bounds panics: one when a GIF was replaced with a shorter animation in Markdown Preview, and one when the AI produced multiple inline rewrites in a single completion.
