### PR TITLE
Port upstream Git fixes and fix agent hook server crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -16924,7 +16924,6 @@ dependencies = [
  "smol",
  "superzent_model",
  "task",
- "tiny_http",
  "url",
  "uuid",
 ]
@@ -17999,15 +17998,14 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.8.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce51b50006056f590c9b7c3808c3bd70f0d1101666629713866c227d6e58d39"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
 dependencies = [
  "ascii",
- "chrono",
  "chunked_transfer",
+ "httpdate",
  "log",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -728,7 +728,7 @@ time = { version = "0.3", features = [
     "formatting",
     "local-offset",
 ] }
-tiny_http = "0.8"
+tiny_http = "0.12"
 tokio = { version = "1" }
 tokio-socks = { version = "0.5.2", default-features = false, features = [
     "futures-io",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1399,7 +1399,11 @@ impl Client {
                     // Start an HTTP server to receive the redirect from Zed's sign-in page.
                     let server = tiny_http::Server::http("127.0.0.1:0")
                         .map_err(|e| anyhow!(e).context("failed to bind callback port"))?;
-                    let port = server.server_addr().port();
+                    let port = server
+                        .server_addr()
+                        .to_ip()
+                        .context("callback server is not listening on an ip address")?
+                        .port();
 
                     // Open the Zed sign-in page in the user's browser, with query parameters that indicate
                     // that the user is signing in from a Zed app running on the same device.

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -55,6 +55,7 @@ pub struct FakeGitRepositoryState {
     pub refs: HashMap<String, String>,
     pub graph_commits: Vec<Arc<InitialGraphCommitData>>,
     pub worktrees: Vec<Worktree>,
+    pub stash_entries: git::stash::GitStash,
 }
 
 impl FakeGitRepositoryState {
@@ -75,6 +76,7 @@ impl FakeGitRepositoryState {
             remotes: HashMap::default(),
             graph_commits: Vec::new(),
             worktrees: Vec::new(),
+            stash_entries: Default::default(),
         }
     }
 }
@@ -381,7 +383,7 @@ impl GitRepository for FakeGitRepository {
     }
 
     fn stash_entries(&self) -> BoxFuture<'_, Result<git::stash::GitStash>> {
-        async { Ok(git::stash::GitStash::default()) }.boxed()
+        self.with_state_async(false, |state| Ok(state.stash_entries.clone()))
     }
 
     fn branches(&self) -> BoxFuture<'_, Result<Vec<Branch>>> {

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -21,8 +21,19 @@ pub const DOT_GIT: &str = ".git";
 pub const GITIGNORE: &str = ".gitignore";
 pub const FSMONITOR_DAEMON: &str = "fsmonitor--daemon";
 pub const LFS_DIR: &str = "lfs";
+pub const OBJECTS_DIR: &str = "objects";
+pub const HOOKS_DIR: &str = "hooks";
+pub const LOGS_DIR: &str = "logs";
+pub const LOGS_REF_STASH: &str = "logs/refs/stash";
+pub const REBASE_MERGE_DIR: &str = "rebase-merge";
+pub const REBASE_APPLY_DIR: &str = "rebase-apply";
+pub const SEQUENCER_DIR: &str = "sequencer";
 pub const COMMIT_MESSAGE: &str = "COMMIT_EDITMSG";
-pub const INDEX_LOCK: &str = "index.lock";
+pub const FETCH_HEAD: &str = "FETCH_HEAD";
+pub const ORIG_HEAD: &str = "ORIG_HEAD";
+pub const BISECT_LOG: &str = "BISECT_LOG";
+pub const GC_PID: &str = "gc.pid";
+pub const INFO_DIR: &str = "info";
 pub const REPO_EXCLUDE: &str = "info/exclude";
 
 actions!(

--- a/crates/git/src/remote.rs
+++ b/crates/git/src/remote.rs
@@ -9,8 +9,12 @@ use url::Url;
 #[derive(Debug, PartialEq, Eq, Clone, Deref)]
 pub struct RemoteUrl(Url);
 
+// Detect the `user@` prefix of an SCP-like remote (e.g. `git@host:path`). The
+// username may contain anything but the `@`/`:`/`/` that delimit the user,
+// host, and path, so match by exclusion rather than an allowlist that misses
+// names like `first.last`.
 static USERNAME_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[0-9a-zA-Z\-_]+@").expect("Failed to create USERNAME_REGEX"));
+    LazyLock::new(|| Regex::new(r"^[^/@:]+@").expect("Failed to create USERNAME_REGEX"));
 
 impl FromStr for RemoteUrl {
     type Err = url::ParseError;
@@ -42,6 +46,12 @@ mod tests {
                 "/octocat/zed.git",
             ),
             (
+                "https://jlannister@github.com/octocat/zed.git",
+                "https",
+                "github.com",
+                "/octocat/zed.git",
+            ),
+            (
                 "git@github.com:octocat/zed.git",
                 "ssh",
                 "github.com",
@@ -52,6 +62,12 @@ mod tests {
                 "ssh",
                 "github.com",
                 "/octocat/zed.git",
+            ),
+            (
+                "first.last@gitlab.example.com:group/repo.git",
+                "ssh",
+                "gitlab.example.com",
+                "/group/repo.git",
             ),
             (
                 "ssh://git@github.com/octocat/zed.git",

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -3,7 +3,7 @@ use agent_settings::AgentSettings;
 use collections::{HashMap, HashSet};
 use editor::{
     ConflictsOurs, ConflictsOursMarker, ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker,
-    Editor, EditorEvent, ExcerptId, MultiBuffer, RowHighlightOptions,
+    Editor, ExcerptId, MultiBuffer, RowHighlightOptions,
     display_map::{BlockContext, BlockPlacement, BlockProperties, BlockStyle, CustomBlockId},
 };
 #[cfg(feature = "ai")]
@@ -15,7 +15,7 @@ use gpui::{
 use language::{Anchor, Buffer, BufferId};
 #[cfg(feature = "ai")]
 use project::git_store::{GitStoreEvent, RepositoryEvent};
-use project::{ConflictRegion, ConflictSet, ConflictSetUpdate, ProjectItem as _};
+use project::{ConflictRegion, ConflictSet, ConflictSetUpdate};
 #[cfg(feature = "ai")]
 use settings::Settings as _;
 #[cfg(feature = "ai")]
@@ -24,7 +24,7 @@ use std::{ops::Range, sync::Arc};
 #[cfg(feature = "ai")]
 use ui::Divider;
 use ui::{ActiveTheme, Element as _, Styled, Window, prelude::*};
-use util::{ResultExt as _, debug_panic, maybe};
+use util::{debug_panic, maybe};
 use workspace::Workspace;
 #[cfg(feature = "ai")]
 use workspace::notifications::simple_message_notification::MessageNotification;
@@ -35,14 +35,6 @@ use zed_actions::agent::{
 
 pub(crate) struct ConflictAddon {
     buffers: HashMap<BufferId, BufferConflicts>,
-}
-
-impl ConflictAddon {
-    pub(crate) fn conflict_set(&self, buffer_id: BufferId) -> Option<Entity<ConflictSet>> {
-        self.buffers
-            .get(&buffer_id)
-            .map(|entry| entry.conflict_set.clone())
-    }
 }
 
 struct BufferConflicts {
@@ -62,10 +54,9 @@ impl editor::Addon for ConflictAddon {
 }
 
 pub fn register_editor(editor: &mut Editor, buffer: Entity<MultiBuffer>, cx: &mut Context<Editor>) {
-    // Only show conflict UI for singletons and in the project diff.
+    let is_singleton = editor.buffer().read(cx).is_singleton();
     if !editor.mode().is_full()
-        || (!editor.buffer().read(cx).is_singleton()
-            && !editor.buffer().read(cx).all_diff_hunks_expanded())
+        || (!is_singleton && !editor.buffer().read(cx).all_diff_hunks_expanded())
         || editor.read_only(cx)
     {
         return;
@@ -75,82 +66,76 @@ pub fn register_editor(editor: &mut Editor, buffer: Entity<MultiBuffer>, cx: &mu
         buffers: Default::default(),
     });
 
-    let buffers = buffer.read(cx).all_buffers();
-    for buffer in buffers {
-        buffer_added(editor, buffer, cx);
-    }
-
-    cx.subscribe(&cx.entity(), |editor, _, event, cx| match event {
-        EditorEvent::ExcerptsAdded { buffer, .. } => buffer_added(editor, buffer.clone(), cx),
-        EditorEvent::ExcerptsExpanded { ids } => {
-            let multibuffer = editor.buffer().read(cx).snapshot(cx);
-            for excerpt_id in ids {
-                let Some(buffer) = multibuffer.buffer_for_excerpt(*excerpt_id) else {
-                    continue;
-                };
-                let addon = editor.addon::<ConflictAddon>().unwrap();
-                let Some(conflict_set) = addon.conflict_set(buffer.remote_id()).clone() else {
-                    return;
-                };
-                excerpt_for_buffer_updated(editor, conflict_set, cx);
-            }
+    if is_singleton {
+        let buffers = buffer.read(cx).all_buffers();
+        for buffer in buffers {
+            open_conflict_set_for_buffer(editor, buffer, cx);
         }
-        EditorEvent::ExcerptsRemoved {
-            removed_buffer_ids, ..
-        } => buffers_removed(editor, removed_buffer_ids, cx),
-        _ => {}
+    }
+}
+
+fn open_conflict_set_for_buffer(
+    _editor: &mut Editor,
+    buffer: Entity<Buffer>,
+    cx: &mut Context<Editor>,
+) {
+    let buffer = buffer.downgrade();
+
+    cx.spawn(async move |editor, cx| {
+        let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id())?;
+        if let Some(conflict_set) = editor.read_with(cx, |editor, _| {
+            editor
+                .addon::<ConflictAddon>()
+                .and_then(|addon| addon.buffers.get(&buffer_id))
+                .map(|buffer_conflicts| buffer_conflicts.conflict_set.clone())
+        })? {
+            editor.update(cx, |editor, cx| {
+                buffer_ranges_updated(editor, conflict_set, cx);
+            })?;
+            return anyhow::Ok(());
+        }
+
+        let Some(project) = editor.read_with(cx, |editor, _| editor.project().cloned())? else {
+            return anyhow::Ok(());
+        };
+        let git_store = project.read_with(cx, |project, _| project.git_store().clone());
+        let Some(buffer) = buffer.upgrade() else {
+            return Ok(());
+        };
+        let conflict_set = git_store
+            .update(cx, |git_store, cx| {
+                git_store.open_conflict_set(buffer.clone(), cx)
+            })
+            .await;
+        editor.update(cx, |editor, cx| {
+            buffer_ranges_updated(editor, conflict_set, cx);
+        })?;
+        Ok(())
     })
     .detach();
 }
 
-fn excerpt_for_buffer_updated(
+#[ztracing::instrument(skip_all)]
+pub(crate) fn buffer_ranges_updated(
     editor: &mut Editor,
     conflict_set: Entity<ConflictSet>,
     cx: &mut Context<Editor>,
 ) {
-    let conflicts_len = conflict_set.read(cx).snapshot().conflicts.len();
-    let buffer_id = conflict_set.read(cx).snapshot().buffer_id;
-    let Some(buffer_conflicts) = editor
-        .addon_mut::<ConflictAddon>()
-        .unwrap()
-        .buffers
-        .get(&buffer_id)
-    else {
+    let buffer_id = conflict_set.read(cx).snapshot.buffer_id;
+    if editor.buffer().read(cx).buffer(buffer_id).is_none() {
         return;
-    };
-    let addon_conflicts_len = buffer_conflicts.block_ids.len();
-    conflicts_updated(
-        editor,
-        conflict_set,
-        &ConflictSetUpdate {
-            buffer_range: None,
-            old_range: 0..addon_conflicts_len,
-            new_range: 0..conflicts_len,
-        },
-        cx,
-    );
-}
-
-#[ztracing::instrument(skip_all)]
-fn buffer_added(editor: &mut Editor, buffer: Entity<Buffer>, cx: &mut Context<Editor>) {
-    let Some(project) = editor.project() else {
-        return;
-    };
-    let git_store = project.read(cx).git_store().clone();
+    }
 
     let buffer_conflicts = editor
         .addon_mut::<ConflictAddon>()
         .unwrap()
         .buffers
-        .entry(buffer.read(cx).remote_id())
+        .entry(buffer_id)
         .or_insert_with(|| {
-            let conflict_set = git_store.update(cx, |git_store, cx| {
-                git_store.open_conflict_set(buffer.clone(), cx)
-            });
             let subscription = cx.subscribe(&conflict_set, conflicts_updated);
             BufferConflicts {
                 block_ids: Vec::new(),
-                conflict_set,
+                conflict_set: conflict_set.clone(),
                 _subscription: subscription,
             }
         });
@@ -170,7 +155,11 @@ fn buffer_added(editor: &mut Editor, buffer: Entity<Buffer>, cx: &mut Context<Ed
     );
 }
 
-fn buffers_removed(editor: &mut Editor, removed_buffer_ids: &[BufferId], cx: &mut Context<Editor>) {
+pub(crate) fn buffers_removed(
+    editor: &mut Editor,
+    removed_buffer_ids: &[BufferId],
+    cx: &mut Context<Editor>,
+) {
     let mut removed_block_ids = HashSet::default();
     editor
         .addon_mut::<ConflictAddon>()
@@ -621,10 +610,8 @@ pub(crate) fn resolve_conflict(
     cx: &mut App,
 ) -> Task<()> {
     window.spawn(cx, async move |cx| {
-        let Some((workspace, project, multibuffer, buffer)) = editor
+        editor
             .update(cx, |editor, cx| {
-                let workspace = editor.workspace()?;
-                let project = editor.project()?.clone();
                 let multibuffer = editor.buffer().clone();
                 let buffer_id = resolved_conflict.ours.end.buffer_id?;
                 let buffer = multibuffer.read(cx).buffer(buffer_id)?;
@@ -655,33 +642,8 @@ pub(crate) fn resolve_conflict(
                 editor.remove_highlighted_rows::<ConflictsOursMarker>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![range], cx);
                 editor.remove_blocks(HashSet::from_iter([block_id]), None, cx);
-                Some((workspace, project, multibuffer, buffer))
+                Some(())
             })
-            .ok()
-            .flatten()
-        else {
-            return;
-        };
-        let save = project.update(cx, |project, cx| {
-            if multibuffer.read(cx).all_diff_hunks_expanded() {
-                project.save_buffer(buffer.clone(), cx)
-            } else {
-                Task::ready(Ok(()))
-            }
-        });
-        if save.await.log_err().is_none() {
-            let open_path = maybe!({
-                let path = buffer.read_with(cx, |buffer, cx| buffer.project_path(cx))?;
-                workspace
-                    .update_in(cx, |workspace, window, cx| {
-                        workspace.open_path_preview(path, None, false, false, false, window, cx)
-                    })
-                    .ok()
-            });
-
-            if let Some(open_path) = open_path {
-                open_path.await.log_err();
-            }
-        }
+            .ok();
     })
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1861,17 +1861,14 @@ impl GitPanel {
         cx.spawn({
             async move |this, cx| {
                 let result = this
-                    .update(cx, |this, cx| {
-                        let task = active_repository.update(cx, |repo, cx| {
+                    .update(cx, |_this, cx| {
+                        active_repository.update(cx, |repo, cx| {
                             if stage {
                                 repo.stage_all(cx)
                             } else {
                                 repo.unstage_all(cx)
                             }
-                        });
-                        this.update_counts(active_repository.read(cx));
-                        cx.notify();
-                        task
+                        })
                     })?
                     .await;
 
@@ -1879,6 +1876,7 @@ impl GitPanel {
                     if let Err(err) = result {
                         this.show_error_toast(if stage { "add" } else { "reset" }, err, cx);
                     }
+                    this.update_counts(active_repository.read(cx));
                     cx.notify()
                 })
             }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1359,6 +1359,14 @@ impl GitPanel {
         }
     }
 
+    fn select_last_entry_if_out_of_bounds(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(idx) = self.selected_entry
+            && idx >= self.entries.len()
+        {
+            self.select_last(&menu::SelectLast, window, cx);
+        }
+    }
+
     fn focus_changes_list(
         &mut self,
         _: &FocusChanges,
@@ -3730,6 +3738,7 @@ impl GitPanel {
         }
 
         self.select_first_entry_if_none(window, cx);
+        self.select_last_entry_if_out_of_bounds(window, cx);
 
         let suggested_commit_message = self.suggest_commit_message(cx);
         let placeholder_text = suggested_commit_message.unwrap_or("Enter commit message".into());

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1,5 +1,5 @@
 use crate::{
-    conflict_view::ConflictAddon,
+    conflict_view,
     git_panel::{GitPanel, GitPanelAddon, GitStatusEntry},
     git_panel_settings::GitPanelSettings,
     remote_button::{render_publish_button, render_push_button},
@@ -26,7 +26,7 @@ use gpui::{
 use language::{Anchor, Buffer, BufferId, Capability, OffsetRangeExt};
 use multi_buffer::{MultiBuffer, PathKey};
 use project::{
-    Project, ProjectPath,
+    ConflictSet, Project, ProjectPath,
     git_store::{
         Repository,
         branch_diff::{self, BranchDiffEvent, DiffBase},
@@ -35,6 +35,7 @@ use project::{
 use settings::{Settings, SettingsStore};
 use smol::future::yield_now;
 use std::any::{Any, TypeId};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use theme::ActiveTheme;
 use ui::{DiffStat, Divider, Icon, KeyBinding, Tooltip, prelude::*, vertical_divider};
@@ -67,25 +68,25 @@ actions!(
     ]
 );
 
+struct BufferSubscriptions {
+    _diff: Entity<BufferDiff>,
+    _diff_subscription: Subscription,
+    _conflict_set: Entity<ConflictSet>,
+    _conflict_set_subscription: Subscription,
+}
+
 pub struct ProjectDiff {
     project: Entity<Project>,
     multibuffer: Entity<MultiBuffer>,
     branch_diff: Entity<branch_diff::BranchDiff>,
     editor: Entity<SplittableEditor>,
-    buffer_diff_subscriptions: HashMap<Arc<RelPath>, (Entity<BufferDiff>, Subscription)>,
+    buffer_subscriptions: HashMap<Arc<RelPath>, BufferSubscriptions>,
     workspace: WeakEntity<Workspace>,
     focus_handle: FocusHandle,
     pending_scroll: Option<PathKey>,
     review_comment_count: usize,
     _task: Task<Result<()>>,
     _subscription: Subscription,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RefreshReason {
-    DiffChanged,
-    StatusesChanged,
-    EditorSaved,
 }
 
 const CONFLICT_SORT_PREFIX: u64 = 1;
@@ -416,7 +417,7 @@ impl ProjectDiff {
                 BranchDiffEvent::FileListChanged => {
                     this._task = window.spawn(cx, {
                         let this = cx.weak_entity();
-                        async |cx| Self::refresh(this, RefreshReason::StatusesChanged, cx).await
+                        async |cx| Self::refresh(this, cx).await
                     })
                 }
             },
@@ -435,7 +436,7 @@ impl ProjectDiff {
                 this._task = {
                     window.spawn(cx, {
                         let this = cx.weak_entity();
-                        async |cx| Self::refresh(this, RefreshReason::StatusesChanged, cx).await
+                        async |cx| Self::refresh(this, cx).await
                     })
                 }
             }
@@ -446,7 +447,7 @@ impl ProjectDiff {
 
         let task = window.spawn(cx, {
             let this = cx.weak_entity();
-            async |cx| Self::refresh(this, RefreshReason::StatusesChanged, cx).await
+            async |cx| Self::refresh(this, cx).await
         });
 
         Self {
@@ -456,7 +457,7 @@ impl ProjectDiff {
             focus_handle,
             editor,
             multibuffer,
-            buffer_diff_subscriptions: Default::default(),
+            buffer_subscriptions: Default::default(),
             pending_scroll: None,
             review_comment_count: 0,
             _task: task,
@@ -684,9 +685,8 @@ impl ProjectDiff {
                     .ok();
             }
             EditorEvent::Saved => {
-                self._task = cx.spawn_in(window, async move |this, cx| {
-                    Self::refresh(this, RefreshReason::EditorSaved, cx).await
-                });
+                self._task =
+                    cx.spawn_in(window, async move |this, cx| Self::refresh(this, cx).await);
             }
             _ => {}
         }
@@ -704,26 +704,57 @@ impl ProjectDiff {
         file_status: FileStatus,
         buffer: Entity<Buffer>,
         diff: Entity<BufferDiff>,
+        conflict_set: Entity<ConflictSet>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<BufferId> {
-        let subscription = cx.subscribe_in(&diff, window, move |this, _, _, window, cx| {
-            this._task = window.spawn(cx, {
-                let this = cx.weak_entity();
-                async |cx| Self::refresh(this, RefreshReason::DiffChanged, cx).await
-            })
+        let diff_subscription = cx.subscribe_in(&diff, window, {
+            let path_key = path_key.clone();
+            let buffer = buffer.clone();
+            let diff = diff.clone();
+            let conflict_set = conflict_set.clone();
+            move |this, _, event, window, cx| match event {
+                buffer_diff::BufferDiffEvent::DiffChanged(_) => {
+                    this.buffer_ranges_changed(
+                        path_key.clone(),
+                        file_status,
+                        buffer.clone(),
+                        diff.clone(),
+                        conflict_set.clone(),
+                        window,
+                        cx,
+                    );
+                }
+                buffer_diff::BufferDiffEvent::LanguageChanged
+                | buffer_diff::BufferDiffEvent::HunksStagedOrUnstaged(_) => {}
+            }
         });
-        self.buffer_diff_subscriptions
-            .insert(path_key.path.clone(), (diff.clone(), subscription));
-
-        // TODO(split-diff) we shouldn't have a conflict addon when split
-        let conflict_addon = self
-            .editor
-            .read(cx)
-            .rhs_editor()
-            .read(cx)
-            .addon::<ConflictAddon>()
-            .expect("project diff editor should have a conflict addon");
+        let conflict_set_subscription = cx.subscribe_in(&conflict_set, window, {
+            let path_key = path_key.clone();
+            let buffer = buffer.clone();
+            let diff = diff.clone();
+            let conflict_set = conflict_set.clone();
+            move |this, _, _, window, cx| {
+                this.buffer_ranges_changed(
+                    path_key.clone(),
+                    file_status,
+                    buffer.clone(),
+                    diff.clone(),
+                    conflict_set.clone(),
+                    window,
+                    cx,
+                )
+            }
+        });
+        self.buffer_subscriptions.insert(
+            path_key.path.clone(),
+            BufferSubscriptions {
+                _diff: diff.clone(),
+                _diff_subscription: diff_subscription,
+                _conflict_set: conflict_set.clone(),
+                _conflict_set_subscription: conflict_set_subscription,
+            },
+        );
 
         let snapshot = buffer.read(cx).snapshot();
         let diff_snapshot = diff.read(cx).snapshot(cx);
@@ -735,11 +766,9 @@ impl ProjectDiff {
                     &snapshot,
                 )
                 .map(|diff_hunk| diff_hunk.buffer_range.to_point(&snapshot));
-            let conflicts = conflict_addon
-                .conflict_set(snapshot.remote_id())
-                .map(|conflict_set| conflict_set.read(cx).snapshot().conflicts)
-                .unwrap_or_default();
+            let conflicts = conflict_set.read(cx).snapshot();
             let mut conflicts = conflicts
+                .conflicts
                 .iter()
                 .map(|conflict| conflict.range.to_point(&snapshot))
                 .peekable();
@@ -763,6 +792,9 @@ impl ProjectDiff {
                 diff,
                 cx,
             );
+            editor.rhs_editor().update(cx, |editor, cx| {
+                conflict_view::buffer_ranges_updated(editor, conflict_set, cx);
+            });
             (was_empty, is_newly_added)
         });
 
@@ -810,14 +842,33 @@ impl ProjectDiff {
         needs_fold
     }
 
-    #[instrument(skip_all)]
-    pub async fn refresh(
-        this: WeakEntity<Self>,
-        reason: RefreshReason,
-        cx: &mut AsyncWindowContext,
-    ) -> Result<()> {
-        let mut path_keys = Vec::new();
-        let buffers_to_load = this.update(cx, |this, cx| {
+    fn buffer_ranges_changed(
+        &mut self,
+        path_key: PathKey,
+        file_status: FileStatus,
+        buffer: Entity<Buffer>,
+        diff: Entity<BufferDiff>,
+        conflict_set: Entity<ConflictSet>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if buffer.read(cx).is_dirty() {
+            return;
+        }
+        self.register_buffer(
+            path_key,
+            file_status,
+            buffer,
+            diff,
+            conflict_set,
+            window,
+            cx,
+        );
+    }
+
+    #[instrument(skip(this, cx))]
+    pub async fn refresh(this: WeakEntity<Self>, cx: &mut AsyncWindowContext) -> Result<()> {
+        let entries = this.update(cx, |this, cx| {
             let (repo, buffers_to_load) = this.branch_diff.update(cx, |branch_diff, cx| {
                 let load_buffers = branch_diff.load_buffers(cx);
                 (branch_diff.repo().cloned(), load_buffers)
@@ -829,71 +880,59 @@ impl ProjectDiff {
                 .cloned()
                 .collect::<HashSet<_>>();
 
+            let mut entries = BTreeMap::new();
             if let Some(repo) = repo {
                 let repo = repo.read(cx);
 
-                path_keys = Vec::with_capacity(buffers_to_load.len());
-                for entry in buffers_to_load.iter() {
-                    let sort_prefix = sort_prefix(&repo, &entry.repo_path, entry.file_status, cx);
-                    let path_key =
-                        PathKey::with_sort_prefix(sort_prefix, entry.repo_path.as_ref().clone());
+                for diff_buffer in buffers_to_load {
+                    let sort_prefix =
+                        sort_prefix(&repo, &diff_buffer.repo_path, diff_buffer.file_status, cx);
+                    let path_key = PathKey::with_sort_prefix(
+                        sort_prefix,
+                        diff_buffer.repo_path.as_ref().clone(),
+                    );
                     previous_paths.remove(&path_key);
-                    path_keys.push(path_key)
+                    entries.insert(path_key, diff_buffer);
                 }
             }
 
             this.editor.update(cx, |editor, cx| {
                 for path in previous_paths {
+                    this.buffer_subscriptions.remove(&path.path);
                     if let Some(buffer) = this.multibuffer.read(cx).buffer_for_path(&path, cx) {
-                        let skip = match reason {
-                            RefreshReason::DiffChanged | RefreshReason::EditorSaved => {
-                                buffer.read(cx).is_dirty()
-                            }
-                            RefreshReason::StatusesChanged => false,
-                        };
-                        if skip {
-                            continue;
-                        }
+                        let buffer_id = buffer.read(cx).remote_id();
+                        editor.rhs_editor().update(cx, |editor, cx| {
+                            conflict_view::buffers_removed(editor, &[buffer_id], cx);
+                        });
                     }
-
-                    this.buffer_diff_subscriptions.remove(&path.path);
+                    let _span = ztracing::info_span!("remove_excerpts_for_path");
+                    _span.enter();
                     editor.remove_excerpts_for_path(path, cx);
                 }
             });
-            buffers_to_load
+
+            entries
         })?;
 
         let mut buffers_to_fold = Vec::new();
 
-        for (entry, path_key) in buffers_to_load.into_iter().zip(path_keys.into_iter()) {
-            if let Some((buffer, diff)) = entry.load.await.log_err() {
+        for (path_key, entry) in entries {
+            if let Some((buffer, diff, conflict_set)) = entry.load.await.log_err() {
                 // We might be lagging behind enough that all future entry.load futures are no longer pending.
                 // If that is the case, this task will never yield, starving the foreground thread of execution time.
                 yield_now().await;
                 cx.update(|window, cx| {
                     this.update(cx, |this, cx| {
-                        let multibuffer = this.multibuffer.read(cx);
-                        let skip = multibuffer.buffer(buffer.read(cx).remote_id()).is_some()
-                            && multibuffer
-                                .diff_for(buffer.read(cx).remote_id())
-                                .is_some_and(|prev_diff| prev_diff.entity_id() == diff.entity_id())
-                            && match reason {
-                                RefreshReason::DiffChanged | RefreshReason::EditorSaved => {
-                                    buffer.read(cx).is_dirty()
-                                }
-                                RefreshReason::StatusesChanged => false,
-                            };
-                        if !skip {
-                            if let Some(buffer_id) = this.register_buffer(
-                                path_key,
-                                entry.file_status,
-                                buffer,
-                                diff,
-                                window,
-                                cx,
-                            ) {
-                                buffers_to_fold.push(buffer_id);
-                            }
+                        if let Some(buffer_id) = this.register_buffer(
+                            path_key,
+                            entry.file_status,
+                            buffer,
+                            diff,
+                            conflict_set,
+                            window,
+                            cx,
+                        ) {
+                            buffers_to_fold.push(buffer_id);
                         }
                     })
                     .ok();
@@ -2293,10 +2332,7 @@ mod tests {
         );
     }
 
-    use crate::{
-        conflict_view::resolve_conflict,
-        project_diff::{self, ProjectDiff},
-    };
+    use crate::project_diff::{self, ProjectDiff};
 
     #[gpui::test]
     async fn test_go_to_prev_hunk_multibuffer(cx: &mut TestAppContext) {
@@ -2345,14 +2381,13 @@ mod tests {
 
         let mut cx = EditorTestContext::for_editor_in(editor, cx).await;
 
-        cx.assert_excerpts_with_selections(indoc!(
+        cx.set_selections_state(indoc!(
             "
-            [EXCERPT]
             before
             really changed
-            [EXCERPT]
-            [FOLDED]
-            [EXCERPT]
+
+            deleted
+
             ˇcreated
         "
         ));
@@ -2468,85 +2503,6 @@ mod tests {
         cx.dispatch_action(editor::actions::MoveToBeginning);
 
         cx.assert_excerpts_with_selections(&format!("[EXCERPT]\nˇ{git_contents}"));
-    }
-
-    #[gpui::test]
-    async fn test_saving_resolved_conflicts(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            path!("/project"),
-            json!({
-                ".git": {},
-                "foo": "<<<<<<< x\nours\n=======\ntheirs\n>>>>>>> y\n",
-            }),
-        )
-        .await;
-        fs.set_status_for_repo(
-            Path::new(path!("/project/.git")),
-            &[(
-                "foo",
-                UnmergedStatus {
-                    first_head: UnmergedStatusCode::Updated,
-                    second_head: UnmergedStatusCode::Updated,
-                }
-                .into(),
-            )],
-        );
-        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
-        let (multi_workspace, cx) =
-            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
-        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
-        let diff = cx.new_window_entity(|window, cx| {
-            ProjectDiff::new(project.clone(), workspace, window, cx)
-        });
-        cx.run_until_parked();
-
-        cx.update(|window, cx| {
-            let editor = diff.read(cx).editor.read(cx).rhs_editor().clone();
-            let excerpt_ids = editor.read(cx).buffer().read(cx).excerpt_ids();
-            assert_eq!(excerpt_ids.len(), 1);
-            let excerpt_id = excerpt_ids[0];
-            let buffer = editor
-                .read(cx)
-                .buffer()
-                .read(cx)
-                .all_buffers()
-                .into_iter()
-                .next()
-                .unwrap();
-            let buffer_id = buffer.read(cx).remote_id();
-            let conflict_set = diff
-                .read(cx)
-                .editor
-                .read(cx)
-                .rhs_editor()
-                .read(cx)
-                .addon::<ConflictAddon>()
-                .unwrap()
-                .conflict_set(buffer_id)
-                .unwrap();
-            assert!(conflict_set.read(cx).has_conflict);
-            let snapshot = conflict_set.read(cx).snapshot();
-            assert_eq!(snapshot.conflicts.len(), 1);
-
-            let ours_range = snapshot.conflicts[0].ours.clone();
-
-            resolve_conflict(
-                editor.downgrade(),
-                excerpt_id,
-                snapshot.conflicts[0].clone(),
-                vec![ours_range],
-                window,
-                cx,
-            )
-        })
-        .await;
-
-        let contents = fs.read_file_sync(path!("/project/foo")).unwrap();
-        let contents = String::from_utf8(contents).unwrap();
-        assert_eq!(contents, "ours\n");
     }
 
     #[gpui::test(iterations = 50)]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1018,8 +1018,7 @@ impl GitStore {
         &mut self,
         buffer: Entity<Buffer>,
         cx: &mut Context<Self>,
-    ) -> Entity<ConflictSet> {
-        log::debug!("open conflict set");
+    ) -> Task<Entity<ConflictSet>> {
         let buffer_id = buffer.read(cx).remote_id();
 
         if let Some(git_state) = self.diffs.get(&buffer_id)
@@ -1032,11 +1031,14 @@ impl GitStore {
             let conflict_set = conflict_set;
             let buffer_snapshot = buffer.read(cx).text_snapshot();
 
-            git_state.update(cx, |state, cx| {
-                let _ = state.reparse_conflict_markers(buffer_snapshot, cx);
+            let rx = git_state.update(cx, |state, cx| {
+                state.reparse_conflict_markers(buffer_snapshot, cx)
             });
 
-            return conflict_set;
+            return cx.spawn(async move |_, _| {
+                rx.await.ok();
+                conflict_set
+            });
         }
 
         let is_unmerged = self
@@ -1054,13 +1056,16 @@ impl GitStore {
                 cx.emit(GitStoreEvent::ConflictsUpdated);
             }));
 
-        buffer_git_state.update(cx, |state, cx| {
+        let rx = buffer_git_state.update(cx, |state, cx| {
             state.conflict_set = Some(conflict_set.downgrade());
             let buffer_snapshot = buffer.read(cx).text_snapshot();
-            let _ = state.reparse_conflict_markers(buffer_snapshot, cx);
+            state.reparse_conflict_markers(buffer_snapshot, cx)
         });
 
-        conflict_set
+        cx.spawn(async move |_, _| {
+            rx.await.ok();
+            conflict_set
+        })
     }
 
     pub fn project_path_git_status(
@@ -3201,39 +3206,35 @@ impl BufferGitState {
             return rx;
         };
 
-        let old_snapshot = conflict_set.read_with(cx, |conflict_set, _| {
-            if conflict_set.has_conflict {
-                Some(conflict_set.snapshot())
-            } else {
-                None
-            }
-        });
-
-        if let Some(old_snapshot) = old_snapshot {
-            self.conflict_updated_futures.push(tx);
-            self.reparse_conflict_markers_task = Some(cx.spawn(async move |this, cx| {
-                let (snapshot, changed_range) = cx
-                    .background_spawn(async move {
-                        let new_snapshot = ConflictSet::parse(&buffer);
-                        let changed_range = old_snapshot.compare(&new_snapshot, &buffer);
-                        (new_snapshot, changed_range)
-                    })
-                    .await;
-                this.update(cx, |this, cx| {
-                    if let Some(conflict_set) = &this.conflict_set {
-                        conflict_set
-                            .update(cx, |conflict_set, cx| {
-                                conflict_set.set_snapshot(snapshot, changed_range, cx);
-                            })
-                            .ok();
-                    }
-                    let futures = std::mem::take(&mut this.conflict_updated_futures);
-                    for tx in futures {
-                        tx.send(()).ok();
-                    }
-                })
-            }))
+        let has_conflict = conflict_set.read_with(cx, |conflict_set, _| conflict_set.has_conflict);
+        if !has_conflict {
+            return rx;
         }
+
+        let old_snapshot = conflict_set.read_with(cx, |conflict_set, _| conflict_set.snapshot());
+        self.conflict_updated_futures.push(tx);
+        self.reparse_conflict_markers_task = Some(cx.spawn(async move |this, cx| {
+            let (snapshot, changed_range) = cx
+                .background_spawn(async move {
+                    let new_snapshot = ConflictSet::parse(&buffer);
+                    let changed_range = old_snapshot.compare(&new_snapshot, &buffer);
+                    (new_snapshot, changed_range)
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                if let Some(conflict_set) = &this.conflict_set {
+                    conflict_set
+                        .update(cx, |conflict_set, cx| {
+                            conflict_set.set_snapshot(snapshot, changed_range, cx);
+                        })
+                        .ok();
+                }
+                let futures = std::mem::take(&mut this.conflict_updated_futures);
+                for tx in futures {
+                    tx.send(()).ok();
+                }
+            })
+        }));
 
         rx
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7111,6 +7111,10 @@ async fn compute_snapshot(
         events.push(RepositoryEvent::GitWorktreeListChanged);
     }
 
+    if stash_entries != prev_snapshot.stash_entries {
+        events.push(RepositoryEvent::StashEntriesChanged);
+    }
+
     let remote_origin_url = backend.remote_url("origin").await;
     let remote_upstream_url = backend.remote_url("upstream").await;
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -6572,7 +6572,6 @@ impl Repository {
 
                 let has_head = prev_snapshot.head_commit.is_some();
 
-                let stash_entries = backend.stash_entries().await?;
                 let changed_path_statuses = cx
                     .background_spawn(async move {
                         let mut changed_paths =
@@ -6629,11 +6628,6 @@ impl Repository {
                     .await?;
 
                 this.update(&mut cx, |this, cx| {
-                    if this.snapshot.stash_entries != stash_entries {
-                        cx.emit(RepositoryEvent::StashEntriesChanged);
-                        this.snapshot.stash_entries = stash_entries;
-                    }
-
                     if !changed_path_statuses.is_empty() {
                         cx.emit(RepositoryEvent::StatusesChanged);
                         this.snapshot

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -706,6 +706,17 @@ impl GitStore {
             .map(|id| self.repositories[id].clone())
     }
 
+    fn file_is_symlink(file: &File, cx: &App) -> bool {
+        file.worktree
+            .read(cx)
+            .entry_for_path(&file.path)
+            .is_some_and(|entry| entry.canonical_path.is_some())
+    }
+
+    fn buffer_is_symlink(buffer: &Entity<Buffer>, cx: &App) -> bool {
+        File::from_dyn(buffer.read(cx).file()).is_some_and(|file| Self::file_is_symlink(file, cx))
+    }
+
     pub fn open_unstaged_diff(
         &mut self,
         buffer: Entity<Buffer>,
@@ -736,13 +747,18 @@ impl GitStore {
             return Task::ready(Err(anyhow!("failed to find git repository for buffer")));
         };
 
+        let is_symlink = Self::buffer_is_symlink(&buffer, cx);
         let task = self
             .loading_diffs
             .entry((buffer_id, DiffKind::Unstaged))
             .or_insert_with(|| {
-                let staged_text = repo.update(cx, |repo, cx| {
-                    repo.load_staged_text(buffer_id, repo_path, cx)
-                });
+                let staged_text = if is_symlink {
+                    Task::ready(Ok(None))
+                } else {
+                    repo.update(cx, |repo, cx| {
+                        repo.load_staged_text(buffer_id, repo_path, cx)
+                    })
+                };
                 cx.spawn(async move |this, cx| {
                     Self::open_diff_internal(
                         this,
@@ -894,13 +910,18 @@ impl GitStore {
             return Task::ready(Err(anyhow!("failed to find git repository for buffer")));
         };
 
+        let is_symlink = Self::buffer_is_symlink(&buffer, cx);
         let task = self
             .loading_diffs
             .entry((buffer_id, DiffKind::Uncommitted))
             .or_insert_with(|| {
-                let changes = repo.update(cx, |repo, cx| {
-                    repo.load_committed_text(buffer_id, repo_path, cx)
-                });
+                let changes = if is_symlink {
+                    Task::ready(Ok(DiffBasesChange::SetBoth(None)))
+                } else {
+                    repo.update(cx, |repo, cx| {
+                        repo.load_committed_text(buffer_id, repo_path, cx)
+                    })
+                };
 
                 // todo(lw): hot foreground spawn
                 cx.spawn(async move |this, cx| {
@@ -1680,14 +1701,18 @@ impl GitStore {
                 {
                     let buffer = buffer.clone();
                     let diff_state = diff_state.clone();
+                    let is_symlink = Self::buffer_is_symlink(&buffer, cx);
 
                     cx.spawn(async move |_git_store, cx| {
                         async {
-                            let diff_bases_change = repo
-                                .update(cx, |repo, cx| {
+                            let diff_bases_change = if is_symlink {
+                                DiffBasesChange::SetBoth(None)
+                            } else {
+                                repo.update(cx, |repo, cx| {
                                     repo.load_committed_text(buffer_id, repo_path, cx)
                                 })
-                                .await?;
+                                .await?
+                            };
 
                             diff_state.update(cx, |diff_state, cx| {
                                 let buffer_snapshot = buffer.read(cx).text_snapshot();
@@ -4042,6 +4067,7 @@ impl Repository {
                                 let file = File::from_dyn(buffer.read(cx).file())?;
                                 let abs_path = file.worktree.read(cx).absolutize(&file.path);
                                 let repo_path = this.abs_path_to_repo_path(&abs_path)?;
+                                let is_symlink = GitStore::file_is_symlink(file, cx);
                                 log::debug!(
                                     "start reload diff bases for repo path {}",
                                     repo_path.as_unix_str()
@@ -4059,6 +4085,7 @@ impl Repository {
                                     Some((
                                         buffer,
                                         repo_path,
+                                        is_symlink,
                                         has_unstaged_diff.then(|| diff_state.index_text.clone()),
                                         has_uncommitted_diff.then(|| diff_state.head_text.clone()),
                                     ))
@@ -4071,15 +4098,20 @@ impl Repository {
                 let buffer_diff_base_changes = cx
                     .background_spawn(async move {
                         let mut changes = Vec::new();
-                        for (buffer, repo_path, current_index_text, current_head_text) in
-                            &repo_diff_state_updates
+                        for (
+                            buffer,
+                            repo_path,
+                            is_symlink,
+                            current_index_text,
+                            current_head_text,
+                        ) in &repo_diff_state_updates
                         {
-                            let index_text = if current_index_text.is_some() {
+                            let index_text = if current_index_text.is_some() && !*is_symlink {
                                 backend.load_index_text(repo_path.clone()).await
                             } else {
                                 None
                             };
-                            let head_text = if current_head_text.is_some() {
+                            let head_text = if current_head_text.is_some() && !*is_symlink {
                                 backend.load_committed_text(repo_path.clone()).await
                             } else {
                                 None

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3057,6 +3057,23 @@ impl GitStore {
             .collect()
     }
 
+    fn coalesce_repo_paths(mut paths: Vec<RepoPath>) -> Vec<RepoPath> {
+        paths.sort();
+
+        let mut coalesced = Vec::with_capacity(paths.len());
+        for path in paths {
+            if coalesced
+                .last()
+                .is_some_and(|ancestor: &RepoPath| path.starts_with(ancestor))
+            {
+                continue;
+            }
+            coalesced.push(path);
+        }
+
+        coalesced
+    }
+
     fn process_updated_entries(
         &self,
         worktree: &Entity<Worktree>,
@@ -7261,5 +7278,42 @@ mod tests {
                 Some(CommitDataState::Loading)
             ));
         });
+    }
+
+    fn repo_paths(paths: &[&str]) -> Vec<RepoPath> {
+        paths.iter().map(git::repository::repo_path).collect()
+    }
+
+    #[test]
+    fn coalesce_repo_paths_keeps_root_only() {
+        let coalesced = GitStore::coalesce_repo_paths(repo_paths(&["", "src", "src/lib.rs"]));
+
+        assert_eq!(coalesced, repo_paths(&[""]));
+    }
+
+    #[test]
+    fn coalesce_repo_paths_keeps_existing_ancestors() {
+        let coalesced = GitStore::coalesce_repo_paths(repo_paths(&[
+            "src",
+            "src/lib.rs",
+            "src/nested/file.rs",
+            "tests/test.rs",
+        ]));
+
+        assert_eq!(coalesced, repo_paths(&["src", "tests/test.rs"]));
+    }
+
+    #[test]
+    fn coalesce_repo_paths_does_not_invent_missing_parents() {
+        let coalesced = GitStore::coalesce_repo_paths(repo_paths(&[
+            "submodule/a.txt",
+            "submodule/nested/b.txt",
+            "top_level.rs",
+        ]));
+
+        assert_eq!(
+            coalesced,
+            repo_paths(&["submodule/a.txt", "submodule/nested/b.txt", "top_level.rs"])
+        );
     }
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -6574,8 +6574,14 @@ impl Repository {
 
                 let changed_path_statuses = cx
                     .background_spawn(async move {
-                        let mut changed_paths =
-                            changed_paths.into_iter().flatten().collect::<BTreeSet<_>>();
+                        let changed_paths = GitStore::coalesce_repo_paths(
+                            changed_paths
+                                .into_iter()
+                                .flatten()
+                                .collect::<BTreeSet<_>>()
+                                .into_iter()
+                                .collect(),
+                        );
                         let changed_paths_vec = changed_paths.iter().cloned().collect::<Vec<_>>();
 
                         let status_task = backend.status(&changed_paths_vec);
@@ -6596,12 +6602,34 @@ impl Repository {
 
                         let mut changed_path_statuses = Vec::new();
                         let prev_statuses = prev_snapshot.statuses_by_path.clone();
+                        let current_status_paths = statuses
+                            .entries
+                            .iter()
+                            .map(|(repo_path, _)| repo_path.clone())
+                            .collect::<BTreeSet<_>>();
+
+                        for path in &changed_paths {
+                            let mut cursor = prev_statuses.cursor::<PathProgress>(());
+                            cursor.seek_forward(&PathTarget::Path(path), Bias::Left);
+                            while let Some(entry) = cursor.item() {
+                                if !entry.repo_path.starts_with(path) {
+                                    break;
+                                }
+
+                                if !current_status_paths.contains(&entry.repo_path) {
+                                    changed_path_statuses.push(Edit::Remove(PathKey(
+                                        entry.repo_path.as_ref().clone(),
+                                    )));
+                                }
+                                cursor.next();
+                            }
+                        }
+
                         let mut cursor = prev_statuses.cursor::<PathProgress>(());
 
                         for (repo_path, status) in &*statuses.entries {
                             let current_diff_stat = diff_stats.get(repo_path).copied();
 
-                            changed_paths.remove(repo_path);
                             if cursor.seek_forward(&PathTarget::Path(repo_path), Bias::Left)
                                 && cursor.item().is_some_and(|entry| {
                                     entry.status == *status && entry.diff_stat == current_diff_stat
@@ -6615,13 +6643,6 @@ impl Repository {
                                 status: *status,
                                 diff_stat: current_diff_stat,
                             }));
-                        }
-                        let mut cursor = prev_statuses.cursor::<PathProgress>(());
-                        for path in changed_paths.into_iter() {
-                            if cursor.seek_forward(&PathTarget::Path(&path), Bias::Left) {
-                                changed_path_statuses
-                                    .push(Edit::Remove(PathKey(path.as_ref().clone())));
-                            }
                         }
                         anyhow::Ok(changed_path_statuses)
                     })

--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -17,7 +17,7 @@ use util::ResultExt;
 use ztracing::instrument;
 
 use crate::{
-    Project,
+    ConflictSet, Project,
     git_store::{GitStoreEvent, Repository, RepositoryEvent},
 };
 
@@ -76,7 +76,6 @@ impl BranchDiff {
                         .repo
                         .as_ref()
                         .is_some_and(|r| r.read(cx).snapshot().id == *event_repo_id),
-                    GitStoreEvent::ConflictsUpdated => this.repo.is_some(),
                     _ => false,
                 };
 
@@ -351,7 +350,7 @@ impl BranchDiff {
         project_path: crate::ProjectPath,
         repo: Entity<Repository>,
         cx: &Context<'_, Project>,
-    ) -> Task<Result<(Entity<Buffer>, Entity<BufferDiff>)>> {
+    ) -> Task<Result<(Entity<Buffer>, Entity<BufferDiff>, Entity<ConflictSet>)>> {
         let task = cx.spawn(async move |project, cx| {
             let buffer = project
                 .update(cx, |project, cx| project.open_buffer(project_path, cx))?
@@ -377,7 +376,14 @@ impl BranchDiff {
                     })?
                     .await?
             };
-            Ok((buffer, changes))
+            let conflict_set = project
+                .update(cx, |project, cx| {
+                    project.git_store().update(cx, |git_store, cx| {
+                        git_store.open_conflict_set(buffer.clone(), cx)
+                    })
+                })?
+                .await;
+            Ok((buffer, changes, conflict_set))
         });
         task
     }
@@ -405,5 +411,5 @@ fn diff_status_to_file_status(branch_diff: &git::status::TreeDiffStatus) -> File
 pub struct DiffBuffer {
     pub repo_path: RepoPath,
     pub file_status: FileStatus,
-    pub load: Task<Result<(Entity<Buffer>, Entity<BufferDiff>)>>,
+    pub load: Task<Result<(Entity<Buffer>, Entity<BufferDiff>, Entity<ConflictSet>)>>,
 }

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -299,9 +299,11 @@ mod conflict_set_tests {
             )
         });
         let buffer = buffer.await.unwrap();
-        let conflict_set = git_store.update(cx, |git_store, cx| {
-            git_store.open_conflict_set(buffer.clone(), cx)
-        });
+        let conflict_set = git_store
+            .update(cx, |git_store, cx| {
+                git_store.open_conflict_set(buffer.clone(), cx)
+            })
+            .await;
         let (events_tx, events_rx) = mpsc::channel::<ConflictSetUpdate>();
         let _conflict_set_subscription = cx.update(|cx| {
             cx.subscribe(&conflict_set, move |_, event, _| {
@@ -417,9 +419,11 @@ mod conflict_set_tests {
         let buffer = buffer.await.unwrap();
 
         // Open the conflict set for a file that currently has conflicts.
-        let conflict_set = git_store.update(cx, |git_store, cx| {
-            git_store.open_conflict_set(buffer.clone(), cx)
-        });
+        let conflict_set = git_store
+            .update(cx, |git_store, cx| {
+                git_store.open_conflict_set(buffer.clone(), cx)
+            })
+            .await;
 
         cx.run_until_parked();
         conflict_set.update(cx, |conflict_set, cx| {
@@ -518,9 +522,11 @@ mod conflict_set_tests {
             )
         });
         let buffer = buffer.await.unwrap();
-        let conflict_set = git_store.update(cx, |git_store, cx| {
-            git_store.open_conflict_set(buffer.clone(), cx)
-        });
+        let conflict_set = git_store
+            .update(cx, |git_store, cx| {
+                git_store.open_conflict_set(buffer.clone(), cx)
+            })
+            .await;
 
         let (events_tx, events_rx) = mpsc::channel::<ConflictSetUpdate>();
         let _conflict_set_subscription = cx.update(|cx| {

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1582,3 +1582,87 @@ mod trust_tests {
         });
     }
 }
+
+mod stash_tests {
+    use std::{str::FromStr as _, sync::mpsc};
+
+    use fs::FakeFs;
+    use git::stash::{GitStash, StashEntry};
+    use gpui::TestAppContext;
+    use project::git_store::RepositoryEvent;
+    use serde_json::json;
+    use settings::SettingsStore;
+    use util::path;
+
+    use crate::Project;
+
+    fn init_test(cx: &mut TestAppContext) {
+        zlog::init_test();
+
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_stash_list_refreshes_on_git_event(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": "hello",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        cx.executor().run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project.repositories(cx).values().next().unwrap().clone()
+        });
+        repository.read_with(cx, |repo, _| {
+            assert!(repo.cached_stash().entries.is_empty());
+        });
+
+        let (events_tx, events_rx) = mpsc::channel::<RepositoryEvent>();
+        let _subscription = cx.update(|cx| {
+            cx.subscribe(&repository, move |_, event: &RepositoryEvent, _| {
+                events_tx.send(event.clone()).ok();
+            })
+        });
+
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.stash_entries = GitStash {
+                entries: vec![StashEntry {
+                    index: 0,
+                    oid: git::Oid::from_str("1234567890abcdef1234567890abcdef12345678")
+                        .expect("valid oid"),
+                    message: "WIP on main".to_string(),
+                    branch: Some("main".to_string()),
+                    timestamp: 0,
+                }]
+                .into(),
+            };
+        })
+        .expect("update fake git state");
+        cx.executor().run_until_parked();
+
+        repository.read_with(cx, |repo, _| {
+            assert_eq!(
+                repo.cached_stash().entries.len(),
+                1,
+                "stash list should be refreshed after a .git event"
+            );
+        });
+        assert!(
+            events_rx
+                .try_iter()
+                .any(|event| event == RepositoryEvent::StashEntriesChanged),
+            "a stash list change should emit StashEntriesChanged"
+        );
+    }
+}

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1071,6 +1071,84 @@ mod git_traversal {
         );
     }
 
+    #[gpui::test]
+    async fn test_open_uncommitted_diff_skips_symlinks(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "target.txt": "rule one\nrule two\n",
+            }),
+        )
+        .await;
+        fs.insert_symlink(
+            path!("/project/agents.md"),
+            std::path::PathBuf::from("target.txt"),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                // git stores the symlink's target path as the blob for `agents.md`
+                ("agents.md", "target.txt".into()),
+                ("target.txt", "rule one\n".into()),
+            ],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+
+        // symlink file should not produce a base diff
+        let symlink_buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path("agents.md")), cx)
+            })
+            .await
+            .unwrap();
+        let symlink_diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(symlink_buffer, cx)
+            })
+            .await
+            .unwrap();
+        symlink_diff.read_with(cx, |diff, _| {
+            assert!(
+                !diff.base_text_exists(),
+                "symlinked buffer should not have a git diff base"
+            );
+        });
+
+        // regular file should still produce a base diff
+        let regular_buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path("target.txt")), cx)
+            })
+            .await
+            .unwrap();
+        let regular_diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(regular_buffer, cx)
+            })
+            .await
+            .unwrap();
+        regular_diff.read_with(cx, |diff, _| {
+            assert!(
+                diff.base_text_exists(),
+                "regular file should have a git diff base"
+            );
+        });
+    }
+
     fn init_test(cx: &mut gpui::TestAppContext) {
         zlog::init_test();
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -9671,6 +9671,96 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_git_repository_status_removes_directory_descendants(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "project": {
+                ".git": {},
+                "ci2": {
+                    "Dockerfile.namespace": "untracked",
+                },
+            },
+        }),
+    )
+    .await;
+    fs.set_status_for_repo(
+        path!("/root/project/.git").as_ref(),
+        &[("ci2/Dockerfile.namespace", FileStatus::Untracked)],
+    );
+
+    let project = Project::test(fs.clone(), [path!("/root/project").as_ref()], cx).await;
+
+    let tree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    tree.flush_fs_events(cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.executor().run_until_parked();
+
+    let repository = project.read_with(cx, |project, cx| {
+        project.repositories(cx).values().next().unwrap().clone()
+    });
+
+    repository.read_with(cx, |repository, _| {
+        assert_eq!(
+            repository.cached_status().collect::<Vec<_>>(),
+            [StatusEntry {
+                repo_path: repo_path("ci2/Dockerfile.namespace"),
+                status: FileStatus::Untracked,
+                diff_stat: None,
+            }]
+        );
+    });
+
+    fs.pause_events();
+    fs.create_dir(path!("/root/project/ci3").as_ref())
+        .await
+        .unwrap();
+    fs.copy_file(
+        path!("/root/project/ci2/Dockerfile.namespace").as_ref(),
+        path!("/root/project/ci3/Dockerfile.namespace").as_ref(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.remove_dir(
+        path!("/root/project/ci2").as_ref(),
+        RemoveOptions {
+            recursive: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    fs.clear_buffered_events();
+    fs.unpause_events_and_flush();
+    fs.emit_fs_event(path!("/root/project/ci2"), Some(PathEventKind::Removed));
+    fs.emit_fs_event(path!("/root/project/ci3"), Some(PathEventKind::Created));
+
+    tree.flush_fs_events(cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.executor().run_until_parked();
+
+    repository.read_with(cx, |repository, _| {
+        assert_eq!(
+            repository.cached_status().collect::<Vec<_>>(),
+            [StatusEntry {
+                repo_path: repo_path("ci3/Dockerfile.namespace"),
+                status: FileStatus::Untracked,
+                diff_stat: None,
+            }]
+        );
+    });
+}
+
+#[gpui::test]
 #[ignore]
 async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
     init_test(cx);

--- a/crates/superzent_agent/Cargo.toml
+++ b/crates/superzent_agent/Cargo.toml
@@ -22,6 +22,5 @@ serde_urlencoded.workspace = true
 smol.workspace = true
 superzent_model.workspace = true
 task.workspace = true
-tiny_http.workspace = true
 url.workspace = true
 uuid.workspace = true

--- a/crates/superzent_agent/src/runtime.rs
+++ b/crates/superzent_agent/src/runtime.rs
@@ -3,13 +3,15 @@ use collections::HashMap;
 use serde::Deserialize;
 use std::{
     fs,
+    io::{BufRead, BufReader, Read, Write},
+    net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, OnceLock},
     thread,
+    time::Duration,
 };
 use superzent_model::{AgentPreset, AgentSession, PresetLaunchMode, WorkspaceEntry};
 use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, SpawnInTerminal, TaskId};
-use tiny_http::{Response, Server};
 use url::Url;
 use uuid::Uuid;
 
@@ -195,16 +197,15 @@ impl AgentHookRuntime {
     fn new() -> Result<Self> {
         let bin_dir = ensure_agent_hook_wrapper_files()?;
 
-        let server = Server::http("127.0.0.1:0")
-            .map_err(|error| anyhow!(error).context("bind hook port"))?;
+        let listener = TcpListener::bind("127.0.0.1:0").context("bind hook port")?;
         let hook_url = format!(
             "http://127.0.0.1:{}{}",
-            server.server_addr().port(),
+            listener.local_addr().context("read hook port")?.port(),
             HOOK_ENDPOINT_PATH
         );
 
         let subscribers = Arc::new(Mutex::new(Vec::new()));
-        spawn_hook_server(server, subscribers.clone());
+        spawn_hook_server(listener, subscribers.clone());
 
         Ok(Self {
             paths: AgentHookPaths { bin_dir, hook_url },
@@ -235,54 +236,113 @@ fn ensure_agent_hook_wrapper_files() -> Result<PathBuf> {
     Ok(bin_dir)
 }
 
+// This server intentionally avoids an HTTP library: hook notifications arrive from
+// short-lived `curl --max-time` invocations that routinely disconnect mid-request when
+// the app is busy, and tiny_http panicked (aborting the whole app) on such connections.
 fn spawn_hook_server(
-    server: Server,
+    listener: TcpListener,
     subscribers: Arc<Mutex<Vec<smol::channel::Sender<AgentHookEvent>>>>,
 ) {
     thread::Builder::new()
         .name("superzent-agent-hooks".to_string())
         .spawn(move || {
             loop {
-                let Ok(request) = server.recv() else {
-                    break;
-                };
-
-                let response = match parse_request(request.url()) {
-                    Ok(Some(event)) => {
-                        if debug_hooks_enabled() {
-                            log::info!(
-                                "superzent hook server accepted event: type={:?} terminal_id={} workspace_id={:?} session_id={:?} cwd={:?}",
-                                event.event_type,
-                                event.terminal_id,
-                                event.workspace_id,
-                                event.session_id,
-                                event.cwd,
-                            );
-                        }
-                        if let Ok(mut subscribers) = subscribers.lock() {
-                            subscribers
-                                .retain(|sender| sender.send_blocking(event.clone()).is_ok());
-                        }
-                        Response::empty(204)
-                    }
-                    Ok(None) => {
-                        if debug_hooks_enabled() {
-                            log::info!("superzent hook server ignored request: url={}", request.url());
-                        }
-                        Response::empty(204)
-                    }
+                let stream = match listener.accept() {
+                    Ok((stream, _)) => stream,
                     Err(error) => {
-                        log::warn!("failed to parse agent hook request: {error:#}");
-                        Response::empty(400)
+                        log::debug!("agent hook server failed to accept connection: {error}");
+                        thread::sleep(Duration::from_millis(100));
+                        continue;
                     }
                 };
-
-                if let Err(error) = request.respond(response) {
-                    log::debug!("failed to respond to agent hook request: {error}");
-                }
+                let subscribers = subscribers.clone();
+                thread::Builder::new()
+                    .name("superzent-agent-hook-conn".to_string())
+                    .spawn(move || {
+                        if let Err(error) = handle_hook_connection(&stream, &subscribers) {
+                            log::debug!("failed to handle agent hook connection: {error:#}");
+                        }
+                    })
+                    .ok();
             }
         })
         .ok();
+}
+
+fn handle_hook_connection(
+    stream: &TcpStream,
+    subscribers: &Mutex<Vec<smol::channel::Sender<AgentHookEvent>>>,
+) -> Result<()> {
+    const MAX_REQUEST_HEAD_BYTES: u64 = 16 * 1024;
+
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .context("set hook connection read timeout")?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .context("set hook connection write timeout")?;
+
+    let mut reader = BufReader::new(stream.take(MAX_REQUEST_HEAD_BYTES));
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .context("read hook request line")?;
+    let url = request_line
+        .split_whitespace()
+        .nth(1)
+        .context("malformed hook request line")?
+        .to_string();
+
+    // Drain the remaining headers so curl finishes sending before we respond and close.
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) if line == "\r\n" || line == "\n" => break,
+            Ok(_) => {}
+            Err(error) => {
+                log::debug!("failed to read agent hook request headers: {error}");
+                break;
+            }
+        }
+    }
+
+    let status_line = match parse_request(&url) {
+        Ok(Some(event)) => {
+            if debug_hooks_enabled() {
+                log::info!(
+                    "superzent hook server accepted event: type={:?} terminal_id={} workspace_id={:?} session_id={:?} cwd={:?}",
+                    event.event_type,
+                    event.terminal_id,
+                    event.workspace_id,
+                    event.session_id,
+                    event.cwd,
+                );
+            }
+            if let Ok(mut subscribers) = subscribers.lock() {
+                subscribers.retain(|sender| sender.send_blocking(event.clone()).is_ok());
+            }
+            "204 No Content"
+        }
+        Ok(None) => {
+            if debug_hooks_enabled() {
+                log::info!("superzent hook server ignored request: url={url}");
+            }
+            "204 No Content"
+        }
+        Err(error) => {
+            log::warn!("failed to parse agent hook request: {error:#}");
+            "400 Bad Request"
+        }
+    };
+
+    let mut stream = stream;
+    stream
+        .write_all(format!("HTTP/1.1 {status_line}\r\nConnection: close\r\n\r\n").as_bytes())
+        .context("respond to hook request")?;
+    stream.flush().context("flush hook response")?;
+    Ok(())
 }
 
 fn parse_request(url: &str) -> Result<Option<AgentHookEvent>> {
@@ -863,5 +923,87 @@ mod tests {
             error.to_string(),
             "ACP presets cannot be launched in a terminal"
         );
+    }
+
+    fn spawn_test_hook_server() -> (
+        std::net::SocketAddr,
+        smol::channel::Receiver<AgentHookEvent>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("read test listener addr");
+        let (sender, receiver) = smol::channel::unbounded();
+        let subscribers = Arc::new(Mutex::new(vec![sender]));
+        spawn_hook_server(listener, subscribers);
+        (addr, receiver)
+    }
+
+    fn read_response(stream: &mut TcpStream) -> String {
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .expect("read hook response");
+        response
+    }
+
+    #[test]
+    fn hook_server_dispatches_events_and_survives_aborted_connections() {
+        let (addr, receiver) = spawn_test_hook_server();
+
+        // A client that connects and disconnects mid-request (like `curl --max-time`
+        // under load) must not take the server down.
+        let mut aborted = TcpStream::connect(addr).expect("connect aborted client");
+        aborted
+            .write_all(b"GET /agent-hook?event_type=Stop")
+            .expect("write partial request");
+        drop(aborted);
+
+        // Garbage that isn't HTTP at all must not take the server down either.
+        let mut garbage = TcpStream::connect(addr).expect("connect garbage client");
+        garbage.write_all(b"\r\n\r\n").expect("write garbage");
+        drop(garbage);
+
+        let mut stream = TcpStream::connect(addr).expect("connect valid client");
+        stream
+            .write_all(
+                format!(
+                    "GET /agent-hook?event_type=Stop&terminal_id=terminal-1&version={AGENT_HOOK_VERSION} HTTP/1.1\r\n\
+                     Host: 127.0.0.1\r\n\
+                     \r\n"
+                )
+                .as_bytes(),
+            )
+            .expect("write valid request");
+
+        let response = read_response(&mut stream);
+        assert!(
+            response.starts_with("HTTP/1.1 204 No Content"),
+            "unexpected response: {response}"
+        );
+
+        let event = receiver.recv_blocking().expect("receive hook event");
+        assert_eq!(event.event_type, AgentHookEventType::Stop);
+        assert_eq!(event.terminal_id, "terminal-1");
+    }
+
+    #[test]
+    fn hook_server_rejects_unparseable_requests() {
+        let (addr, receiver) = spawn_test_hook_server();
+
+        let mut stream = TcpStream::connect(addr).expect("connect client");
+        stream
+            .write_all(
+                format!(
+                    "GET /agent-hook?event_type=Stop&version={AGENT_HOOK_VERSION} HTTP/1.1\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .expect("write request");
+
+        let response = read_response(&mut stream);
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request"),
+            "unexpected response: {response}"
+        );
+        assert!(receiver.is_empty());
     }
 }

--- a/crates/superzent_agent/src/runtime.rs
+++ b/crates/superzent_agent/src/runtime.rs
@@ -986,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn hook_server_rejects_unparseable_requests() {
+    fn hook_server_rejects_unparsable_requests() {
         let (addr, receiver) = spawn_test_hook_server();
 
         let mut stream = TcpStream::connect(addr).expect("connect client");

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -387,7 +387,9 @@ mod test {
             the lazy Oneˇ."},
             Mode::Replace,
         );
-        cx.simulate_keystrokes("enter T w o");
+        cx.simulate_keystrokes("enter");
+        cx.run_until_parked();
+        cx.simulate_keystrokes("T w o");
         cx.assert_state(
             indoc! {"
             One

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -19,8 +19,9 @@ use futures::{
 };
 use fuzzy::CharBag;
 use git::{
-    COMMIT_MESSAGE, DOT_GIT, FSMONITOR_DAEMON, GITIGNORE, INDEX_LOCK, LFS_DIR, REPO_EXCLUDE,
-    status::GitSummary,
+    BISECT_LOG, COMMIT_MESSAGE, DOT_GIT, FETCH_HEAD, FSMONITOR_DAEMON, GC_PID, GITIGNORE,
+    HOOKS_DIR, INFO_DIR, LFS_DIR, LOGS_DIR, LOGS_REF_STASH, OBJECTS_DIR, ORIG_HEAD,
+    REBASE_APPLY_DIR, REBASE_MERGE_DIR, REPO_EXCLUDE, SEQUENCER_DIR, status::GitSummary,
 };
 use gpui::{
     App, AppContext as _, AsyncApp, BackgroundExecutor, Context, Entity, EventEmitter, Priority,
@@ -4056,8 +4057,17 @@ impl BackgroundScanner {
 
         // Certain directories may have FS changes, but do not lead to git data changes that Zed cares about.
         // Ignore these, to avoid Zed unnecessarily rescanning git metadata.
-        let skipped_files_in_dot_git = [COMMIT_MESSAGE, INDEX_LOCK];
-        let skipped_dirs_in_dot_git = [FSMONITOR_DAEMON, LFS_DIR];
+        let skipped_file_names_in_dot_git =
+            [COMMIT_MESSAGE, FETCH_HEAD, ORIG_HEAD, BISECT_LOG, GC_PID];
+        let skipped_dirs_in_dot_git = [
+            FSMONITOR_DAEMON,
+            LFS_DIR,
+            OBJECTS_DIR,
+            HOOKS_DIR,
+            REBASE_MERGE_DIR,
+            REBASE_APPLY_DIR,
+            SEQUENCER_DIR,
+        ];
 
         let mut relative_paths = Vec::with_capacity(events.len());
         let mut dot_git_abs_paths = Vec::new();
@@ -4111,12 +4121,21 @@ impl BackgroundScanner {
                 }
 
                 if let Some((dot_git_abs_path, path_in_git_dir)) = dot_git_paths {
-                    if skipped_files_in_dot_git
+                    if skipped_file_names_in_dot_git
                         .iter()
                         .any(|skipped| OsStr::new(skipped) == path_in_git_dir.as_path().as_os_str())
+                        || (path_in_git_dir.starts_with(LOGS_DIR)
+                            && path_in_git_dir != Path::new(LOGS_REF_STASH))
+                        || (path_in_git_dir.starts_with(INFO_DIR)
+                            && path_in_git_dir != Path::new(REPO_EXCLUDE))
                         || skipped_dirs_in_dot_git.iter().any(|skipped_git_subdir| {
                             path_in_git_dir.starts_with(skipped_git_subdir)
                         })
+                        || path_in_git_dir.extension().is_some_and(|ext| ext == "lock")
+                        || (path_in_git_dir.components().count() == 1
+                            && path_in_git_dir
+                                .extension()
+                                .is_some_and(|ext| ext == "new" || ext == "tmp"))
                     {
                         log::debug!(
                             "ignoring event {abs_path:?} as it's in the .git directory among skipped files or directories"

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -2734,6 +2734,109 @@ fn check_worktree_entries(
     }
 }
 
+#[gpui::test]
+async fn test_noisy_dot_git_events_do_not_emit_git_repo_update(cx: &mut TestAppContext) {
+    // Events for object database writes, hook files, lock files, and the
+    // reflogs of HEAD/branches/remote-tracking branches carry no git state
+    // changes that Zed cares about beyond what the accompanying ref or index
+    // events already convey, so they must not trigger a git metadata rescan.
+    // The stash reflog and ref updates themselves must still trigger one.
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+
+    fs.insert_tree(
+        path!("/repo"),
+        json!({
+            ".git": {},
+            "file.txt": "content",
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        path!("/repo").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    tree.update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    let repo_update_count: std::rc::Rc<std::cell::Cell<usize>> =
+        std::rc::Rc::new(std::cell::Cell::new(0));
+    tree.update(cx, {
+        let repo_update_count = repo_update_count.clone();
+        |_, cx| {
+            cx.subscribe(&cx.entity(), move |_, _, event, _| {
+                if matches!(event, Event::UpdatedGitRepositories(_)) {
+                    repo_update_count.set(repo_update_count.get() + 1);
+                }
+            })
+            .detach();
+        }
+    });
+
+    let skipped_paths = [
+        path!("/repo/.git/objects/aa/bbccddee"),
+        path!("/repo/.git/objects/pack/pack-1234.pack"),
+        path!("/repo/.git/hooks/pre-commit"),
+        path!("/repo/.git/logs/HEAD"),
+        path!("/repo/.git/logs/refs/heads/main"),
+        path!("/repo/.git/logs/refs/remotes/origin/main"),
+        path!("/repo/.git/logs/refs/tags/v1.0"),
+        path!("/repo/.git/rebase-merge/done"),
+        path!("/repo/.git/rebase-apply/onto"),
+        path!("/repo/.git/sequencer/todo"),
+        path!("/repo/.git/index.lock"),
+        path!("/repo/.git/refs/heads/main.lock"),
+        path!("/repo/.git/COMMIT_EDITMSG"),
+        path!("/repo/.git/packed-refs.new"),
+        path!("/repo/.git/config.new"),
+        path!("/repo/.git/index.new"),
+        path!("/repo/.git/index-abc123.tmp"),
+        path!("/repo/.git/FETCH_HEAD"),
+        path!("/repo/.git/ORIG_HEAD"),
+        path!("/repo/.git/BISECT_LOG"),
+        path!("/repo/.git/info/refs"),
+        path!("/repo/.git/info/refs_lzOf51"),
+        path!("/repo/.git/gc.pid"),
+    ];
+    for path in skipped_paths {
+        fs.emit_fs_event(path, Some(fs::PathEventKind::Changed));
+        cx.run_until_parked();
+        assert_eq!(
+            repo_update_count.get(),
+            0,
+            "event for {path} should not emit UpdatedGitRepositories"
+        );
+    }
+
+    let rescan_paths = [
+        path!("/repo/.git/logs/refs/stash"),
+        path!("/repo/.git/refs/heads/main"),
+        path!("/repo/.git/info/exclude"),
+        path!("/repo/.git/refs/heads/branch.new"),
+        path!("/repo/.git/refs/heads/branch.tmp"),
+        path!("/repo/.git/index"),
+    ];
+    for path in rescan_paths {
+        let count_before = repo_update_count.get();
+        fs.emit_fs_event(path, Some(fs::PathEventKind::Changed));
+        cx.run_until_parked();
+        assert!(
+            repo_update_count.get() > count_before,
+            "event for {path} should emit UpdatedGitRepositories"
+        );
+    }
+}
+
 fn init_test(cx: &mut gpui::TestAppContext) {
     zlog::init_test();
 


### PR DESCRIPTION
## Summary

Bundles the git quick-win ports from zed upstream, plus an app crash fix discovered while working on the port.

### Upstream Git ports

- `git_panel`: Fix stale Git status entries for moved directories (zed#59934)
- `git`: Detect SCP remotes with non-standard SSH usernames (zed#59457)
- Git status list fix (zed#59155)
- `git`: Do not run `git stash list` on every file save (zed#59042)
- `git_ui`: Update section header checkboxes immediately on stage/unstage all (zed#57148)
- `git_store`: Coalesce refresh pathspecs (zed#56406) — call site adapted to our `paths_changed` batching; upstream unit tests ported as well
- Fix some overcomputation in the project diff (zed#57859) — the `project_diff.rs`/`conflict_view.rs` half applies to this fork; the multibuffer half targets code we rewrote and was dropped. Removal loop adapted to our `paths()` API, and the fork-only `test_saving_resolved_conflicts` was deleted along with the save-on-resolve behavior, matching upstream
- `project`: Fix spurious git diff for symlinked files (zed#58655) — guards ported at all three base-text load sites; upstream test added to our integration suite
- `git`: Avoid unnecessary git repo rescans when unrelated git files change (zed#59318) — skip lists and predicate ported into our post-dedup event loop (upstream restructured theirs pre-dedup); test adapted to a normal repo because this fork lacks the linked-worktree FakeFs infrastructure

Screened but intentionally NOT ported (bug does not exist in this fork): zed#58853, zed#59521, zed#58359, zed#60717; zed#54823 applies only to remote/collab projects. The screening checklist is now documented in `.rules` ("Porting from zed upstream", committed on main).

### Agent hook server crash fix

The agent hook server used tiny_http 0.8, which panics in its worker threads when a client disconnects mid-request. `notify.sh` sends hook events with `curl --max-time 2`, so whenever the app was too busy to respond in time (e.g. during builds), curl aborted the connection, tiny_http panicked, and the panic hook aborted the entire app with SIGABRT (confirmed by two identical macOS crash reports pointing at `tiny_http::client::ClientConnection::next`).

tiny_http 0.12 still contains the same panicking unwrap paths, so the hook server now handles connections directly with `std::net::TcpListener`: per-connection threads, 5s read/write timeouts, a 16KB request-head cap, and no panicking paths. Regression tests cover connections dropped mid-request and non-HTTP garbage.

tiny_http is upgraded 0.8 → 0.12 for its remaining use in the sign-in callback server, matching zed upstream's pinned version.

## Test plan

- [x] `cargo test -p project git_store::tests` — coalesce tests pass
- [x] `cargo test -p superzent_agent` — 8 passed, including new hook server regression tests
- [x] `cargo test -p git_ui project_diff` / `conflict` — 10 passed after the #57859 port
- [x] `cargo test -p project --test integration` — git_store/diff/conflict/symlink modules pass, including the new `test_open_uncommitted_diff_skips_symlinks`
- [x] `cargo test -p worktree --test integration` — 31/34 pass quickly including the new `test_noisy_dot_git_events_do_not_emit_git_repo_update`; the remaining 3 `test_file_scan_*` RealFs tests are slow fs-event waits unrelated to these changes and were cut short locally
- [x] `./script/clippy` on superzent_agent/client; dev-profile clippy clean on worktree/project/git_ui/git/multi_buffer (only pre-existing `result_large_err` warnings in `debugger/test.rs`)
- [ ] Manual: run a terminal agent during a heavy build and confirm the app no longer quits when hook notifications time out

Release Notes:

- Fixed a crash that could quit the app when agent hook notifications were interrupted, and improved Git performance (fewer redundant rescans and status refreshes) on large repositories.
