### PR TITLE
superzent_ui: Fix high CPU from animated workspace attention dot

### DIFF
--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -21,7 +21,7 @@ use editor::{Editor, EditorEvent, actions::SelectAll};
 use git::repository::validate_worktree_directory;
 use git_ui::git_panel::GitPanel;
 use gpui::{
-    Action, Animation, AnimationExt, App, AsyncWindowContext, ClickEvent, ClipboardItem, Corner,
+    Action, App, AsyncWindowContext, ClickEvent, ClipboardItem, Corner,
     DismissEvent, Entity, EntityId, EventEmitter, FocusHandle, Focusable, MouseButton,
     MouseDownEvent, PathPromptOptions, Point, PromptLevel, ScrollHandle, SharedString,
     Subscription, Task, WeakEntity, WindowHandle, actions, anchored, deferred, px,
@@ -51,7 +51,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 #[cfg(target_os = "macos")]
 use std::{
@@ -8481,38 +8481,164 @@ fn render_workspace_attention_indicator(
             .justify_center()
             .child(Indicator::dot().color(Color::Success))
             .into_any_element(),
-        WorkspaceAttentionStatus::Working => div()
-            .w_3()
-            .items_center()
-            .justify_center()
-            .child(Indicator::dot().color(Color::Warning))
-            .with_animation(
-                gpui::ElementId::from(SharedString::from(format!(
-                    "superzent-working-indicator-{workspace_id}"
-                ))),
-                Animation::new(Duration::from_millis(900)).repeat(),
-                |indicator: gpui::Div, delta: f32| {
-                    let alpha = 0.35 + (delta * std::f32::consts::PI).sin().abs() * 0.65;
-                    indicator.opacity(alpha)
-                },
-            )
-            .into_any_element(),
-        WorkspaceAttentionStatus::Permission => div()
-            .w_3()
-            .items_center()
-            .justify_center()
-            .child(Indicator::dot().color(Color::Error))
-            .with_animation(
-                gpui::ElementId::from(SharedString::from(format!(
-                    "superzent-permission-indicator-{workspace_id}"
-                ))),
-                Animation::new(Duration::from_millis(650)).repeat(),
-                |indicator: gpui::Div, delta: f32| {
-                    let alpha = 0.4 + (delta * std::f32::consts::PI).sin().abs() * 0.6;
-                    indicator.opacity(alpha)
-                },
-            )
-            .into_any_element(),
+        WorkspaceAttentionStatus::Working => PulsingDot::new(
+            SharedString::from(format!("superzent-working-indicator-{workspace_id}")),
+            Duration::from_millis(900),
+            div()
+                .w_3()
+                .items_center()
+                .justify_center()
+                .child(Indicator::dot().color(Color::Warning)),
+            |indicator: Div, delta: f32| {
+                let alpha = 0.35 + (delta * std::f32::consts::PI).sin().abs() * 0.65;
+                indicator.opacity(alpha)
+            },
+        )
+        .into_any_element(),
+        WorkspaceAttentionStatus::Permission => PulsingDot::new(
+            SharedString::from(format!("superzent-permission-indicator-{workspace_id}")),
+            Duration::from_millis(650),
+            div()
+                .w_3()
+                .items_center()
+                .justify_center()
+                .child(Indicator::dot().color(Color::Error)),
+            |indicator: Div, delta: f32| {
+                let alpha = 0.4 + (delta * std::f32::consts::PI).sin().abs() * 0.6;
+                indicator.opacity(alpha)
+            },
+        )
+        .into_any_element(),
+    }
+}
+
+/// A self-contained pulsing wrapper for the workspace attention dot.
+///
+/// `gpui::with_animation` calls `request_animation_frame` on every frame, which
+/// drives a full-window relayout at the display refresh rate (120Hz on ProMotion)
+/// for as long as the animated element is on screen. A tiny attention dot only
+/// needs a low frame rate to read as a smooth pulse, so this element schedules its
+/// own redraw on a fixed interval instead, keeping the whole window from re-laying
+/// out at the display rate while an agent is working.
+struct PulsingDot {
+    id: ElementId,
+    period: Duration,
+    interval: Duration,
+    element: Option<Div>,
+    animator: Box<dyn Fn(Div, f32) -> Div + 'static>,
+}
+
+impl PulsingDot {
+    fn new(
+        id: impl Into<ElementId>,
+        period: Duration,
+        element: Div,
+        animator: impl Fn(Div, f32) -> Div + 'static,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            period,
+            interval: Duration::from_millis(50),
+            element: Some(element),
+            animator: Box::new(animator),
+        }
+    }
+}
+
+struct PulsingDotState {
+    start: Instant,
+    // Holds the scheduled redraw alive; dropping it cancels the wake-up, so the
+    // pulse stops automatically once the element leaves the tree.
+    _redraw: Option<Task<()>>,
+}
+
+impl IntoElement for PulsingDot {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for PulsingDot {
+    type RequestLayoutState = AnyElement;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        global_id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (gpui::LayoutId, Self::RequestLayoutState) {
+        window.with_element_state(
+            global_id.expect("PulsingDot reports an id, so it is always stateful"),
+            |state, window| {
+                let state = state.unwrap_or_else(|| PulsingDotState {
+                    start: Instant::now(),
+                    _redraw: None,
+                });
+                let delta =
+                    (state.start.elapsed().as_secs_f32() / self.period.as_secs_f32()).fract();
+
+                let element = self
+                    .element
+                    .take()
+                    .expect("PulsingDot::request_layout is called once");
+                let mut element = (self.animator)(element, delta).into_any_element();
+
+                // Wake this view after a fixed interval rather than on the next
+                // frame, decoupling the pulse cadence from the display refresh rate.
+                let view = window.current_view();
+                let interval = self.interval;
+                let redraw = cx.spawn(async move |cx| {
+                    cx.background_executor().timer(interval).await;
+                    cx.update(|cx| cx.notify(view));
+                });
+
+                let layout_id = element.request_layout(window, cx);
+                (
+                    (layout_id, element),
+                    PulsingDotState {
+                        start: state.start,
+                        _redraw: Some(redraw),
+                    },
+                )
+            },
+        )
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        _bounds: gpui::Bounds<Pixels>,
+        element: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        element.prepaint(window, cx);
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        _bounds: gpui::Bounds<Pixels>,
+        element: &mut Self::RequestLayoutState,
+        _: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        element.paint(window, cx);
     }
 }
 

--- a/crates/superzent_ui/src/lib.rs
+++ b/crates/superzent_ui/src/lib.rs
@@ -21,10 +21,10 @@ use editor::{Editor, EditorEvent, actions::SelectAll};
 use git::repository::validate_worktree_directory;
 use git_ui::git_panel::GitPanel;
 use gpui::{
-    Action, App, AsyncWindowContext, ClickEvent, ClipboardItem, Corner,
-    DismissEvent, Entity, EntityId, EventEmitter, FocusHandle, Focusable, MouseButton,
-    MouseDownEvent, PathPromptOptions, Point, PromptLevel, ScrollHandle, SharedString,
-    Subscription, Task, WeakEntity, WindowHandle, actions, anchored, deferred, px,
+    Action, App, AsyncWindowContext, ClickEvent, ClipboardItem, Corner, DismissEvent, Entity,
+    EntityId, EventEmitter, FocusHandle, Focusable, MouseButton, MouseDownEvent, PathPromptOptions,
+    Point, PromptLevel, ScrollHandle, SharedString, Subscription, Task, WeakEntity, WindowHandle,
+    actions, anchored, deferred, px,
 };
 use menu;
 use notifications::status_toast::{StatusToast, ToastIcon};

--- a/docs/solutions/ui-bugs/workspace-attention-dot-pulse-causes-full-window-redraw-2026-06-30.md
+++ b/docs/solutions/ui-bugs/workspace-attention-dot-pulse-causes-full-window-redraw-2026-06-30.md
@@ -1,0 +1,84 @@
+---
+title: Animated workspace attention dot pins CPU via full-window redraw
+date: 2026-06-30
+category: ui-bugs
+module: superzent_ui sidebar attention indicator
+problem_type: ui_bug
+component: superzent_ui
+symptoms:
+  - Main thread sits at ~70% CPU the whole time an agent task is running (Working/Permission state)
+  - CPU returns to idle when the sidebar is collapsed, even though the agent is still running
+  - A sampling profile shows the main thread looping in `gpui::Window::draw` → `taffy::compute::flexbox` every frame, never going idle
+  - The app feels unusable during long agent sessions
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+applies_when:
+  - "Adding a continuously animated element (pulse/spin/blink) to an always-present part of the UI in GPUI"
+  - "Using `with_animation(...).repeat()` for an indefinite animation"
+  - "Investigating high idle CPU / runaway redraw in a GPUI app"
+tags:
+  - gpui
+  - animation
+  - performance
+  - redraw-loop
+  - attention-indicator
+  - with_animation
+  - request_animation_frame
+---
+
+# Animated workspace attention dot pins CPU via full-window redraw
+
+## Problem
+
+The sidebar workspace attention dot pulsed (opacity fade) while a workspace was in the `Working` or `Permission` state, using:
+
+```rust
+div()
+    .child(Indicator::dot().color(Color::Warning))
+    .with_animation(
+        id,
+        Animation::new(Duration::from_millis(900)).repeat(),
+        |indicator, delta| indicator.opacity(/* sine pulse */),
+    )
+```
+
+`gpui::with_animation` calls `window.request_animation_frame()` on every layout pass (`crates/gpui/src/elements/animation.rs`), with no frame-rate cap. Because GPUI rebuilds the Taffy layout tree on every `draw()` (`layout_engine.clear()` in `crates/gpui/src/window.rs`), each requested frame re-lays-out and repaints the **entire window** — sidebar, editor, and terminal — on the main thread. With `.repeat()` this never stops, so the window redraws at the display refresh rate (120Hz on ProMotion) the whole time the dot is on screen, just to fade one 12px dot.
+
+## Symptoms
+
+See frontmatter. The tell-tale sign is that collapsing the sidebar (removing the animated element from the tree) immediately drops CPU to idle while the agent keeps running, and a `sample` profile shows a perpetual `Window::draw → request_layout → taffy flexbox` loop on `com.apple.main-thread`.
+
+## Root Cause
+
+`with_animation(...).repeat()` ties the redraw cadence to the display refresh rate. A 900ms opacity pulse is visually identical at ~20fps and at 120fps, so the higher rate buys nothing but burns ~6× the CPU. The cost is not the dot — it is that GPUI re-lays-out the whole window per animation frame (no cross-frame layout cache unless a view is explicitly `.cached(...)`; no compositor-level opacity animation).
+
+## Solution
+
+Replace `with_animation` for the attention dot with a small, file-private `PulsingDot` element in `crates/superzent_ui/src/lib.rs` that schedules its own redraw on a fixed ~20fps interval instead of every frame:
+
+- In `request_layout`, compute opacity from `start.elapsed()` and, instead of `window.request_animation_frame()`, `cx.spawn` a task that awaits `cx.background_executor().timer(50ms)` then `cx.update(|cx| cx.notify(window.current_view()))`.
+- Store `start` and the redraw `Task` in GPUI element state via `with_element_state`, keyed by id. No `SuperzentSidebar` struct fields and no start/stop lifecycle wiring are needed.
+- When the dot leaves the tree (status returns to `Idle`/`Review`), its element state is dropped, which cancels the redraw task — the pulse stops on its own.
+
+Measured: an active pulse drops from ~70% CPU to under 10% on a 120Hz machine, with no visible change to the pulse.
+
+## Why This Works
+
+GPUI marks only the notified view and its **ancestors** dirty (`Window::mark_view_dirty`), and the cost of a redraw scales with how often it happens. Capping the cadence at ~20fps cuts the number of full-window relayouts by ~6× while keeping the pulse smooth, because the eye cannot distinguish a 900ms fade at 20fps from one at 120fps.
+
+## Alternatives Considered
+
+- **Static dot** (no animation): cheapest, but loses the pulse affordance.
+- **`.cached(...)` on heavy sibling panels**: since dirtiness only propagates to ancestors, wrapping the editor/terminal subtrees in `.cached(StyleRefinement)` would let a pulse frame `reuse_prepaint`/`reuse_paint` those subtrees and re-lay-out only the dirty ancestor chain. More thorough but more invasive (cached-view staleness risk), so it was left as a possible follow-up rather than bundled with this fix.
+- There is no GPUI equivalent of a browser/compositor `transform`/`opacity` animation, so a truly zero-CPU pulse (à la CSS `animate-ping`) is not possible without framework-level work.
+
+## Prevention
+
+In GPUI, treat any `with_animation(...).repeat()` on an element that can stay on screen indefinitely as a continuous full-window redraw driver. For low-frequency indicators (pulse/blink), drive the redraw with an explicit interval timer so the cadence is decoupled from the display refresh rate, and/or `.cached(...)` the expensive, unrelated subtrees.
+
+## Related
+
+- `crates/gpui/src/elements/animation.rs` — `AnimationElement::request_layout` unconditionally calls `request_animation_frame`.
+- `crates/gpui/src/window.rs` — `Window::draw` clears the layout engine each frame; `mark_view_dirty` propagates to ancestors; `View::cached` reuse path in `crates/gpui/src/view.rs`.
+- upstream PR: currybab/superzent#38


### PR DESCRIPTION
## Summary

The workspace attention dot in the sidebar pulses while a workspace is in the **Working** or **Permission** state. It used `with_animation(...).repeat()`, and `with_animation` calls `request_animation_frame` on every frame. Because GPUI rebuilds the Taffy layout tree on every `draw()`, this drives a **full-window relayout + repaint at the display refresh rate** (120Hz on ProMotion) on the main thread, continuously, for as long as an agent is working — the whole workspace (sidebar, editor, terminal) is re-laid-out every frame just to fade one 12px dot.

## Why this matters (severity)

This is not a minor inefficiency — it makes the app effectively **unusable during long agent sessions**, which is the app's core workflow:

- The main thread sat at **~70% CPU** the entire time an agent task was running.
- The only way to recover was to **collapse the sidebar** (removing the dot from the element tree).
- It runs the whole time the dot is in Working/Permission, i.e. exactly when the user is relying on the agent.

The cost scales with window complexity × refresh rate, so it is worst on exactly the high-end (ProMotion) machines and busy multi-panel layouts where users spend the most time.

## Root cause

`gpui::with_animation` has no frame-rate cap — it re-requests an animation frame on every layout pass. A 900ms opacity pulse looks identical at ~20fps and at 120fps, so the higher rate buys nothing but burns 6× the CPU.

## Fix

Introduce a small, self-contained `PulsingDot` element (file-private to `superzent_ui`) that replaces `with_animation` for the attention dot. Instead of requesting a frame every display tick, it schedules its own redraw on a fixed ~20fps interval, decoupling the pulse cadence from the display refresh rate.

- State (start time + the scheduled redraw task) lives in GPUI element state keyed by id — **no sidebar struct fields or start/stop lifecycle wiring**.
- When the dot leaves the tree (status returns to Idle/Review), its element state is dropped and the redraw task is cancelled automatically, so the pulse stops on its own.
- No changes to GPUI, to `SuperzentSidebar`, or to the other 27 `with_animation` call sites.

## Measurement

On a 120Hz machine, an active pulse drops from **~70% CPU to under 10%**, with no visible change to the pulse.

## Notes / possible follow-ups

This is the contained, low-risk fix. GPUI has no compositor-level opacity animation, so the pulse is always CPU-side; a more thorough (but more invasive) route would be wrapping the heavy sibling panels in `.cached(...)` so a pulse frame only re-lays-out the dirty ancestor chain. Not done here to keep the change scoped to the dot.

Release Notes:

- Fixed high CPU usage caused by the animated workspace attention indicator continuously re-rendering the whole window while an agent was working